### PR TITLE
feat: Add panel system with CRUD operations and 12-column grid

### DIFF
--- a/agent/prd.json
+++ b/agent/prd.json
@@ -97,7 +97,7 @@
       "TEST: DELETE /api/panels/:id removes panel",
       "TEST: Frontend renders panels as simple cards on dashboard"
     ],
-    "passes": false
+    "passes": true
   },
   {
     "category": "UI - Time Range Picker Component",
@@ -198,7 +198,14 @@
   {
     "category": "Feature - Auto-Refresh for Panels",
     "description": "Auto-refresh panels at configurable intervals (5s, 15s, 30s, etc.).",
-    "refresh_intervals": ["Off", "5s", "15s", "30s", "1m", "5m"],
+    "refresh_intervals": [
+      "Off",
+      "5s",
+      "15s",
+      "30s",
+      "1m",
+      "5m"
+    ],
     "steps": [
       "Add refresh interval selector to TimeRangePicker component",
       "Store selected interval in dashboard state (reactive)",

--- a/agent/progress.txt
+++ b/agent/progress.txt
@@ -77,3 +77,55 @@ This file tracks progress on the dash project features.
   - frontend/package.json - added vue-router
 - Blockers/notes for next iteration:
   - None. Ready to proceed with Panel System feature.
+
+## Core - Panel System (Simple Container) - 2026-02-02
+- What was done:
+  - Created Panel model in Go (internal/models/panel.go) with GridPos struct
+  - Implemented full CRUD handlers for panels:
+    - POST /api/dashboards/{id}/panels (create panel with grid_pos)
+    - GET /api/dashboards/{id}/panels (list panels for dashboard)
+    - PUT /api/panels/{id} (update panel title, type, grid_pos, query)
+    - DELETE /api/panels/{id} (delete with 204 response)
+  - Panels table migration already existed from Sprint 1
+  - Created frontend types (types/panel.ts) with GridPos interface
+  - Created API client (api/panels.ts) with fetch-based CRUD functions
+  - Created Panel.vue component:
+    - Simple card with title header and content slot
+    - Edit and delete action buttons
+    - Placeholder for visualization content
+  - Created PanelEditModal.vue:
+    - Form for panel title, type (dropdown), and query (JSON)
+    - JSON validation for query field
+    - Works for both create and edit modes
+  - Created DashboardDetailView.vue:
+    - Displays dashboard with all panels
+    - 12-column CSS grid layout based on grid_pos
+    - Add Panel button with modal
+    - Edit and delete panel actions with confirmation
+    - Back navigation to dashboard list
+  - Updated DashboardList.vue:
+    - Made dashboard cards clickable to navigate to detail view
+    - Added useRouter for navigation
+  - Added /dashboards/:id route to Vue Router
+  - Added comprehensive tests:
+    - Backend: 10 tests for panel handlers (validation, UUID parsing, JSON)
+    - Frontend: 22 new tests for panel API and components
+    - All 49 frontend tests passing
+    - All backend tests passing
+- Files changed:
+  - backend/internal/models/panel.go (new)
+  - backend/internal/handlers/panels.go (new)
+  - backend/internal/handlers/panels_test.go (new)
+  - backend/cmd/api/main.go - added panel routes
+  - frontend/src/types/panel.ts (new)
+  - frontend/src/api/panels.ts (new)
+  - frontend/src/api/panels.spec.ts (new)
+  - frontend/src/components/Panel.vue (new)
+  - frontend/src/components/Panel.spec.ts (new)
+  - frontend/src/components/PanelEditModal.vue (new)
+  - frontend/src/components/PanelEditModal.spec.ts (new)
+  - frontend/src/views/DashboardDetailView.vue (new)
+  - frontend/src/router/index.ts - added dashboard detail route
+  - frontend/src/components/DashboardList.vue - made cards clickable
+- Blockers/notes for next iteration:
+  - None. Ready to proceed with Time Range Picker Component.

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -46,6 +46,13 @@ func main() {
 	mux.HandleFunc("PUT /api/dashboards/{id}", dashboardHandler.Update)
 	mux.HandleFunc("DELETE /api/dashboards/{id}", dashboardHandler.Delete)
 
+	// Panel routes
+	panelHandler := handlers.NewPanelHandler(pool)
+	mux.HandleFunc("POST /api/dashboards/{id}/panels", panelHandler.Create)
+	mux.HandleFunc("GET /api/dashboards/{id}/panels", panelHandler.ListByDashboard)
+	mux.HandleFunc("PUT /api/panels/{id}", panelHandler.Update)
+	mux.HandleFunc("DELETE /api/panels/{id}", panelHandler.Delete)
+
 	// Apply CORS middleware
 	handler := corsMiddleware(mux)
 

--- a/backend/internal/handlers/panels.go
+++ b/backend/internal/handlers/panels.go
@@ -1,0 +1,211 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/janhoon/dash/backend/internal/models"
+)
+
+type PanelHandler struct {
+	pool *pgxpool.Pool
+}
+
+func NewPanelHandler(pool *pgxpool.Pool) *PanelHandler {
+	return &PanelHandler{pool: pool}
+}
+
+func (h *PanelHandler) Create(w http.ResponseWriter, r *http.Request) {
+	dashboardIDStr := r.PathValue("id")
+	dashboardID, err := uuid.Parse(dashboardIDStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid dashboard id"}`, http.StatusBadRequest)
+		return
+	}
+
+	var req models.CreatePanelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" {
+		http.Error(w, `{"error":"title is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	// Verify dashboard exists
+	var exists bool
+	err = h.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM dashboards WHERE id = $1)`, dashboardID).Scan(&exists)
+	if err != nil || !exists {
+		http.Error(w, `{"error":"dashboard not found"}`, http.StatusNotFound)
+		return
+	}
+
+	panelType := "line_chart"
+	if req.Type != nil {
+		panelType = *req.Type
+	}
+
+	gridPosJSON, err := json.Marshal(req.GridPos)
+	if err != nil {
+		http.Error(w, `{"error":"invalid grid_pos"}`, http.StatusBadRequest)
+		return
+	}
+
+	var panel models.Panel
+	var gridPosBytes []byte
+	var queryBytes []byte
+
+	err = h.pool.QueryRow(ctx,
+		`INSERT INTO panels (dashboard_id, title, type, grid_pos, query)
+		 VALUES ($1, $2, $3, $4, $5)
+		 RETURNING id, dashboard_id, title, type, grid_pos, query, created_at, updated_at`,
+		dashboardID, req.Title, panelType, gridPosJSON, req.Query,
+	).Scan(&panel.ID, &panel.DashboardID, &panel.Title, &panel.Type,
+		&gridPosBytes, &queryBytes, &panel.CreatedAt, &panel.UpdatedAt)
+
+	if err != nil {
+		http.Error(w, `{"error":"failed to create panel"}`, http.StatusInternalServerError)
+		return
+	}
+
+	json.Unmarshal(gridPosBytes, &panel.GridPos)
+	panel.Query = queryBytes
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(panel)
+}
+
+func (h *PanelHandler) ListByDashboard(w http.ResponseWriter, r *http.Request) {
+	dashboardIDStr := r.PathValue("id")
+	dashboardID, err := uuid.Parse(dashboardIDStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid dashboard id"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	rows, err := h.pool.Query(ctx,
+		`SELECT id, dashboard_id, title, type, grid_pos, query, created_at, updated_at
+		 FROM panels
+		 WHERE dashboard_id = $1
+		 ORDER BY created_at ASC`, dashboardID)
+	if err != nil {
+		http.Error(w, `{"error":"failed to fetch panels"}`, http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	panels := []models.Panel{}
+	for rows.Next() {
+		var p models.Panel
+		var gridPosBytes []byte
+		var queryBytes []byte
+
+		if err := rows.Scan(&p.ID, &p.DashboardID, &p.Title, &p.Type,
+			&gridPosBytes, &queryBytes, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			http.Error(w, `{"error":"failed to scan panel"}`, http.StatusInternalServerError)
+			return
+		}
+
+		json.Unmarshal(gridPosBytes, &p.GridPos)
+		p.Query = queryBytes
+
+		panels = append(panels, p)
+	}
+
+	if err := rows.Err(); err != nil {
+		http.Error(w, `{"error":"failed to iterate panels"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(panels)
+}
+
+func (h *PanelHandler) Update(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid panel id"}`, http.StatusBadRequest)
+		return
+	}
+
+	var req models.UpdatePanelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	var gridPosJSON []byte
+	if req.GridPos != nil {
+		gridPosJSON, _ = json.Marshal(req.GridPos)
+	}
+
+	var panel models.Panel
+	var gridPosBytes []byte
+	var queryBytes []byte
+
+	err = h.pool.QueryRow(ctx,
+		`UPDATE panels
+		 SET title = COALESCE($1, title),
+		     type = COALESCE($2, type),
+		     grid_pos = COALESCE($3, grid_pos),
+		     query = COALESCE($4, query),
+		     updated_at = NOW()
+		 WHERE id = $5
+		 RETURNING id, dashboard_id, title, type, grid_pos, query, created_at, updated_at`,
+		req.Title, req.Type, gridPosJSON, req.Query, id,
+	).Scan(&panel.ID, &panel.DashboardID, &panel.Title, &panel.Type,
+		&gridPosBytes, &queryBytes, &panel.CreatedAt, &panel.UpdatedAt)
+
+	if err != nil {
+		http.Error(w, `{"error":"panel not found"}`, http.StatusNotFound)
+		return
+	}
+
+	json.Unmarshal(gridPosBytes, &panel.GridPos)
+	panel.Query = queryBytes
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(panel)
+}
+
+func (h *PanelHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid panel id"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	result, err := h.pool.Exec(ctx, `DELETE FROM panels WHERE id = $1`, id)
+	if err != nil {
+		http.Error(w, `{"error":"failed to delete panel"}`, http.StatusInternalServerError)
+		return
+	}
+
+	if result.RowsAffected() == 0 {
+		http.Error(w, `{"error":"panel not found"}`, http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/handlers/panels_test.go
+++ b/backend/internal/handlers/panels_test.go
@@ -1,0 +1,198 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/janhoon/dash/backend/internal/models"
+)
+
+func TestPanelHandler_Create_InvalidDashboardID(t *testing.T) {
+	handler := &PanelHandler{pool: nil}
+
+	body := bytes.NewBufferString(`{"title":"Test Panel","grid_pos":{"x":0,"y":0,"w":6,"h":4}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/dashboards/invalid-uuid/panels", body)
+	req.SetPathValue("id", "invalid-uuid")
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestPanelHandler_Create_InvalidJSON(t *testing.T) {
+	handler := &PanelHandler{pool: nil}
+
+	body := bytes.NewBufferString(`{invalid}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/dashboards/123e4567-e89b-12d3-a456-426614174000/panels", body)
+	req.SetPathValue("id", "123e4567-e89b-12d3-a456-426614174000")
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestPanelHandler_Create_MissingTitle(t *testing.T) {
+	handler := &PanelHandler{pool: nil}
+
+	body := bytes.NewBufferString(`{"grid_pos":{"x":0,"y":0,"w":6,"h":4}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/dashboards/123e4567-e89b-12d3-a456-426614174000/panels", body)
+	req.SetPathValue("id", "123e4567-e89b-12d3-a456-426614174000")
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestPanelHandler_ListByDashboard_InvalidDashboardID(t *testing.T) {
+	handler := &PanelHandler{pool: nil}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dashboards/invalid-uuid/panels", nil)
+	req.SetPathValue("id", "invalid-uuid")
+	rr := httptest.NewRecorder()
+
+	handler.ListByDashboard(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestPanelHandler_Update_InvalidPanelID(t *testing.T) {
+	handler := &PanelHandler{pool: nil}
+
+	body := bytes.NewBufferString(`{"title":"Updated Panel"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/panels/invalid-uuid", body)
+	req.SetPathValue("id", "invalid-uuid")
+	rr := httptest.NewRecorder()
+
+	handler.Update(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestPanelHandler_Update_InvalidJSON(t *testing.T) {
+	handler := &PanelHandler{pool: nil}
+
+	body := bytes.NewBufferString(`{invalid}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/panels/123e4567-e89b-12d3-a456-426614174000", body)
+	req.SetPathValue("id", "123e4567-e89b-12d3-a456-426614174000")
+	rr := httptest.NewRecorder()
+
+	handler.Update(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestPanelHandler_Delete_InvalidPanelID(t *testing.T) {
+	handler := &PanelHandler{pool: nil}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/panels/invalid-uuid", nil)
+	req.SetPathValue("id", "invalid-uuid")
+	rr := httptest.NewRecorder()
+
+	handler.Delete(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestGridPos_JSON(t *testing.T) {
+	gridPos := models.GridPos{
+		X: 0,
+		Y: 0,
+		W: 6,
+		H: 4,
+	}
+
+	data, err := json.Marshal(gridPos)
+	if err != nil {
+		t.Fatalf("failed to marshal grid_pos: %v", err)
+	}
+
+	var decoded models.GridPos
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal grid_pos: %v", err)
+	}
+
+	if decoded.X != gridPos.X || decoded.Y != gridPos.Y || decoded.W != gridPos.W || decoded.H != gridPos.H {
+		t.Errorf("expected grid_pos %+v, got %+v", gridPos, decoded)
+	}
+}
+
+func TestCreatePanelRequest_JSON(t *testing.T) {
+	panelType := "bar_chart"
+	req := models.CreatePanelRequest{
+		Title:   "Test Panel",
+		Type:    &panelType,
+		GridPos: models.GridPos{X: 0, Y: 0, W: 6, H: 4},
+		Query:   []byte(`{"promql":"up"}`),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	var decoded models.CreatePanelRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal request: %v", err)
+	}
+
+	if decoded.Title != req.Title {
+		t.Errorf("expected title %s, got %s", req.Title, decoded.Title)
+	}
+
+	if decoded.Type == nil || *decoded.Type != *req.Type {
+		t.Errorf("expected type %v, got %v", req.Type, decoded.Type)
+	}
+}
+
+func TestUpdatePanelRequest_JSON(t *testing.T) {
+	title := "Updated Panel"
+	panelType := "gauge"
+	gridPos := models.GridPos{X: 2, Y: 2, W: 4, H: 3}
+	req := models.UpdatePanelRequest{
+		Title:   &title,
+		Type:    &panelType,
+		GridPos: &gridPos,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	var decoded models.UpdatePanelRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal request: %v", err)
+	}
+
+	if decoded.Title == nil || *decoded.Title != *req.Title {
+		t.Errorf("expected title %v, got %v", req.Title, decoded.Title)
+	}
+
+	if decoded.Type == nil || *decoded.Type != *req.Type {
+		t.Errorf("expected type %v, got %v", req.Type, decoded.Type)
+	}
+
+	if decoded.GridPos == nil || *decoded.GridPos != *req.GridPos {
+		t.Errorf("expected grid_pos %v, got %v", req.GridPos, decoded.GridPos)
+	}
+}

--- a/backend/internal/models/panel.go
+++ b/backend/internal/models/panel.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type GridPos struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+	W int `json:"w"`
+	H int `json:"h"`
+}
+
+type Panel struct {
+	ID          uuid.UUID       `json:"id"`
+	DashboardID uuid.UUID       `json:"dashboard_id"`
+	Title       string          `json:"title"`
+	Type        string          `json:"type"`
+	GridPos     GridPos         `json:"grid_pos"`
+	Query       json.RawMessage `json:"query,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+type CreatePanelRequest struct {
+	Title   string          `json:"title"`
+	Type    *string         `json:"type,omitempty"`
+	GridPos GridPos         `json:"grid_pos"`
+	Query   json.RawMessage `json:"query,omitempty"`
+}
+
+type UpdatePanelRequest struct {
+	Title   *string         `json:"title,omitempty"`
+	Type    *string         `json:"type,omitempty"`
+	GridPos *GridPos        `json:"grid_pos,omitempty"`
+	Query   json.RawMessage `json:"query,omitempty"`
+}

--- a/frontend/src/api/panels.spec.ts
+++ b/frontend/src/api/panels.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { listPanels, createPanel, updatePanel, deletePanel } from './panels'
+
+describe('Panel API', () => {
+  const mockFetch = vi.fn()
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    global.fetch = mockFetch
+    mockFetch.mockClear()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  describe('listPanels', () => {
+    it('fetches panels for a dashboard from API', async () => {
+      const mockData = [{ id: '1', title: 'Test Panel' }]
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData)
+      })
+
+      const result = await listPanels('dashboard-123')
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/api/dashboards/dashboard-123/panels')
+      expect(result).toEqual(mockData)
+    })
+
+    it('throws error on failure', async () => {
+      mockFetch.mockResolvedValue({ ok: false })
+      await expect(listPanels('dashboard-123')).rejects.toThrow('Failed to fetch panels')
+    })
+  })
+
+  describe('createPanel', () => {
+    it('creates panel via API', async () => {
+      const mockData = { id: '1', title: 'New Panel' }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData)
+      })
+
+      const result = await createPanel('dashboard-123', {
+        title: 'New Panel',
+        grid_pos: { x: 0, y: 0, w: 6, h: 4 }
+      })
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/dashboards/dashboard-123/panels',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: 'New Panel',
+            grid_pos: { x: 0, y: 0, w: 6, h: 4 }
+          })
+        })
+      )
+      expect(result).toEqual(mockData)
+    })
+
+    it('throws error on failure', async () => {
+      mockFetch.mockResolvedValue({ ok: false })
+      await expect(createPanel('dashboard-123', {
+        title: 'Test',
+        grid_pos: { x: 0, y: 0, w: 6, h: 4 }
+      })).rejects.toThrow('Failed to create panel')
+    })
+  })
+
+  describe('updatePanel', () => {
+    it('updates panel via API', async () => {
+      const mockData = { id: '1', title: 'Updated' }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData)
+      })
+
+      const result = await updatePanel('panel-1', { title: 'Updated' })
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/panels/panel-1',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title: 'Updated' })
+        })
+      )
+      expect(result).toEqual(mockData)
+    })
+
+    it('throws error on failure', async () => {
+      mockFetch.mockResolvedValue({ ok: false })
+      await expect(updatePanel('1', { title: 'Test' })).rejects.toThrow('Failed to update panel')
+    })
+  })
+
+  describe('deletePanel', () => {
+    it('deletes panel via API', async () => {
+      mockFetch.mockResolvedValue({ ok: true })
+
+      await deletePanel('panel-1')
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/panels/panel-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+
+    it('throws error on failure', async () => {
+      mockFetch.mockResolvedValue({ ok: false })
+      await expect(deletePanel('1')).rejects.toThrow('Failed to delete panel')
+    })
+  })
+})

--- a/frontend/src/api/panels.ts
+++ b/frontend/src/api/panels.ts
@@ -1,0 +1,48 @@
+import type { Panel, CreatePanelRequest, UpdatePanelRequest } from '../types/panel'
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
+
+export async function listPanels(dashboardId: string): Promise<Panel[]> {
+  const response = await fetch(`${API_BASE}/api/dashboards/${dashboardId}/panels`)
+  if (!response.ok) {
+    throw new Error('Failed to fetch panels')
+  }
+  return response.json()
+}
+
+export async function createPanel(dashboardId: string, data: CreatePanelRequest): Promise<Panel> {
+  const response = await fetch(`${API_BASE}/api/dashboards/${dashboardId}/panels`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to create panel')
+  }
+  return response.json()
+}
+
+export async function updatePanel(id: string, data: UpdatePanelRequest): Promise<Panel> {
+  const response = await fetch(`${API_BASE}/api/panels/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to update panel')
+  }
+  return response.json()
+}
+
+export async function deletePanel(id: string): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/panels/${id}`, {
+    method: 'DELETE',
+  })
+  if (!response.ok) {
+    throw new Error('Failed to delete panel')
+  }
+}

--- a/frontend/src/components/DashboardList.vue
+++ b/frontend/src/components/DashboardList.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import type { Dashboard } from '../types/dashboard'
 import { listDashboards, deleteDashboard } from '../api/dashboards'
 import CreateDashboardModal from './CreateDashboardModal.vue'
 import EditDashboardModal from './EditDashboardModal.vue'
+
+const router = useRouter()
 
 const dashboards = ref<Dashboard[]>([])
 const loading = ref(true)
@@ -86,6 +89,10 @@ function formatDate(dateStr: string): string {
   })
 }
 
+function openDashboard(dashboard: Dashboard) {
+  router.push(`/dashboards/${dashboard.id}`)
+}
+
 onMounted(fetchDashboards)
 </script>
 
@@ -114,15 +121,16 @@ onMounted(fetchDashboards)
         v-for="dashboard in dashboards"
         :key="dashboard.id"
         class="dashboard-card"
+        @click="openDashboard(dashboard)"
       >
         <div class="card-header">
           <h3>{{ dashboard.title }}</h3>
-          <div class="card-actions">
+          <div class="card-actions" @click.stop>
             <button class="btn btn-icon" @click="openEditModal(dashboard)" title="Edit">
-              ✏️
+              Edit
             </button>
             <button class="btn btn-icon btn-danger" @click="confirmDelete(dashboard)" title="Delete">
-              🗑️
+              X
             </button>
           </div>
         </div>
@@ -242,10 +250,12 @@ onMounted(fetchDashboards)
   border-radius: 8px;
   padding: 1.5rem;
   transition: box-shadow 0.2s;
+  cursor: pointer;
 }
 
 .dashboard-card:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: #3498db;
 }
 
 .card-header {

--- a/frontend/src/components/Panel.spec.ts
+++ b/frontend/src/components/Panel.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Panel from './Panel.vue'
+
+describe('Panel', () => {
+  const mockPanel = {
+    id: '1',
+    dashboard_id: 'dashboard-1',
+    title: 'Test Panel',
+    type: 'line_chart',
+    grid_pos: { x: 0, y: 0, w: 6, h: 4 },
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z'
+  }
+
+  it('renders panel title', () => {
+    const wrapper = mount(Panel, {
+      props: { panel: mockPanel }
+    })
+    expect(wrapper.find('.panel-title').text()).toBe('Test Panel')
+  })
+
+  it('displays panel type', () => {
+    const wrapper = mount(Panel, {
+      props: { panel: mockPanel }
+    })
+    expect(wrapper.find('.panel-type').text()).toBe('line_chart')
+  })
+
+  it('emits edit event when edit button is clicked', async () => {
+    const wrapper = mount(Panel, {
+      props: { panel: mockPanel }
+    })
+    await wrapper.findAll('button').find(b => b.text() === 'Edit')?.trigger('click')
+    expect(wrapper.emitted('edit')).toBeTruthy()
+    expect(wrapper.emitted('edit')![0]).toEqual([mockPanel])
+  })
+
+  it('emits delete event when delete button is clicked', async () => {
+    const wrapper = mount(Panel, {
+      props: { panel: mockPanel }
+    })
+    await wrapper.findAll('button').find(b => b.text() === 'X')?.trigger('click')
+    expect(wrapper.emitted('delete')).toBeTruthy()
+    expect(wrapper.emitted('delete')![0]).toEqual([mockPanel])
+  })
+
+  it('renders slot content when provided', () => {
+    const wrapper = mount(Panel, {
+      props: { panel: mockPanel },
+      slots: {
+        default: '<div class="custom-content">Custom Content</div>'
+      }
+    })
+    expect(wrapper.find('.custom-content').exists()).toBe(true)
+    expect(wrapper.find('.custom-content').text()).toBe('Custom Content')
+  })
+})

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import type { Panel } from '../types/panel'
+
+defineProps<{
+  panel: Panel
+}>()
+
+defineEmits<{
+  edit: [panel: Panel]
+  delete: [panel: Panel]
+}>()
+</script>
+
+<template>
+  <div class="panel">
+    <div class="panel-header">
+      <h3 class="panel-title">{{ panel.title }}</h3>
+      <div class="panel-actions">
+        <button class="btn btn-icon" @click="$emit('edit', panel)" title="Edit">
+          Edit
+        </button>
+        <button class="btn btn-icon btn-danger" @click="$emit('delete', panel)" title="Delete">
+          X
+        </button>
+      </div>
+    </div>
+    <div class="panel-content">
+      <slot>
+        <div class="panel-placeholder">
+          <span class="panel-type">{{ panel.type }}</span>
+          <p>Panel content will be rendered here</p>
+        </div>
+      </slot>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.panel {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 150px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e0e0e0;
+  background: #f8f9fa;
+}
+
+.panel-title {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.panel-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.btn {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.btn:hover {
+  background: #f5f5f5;
+}
+
+.btn-icon {
+  padding: 0.25rem 0.5rem;
+}
+
+.btn-danger {
+  color: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.btn-danger:hover {
+  background: #fdf2f2;
+}
+
+.panel-content {
+  flex: 1;
+  padding: 1rem;
+  overflow: auto;
+}
+
+.panel-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #999;
+  text-align: center;
+}
+
+.panel-type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #e0e0e0;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.panel-placeholder p {
+  margin: 0;
+  font-size: 0.875rem;
+}
+</style>

--- a/frontend/src/components/PanelEditModal.spec.ts
+++ b/frontend/src/components/PanelEditModal.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import PanelEditModal from './PanelEditModal.vue'
+import * as api from '../api/panels'
+
+vi.mock('../api/panels')
+
+describe('PanelEditModal', () => {
+  const dashboardId = 'dashboard-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders form fields', () => {
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId }
+    })
+    expect(wrapper.find('input#title').exists()).toBe(true)
+    expect(wrapper.find('select#type').exists()).toBe(true)
+    expect(wrapper.find('textarea#query').exists()).toBe(true)
+  })
+
+  it('shows "Add Panel" title when creating new panel', () => {
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId }
+    })
+    expect(wrapper.find('.modal-header h2').text()).toBe('Add Panel')
+  })
+
+  it('shows "Edit Panel" title when editing existing panel', () => {
+    const wrapper = mount(PanelEditModal, {
+      props: {
+        dashboardId,
+        panel: {
+          id: '1',
+          dashboard_id: dashboardId,
+          title: 'Existing Panel',
+          type: 'line_chart',
+          grid_pos: { x: 0, y: 0, w: 6, h: 4 },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
+        }
+      }
+    })
+    expect(wrapper.find('.modal-header h2').text()).toBe('Edit Panel')
+  })
+
+  it('emits close event when cancel is clicked', async () => {
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId }
+    })
+    await wrapper.findAll('button').find(b => b.text() === 'Cancel')?.trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('shows error when title is empty', async () => {
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId }
+    })
+    await wrapper.find('form').trigger('submit')
+    expect(wrapper.text()).toContain('Title is required')
+  })
+
+  it('shows error for invalid JSON in query', async () => {
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId }
+    })
+    await wrapper.find('input#title').setValue('Test Panel')
+    await wrapper.find('textarea#query').setValue('invalid json')
+    await wrapper.find('form').trigger('submit')
+    expect(wrapper.text()).toContain('Invalid JSON in query field')
+  })
+
+  it('calls createPanel API on submit when creating', async () => {
+    vi.mocked(api.createPanel).mockResolvedValue({
+      id: '123',
+      dashboard_id: dashboardId,
+      title: 'New Panel',
+      type: 'line_chart',
+      grid_pos: { x: 0, y: 0, w: 6, h: 4 },
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z'
+    })
+
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId }
+    })
+    await wrapper.find('input#title').setValue('New Panel')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(api.createPanel).toHaveBeenCalledWith(dashboardId, {
+      title: 'New Panel',
+      type: 'line_chart',
+      grid_pos: { x: 0, y: 0, w: 6, h: 4 },
+      query: undefined
+    })
+    expect(wrapper.emitted('saved')).toBeTruthy()
+  })
+
+  it('calls updatePanel API on submit when editing', async () => {
+    const existingPanel = {
+      id: '1',
+      dashboard_id: dashboardId,
+      title: 'Existing Panel',
+      type: 'line_chart',
+      grid_pos: { x: 0, y: 0, w: 6, h: 4 },
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z'
+    }
+
+    vi.mocked(api.updatePanel).mockResolvedValue({
+      ...existingPanel,
+      title: 'Updated Panel'
+    })
+
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId, panel: existingPanel }
+    })
+    await wrapper.find('input#title').setValue('Updated Panel')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(api.updatePanel).toHaveBeenCalledWith('1', {
+      title: 'Updated Panel',
+      type: 'line_chart',
+      query: undefined
+    })
+    expect(wrapper.emitted('saved')).toBeTruthy()
+  })
+
+  it('shows error on API failure', async () => {
+    vi.mocked(api.createPanel).mockRejectedValue(new Error('Network error'))
+
+    const wrapper = mount(PanelEditModal, {
+      props: { dashboardId }
+    })
+    await wrapper.find('input#title').setValue('New Panel')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to create panel')
+  })
+})

--- a/frontend/src/components/PanelEditModal.vue
+++ b/frontend/src/components/PanelEditModal.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { Panel } from '../types/panel'
+import { createPanel, updatePanel } from '../api/panels'
+
+const props = defineProps<{
+  panel?: Panel
+  dashboardId: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  saved: []
+}>()
+
+const isEditing = computed(() => !!props.panel)
+
+const title = ref(props.panel?.title || '')
+const panelType = ref(props.panel?.type || 'line_chart')
+const queryStr = ref(props.panel?.query ? JSON.stringify(props.panel.query, null, 2) : '')
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+async function handleSubmit() {
+  if (!title.value.trim()) {
+    error.value = 'Title is required'
+    return
+  }
+
+  let query: Record<string, unknown> | undefined
+  if (queryStr.value.trim()) {
+    try {
+      query = JSON.parse(queryStr.value.trim())
+    } catch {
+      error.value = 'Invalid JSON in query field'
+      return
+    }
+  }
+
+  loading.value = true
+  error.value = null
+
+  try {
+    if (isEditing.value && props.panel) {
+      await updatePanel(props.panel.id, {
+        title: title.value.trim(),
+        type: panelType.value,
+        query
+      })
+    } else {
+      await createPanel(props.dashboardId, {
+        title: title.value.trim(),
+        type: panelType.value,
+        grid_pos: { x: 0, y: 0, w: 6, h: 4 },
+        query
+      })
+    }
+    emit('saved')
+  } catch {
+    error.value = isEditing.value ? 'Failed to update panel' : 'Failed to create panel'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="modal-overlay" @click.self="emit('close')">
+    <div class="modal">
+      <header class="modal-header">
+        <h2>{{ isEditing ? 'Edit Panel' : 'Add Panel' }}</h2>
+        <button class="btn-close" @click="emit('close')">&times;</button>
+      </header>
+
+      <form @submit.prevent="handleSubmit">
+        <div class="form-group">
+          <label for="title">Title *</label>
+          <input
+            id="title"
+            v-model="title"
+            type="text"
+            placeholder="Panel title"
+            :disabled="loading"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="type">Panel Type</label>
+          <select id="type" v-model="panelType" :disabled="loading">
+            <option value="line_chart">Line Chart</option>
+            <option value="bar_chart">Bar Chart</option>
+            <option value="gauge">Gauge</option>
+            <option value="stat">Stat</option>
+            <option value="table">Table</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="query">Query (JSON)</label>
+          <textarea
+            id="query"
+            v-model="queryStr"
+            placeholder='{"promql": "up"}'
+            rows="4"
+            :disabled="loading"
+          ></textarea>
+        </div>
+
+        <div v-if="error" class="error">{{ error }}</div>
+
+        <div class="modal-actions">
+          <button type="button" class="btn" @click="emit('close')" :disabled="loading">
+            Cancel
+          </button>
+          <button type="submit" class="btn btn-primary" :disabled="loading">
+            {{ loading ? 'Saving...' : (isEditing ? 'Save' : 'Add Panel') }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: white;
+  border-radius: 8px;
+  padding: 0;
+  width: 100%;
+  max-width: 480px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: #2c3e50;
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #999;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.btn-close:hover {
+  color: #666;
+}
+
+form {
+  padding: 1.5rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  color: #2c3e50;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+.form-group textarea {
+  font-family: monospace;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+.error {
+  color: #e74c3c;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.btn:hover:not(:disabled) {
+  background: #f5f5f5;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: #3498db;
+  border-color: #3498db;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #2980b9;
+}
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import DashboardsView from '../views/DashboardsView.vue'
+import DashboardDetailView from '../views/DashboardDetailView.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -12,6 +13,11 @@ const router = createRouter({
       path: '/dashboards',
       name: 'dashboards',
       component: DashboardsView
+    },
+    {
+      path: '/dashboards/:id',
+      name: 'dashboard-detail',
+      component: DashboardDetailView
     }
   ]
 })

--- a/frontend/src/types/panel.ts
+++ b/frontend/src/types/panel.ts
@@ -1,0 +1,31 @@
+export interface GridPos {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface Panel {
+  id: string
+  dashboard_id: string
+  title: string
+  type: string
+  grid_pos: GridPos
+  query?: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface CreatePanelRequest {
+  title: string
+  type?: string
+  grid_pos: GridPos
+  query?: Record<string, unknown>
+}
+
+export interface UpdatePanelRequest {
+  title?: string
+  type?: string
+  grid_pos?: GridPos
+  query?: Record<string, unknown>
+}

--- a/frontend/src/views/DashboardDetailView.vue
+++ b/frontend/src/views/DashboardDetailView.vue
@@ -1,0 +1,303 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { Dashboard } from '../types/dashboard'
+import type { Panel as PanelType } from '../types/panel'
+import { getDashboard } from '../api/dashboards'
+import { listPanels, deletePanel } from '../api/panels'
+import Panel from '../components/Panel.vue'
+import PanelEditModal from '../components/PanelEditModal.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const dashboard = ref<Dashboard | null>(null)
+const panels = ref<PanelType[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const showPanelModal = ref(false)
+const editingPanel = ref<PanelType | null>(null)
+const showDeleteConfirm = ref(false)
+const deletingPanel = ref<PanelType | null>(null)
+
+const dashboardId = route.params.id as string
+
+async function fetchDashboard() {
+  try {
+    dashboard.value = await getDashboard(dashboardId)
+  } catch {
+    error.value = 'Dashboard not found'
+    return
+  }
+}
+
+async function fetchPanels() {
+  try {
+    panels.value = await listPanels(dashboardId)
+  } catch {
+    error.value = 'Failed to load panels'
+  }
+}
+
+async function loadData() {
+  loading.value = true
+  error.value = null
+  await fetchDashboard()
+  if (!error.value) {
+    await fetchPanels()
+  }
+  loading.value = false
+}
+
+function openAddPanel() {
+  editingPanel.value = null
+  showPanelModal.value = true
+}
+
+function openEditPanel(panel: PanelType) {
+  editingPanel.value = panel
+  showPanelModal.value = true
+}
+
+function closePanelModal() {
+  showPanelModal.value = false
+  editingPanel.value = null
+}
+
+function onPanelSaved() {
+  closePanelModal()
+  fetchPanels()
+}
+
+function confirmDeletePanel(panel: PanelType) {
+  deletingPanel.value = panel
+  showDeleteConfirm.value = true
+}
+
+function cancelDelete() {
+  showDeleteConfirm.value = false
+  deletingPanel.value = null
+}
+
+async function handleDeletePanel() {
+  if (!deletingPanel.value) return
+
+  try {
+    await deletePanel(deletingPanel.value.id)
+    cancelDelete()
+    fetchPanels()
+  } catch {
+    error.value = 'Failed to delete panel'
+  }
+}
+
+function goBack() {
+  router.push('/dashboards')
+}
+
+onMounted(loadData)
+</script>
+
+<template>
+  <div class="dashboard-detail">
+    <header class="header">
+      <div class="header-left">
+        <button class="btn btn-back" @click="goBack">
+          &larr; Back
+        </button>
+        <h1 v-if="dashboard">{{ dashboard.title }}</h1>
+      </div>
+      <button class="btn btn-primary" @click="openAddPanel" :disabled="loading">
+        + Add Panel
+      </button>
+    </header>
+
+    <div v-if="loading" class="loading">Loading dashboard...</div>
+
+    <div v-else-if="error" class="error">{{ error }}</div>
+
+    <template v-else>
+      <p v-if="dashboard?.description" class="dashboard-description">
+        {{ dashboard.description }}
+      </p>
+
+      <div v-if="panels.length === 0" class="empty">
+        <p>No panels yet</p>
+        <button class="btn btn-primary" @click="openAddPanel">
+          Add your first panel
+        </button>
+      </div>
+
+      <div v-else class="panel-grid">
+        <div
+          v-for="panel in panels"
+          :key="panel.id"
+          class="panel-wrapper"
+          :style="{
+            gridColumn: `span ${panel.grid_pos.w}`,
+            gridRow: `span ${panel.grid_pos.h}`
+          }"
+        >
+          <Panel
+            :panel="panel"
+            @edit="openEditPanel"
+            @delete="confirmDeletePanel"
+          />
+        </div>
+      </div>
+    </template>
+
+    <PanelEditModal
+      v-if="showPanelModal"
+      :dashboard-id="dashboardId"
+      :panel="editingPanel || undefined"
+      @close="closePanelModal"
+      @saved="onPanelSaved"
+    />
+
+    <div v-if="showDeleteConfirm" class="modal-overlay" @click.self="cancelDelete">
+      <div class="modal delete-modal">
+        <h2>Delete Panel</h2>
+        <p>Are you sure you want to delete "{{ deletingPanel?.title }}"?</p>
+        <p class="warning">This action cannot be undone.</p>
+        <div class="modal-actions">
+          <button class="btn" @click="cancelDelete">Cancel</button>
+          <button class="btn btn-danger" @click="handleDeletePanel">Delete</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dashboard-detail {
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header h1 {
+  margin: 0;
+  color: #2c3e50;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.btn:hover:not(:disabled) {
+  background: #f5f5f5;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-back {
+  padding: 0.5rem 0.75rem;
+}
+
+.btn-primary {
+  background: #3498db;
+  border-color: #3498db;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #2980b9;
+}
+
+.btn-danger {
+  background: #e74c3c;
+  border-color: #e74c3c;
+  color: white;
+}
+
+.btn-danger:hover {
+  background: #c0392b;
+}
+
+.dashboard-description {
+  color: #666;
+  margin: 0 0 1.5rem 0;
+}
+
+.loading, .error, .empty {
+  text-align: center;
+  padding: 3rem;
+  color: #666;
+}
+
+.error {
+  color: #e74c3c;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+  grid-auto-rows: minmax(100px, auto);
+}
+
+.panel-wrapper {
+  min-height: 200px;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.delete-modal h2 {
+  margin: 0 0 1rem 0;
+  color: #e74c3c;
+}
+
+.warning {
+  color: #e74c3c;
+  font-size: 0.875rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- Implemented full panel CRUD operations in Go backend with PostgreSQL storage
- Created Panel.vue component as a simple card container for visualizations
- Built DashboardDetailView with 12-column CSS grid layout for panel positioning
- Added clickable dashboard cards for navigation to panel view

## Changes

### Backend
- `Panel` model with `GridPos` struct (x, y, w, h) for grid positioning
- `POST /api/dashboards/:id/panels` - Create panel for dashboard
- `GET /api/dashboards/:id/panels` - List all panels for a dashboard
- `PUT /api/panels/:id` - Update panel title, type, query, and position
- `DELETE /api/panels/:id` - Delete panel with 204 response

### Frontend
- `Panel.vue` - Card component with title header and content slot
- `PanelEditModal.vue` - Form for create/edit with JSON query validation
- `DashboardDetailView.vue` - Dashboard view with 12-column grid layout
- Updated `DashboardList.vue` - Cards now navigate to dashboard detail
- `api/panels.ts` - Fetch-based API client for panel CRUD

### Tests
- 10 backend tests for panel handlers (validation, UUID parsing, JSON serialization)
- 22 frontend tests for panel API and components
- All 49 frontend tests passing
- All backend tests passing

## Test plan
- [ ] Create a new dashboard
- [ ] Click on dashboard card to open detail view
- [ ] Click "Add Panel" to create a panel
- [ ] Verify panel appears in the grid
- [ ] Edit panel title and query
- [ ] Delete panel with confirmation
- [ ] Verify panel CRUD persists across page refresh

## PRD Reference
Feature: Core - Panel System (Simple Container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)