### PR TITLE
feat: Add time range picker component

### DIFF
--- a/agent/prd.json
+++ b/agent/prd.json
@@ -127,7 +127,7 @@
       "TEST: Time range updates trigger panel re-fetch",
       "TEST: Auto-refresh at 5s interval triggers panel updates"
     ],
-    "passes": false
+    "passes": true
   },
   {
     "category": "Data - Prometheus Data Source Integration",

--- a/agent/progress.txt
+++ b/agent/progress.txt
@@ -129,3 +129,39 @@ This file tracks progress on the dash project features.
   - frontend/src/components/DashboardList.vue - made cards clickable
 - Blockers/notes for next iteration:
   - None. Ready to proceed with Time Range Picker Component.
+
+## UI - Time Range Picker Component - 2026-02-02
+- What was done:
+  - Created useTimeRange.ts composable with:
+    - Reactive start/end timestamps calculation
+    - All 7 preset ranges (5m, 15m, 30m, 1h, 6h, 24h, 7d)
+    - Custom range support with date pickers
+    - Auto-refresh with intervals (Off, 5s, 15s, 30s, 1m)
+    - Shared state across components using the composable
+    - onRefresh callback system for panel data refresh
+  - Created TimeRangePicker.vue component with:
+    - Dropdown UI for selecting time ranges
+    - Quick range presets list with visual selection indicator
+    - Custom range form with datetime-local inputs
+    - Validation for custom ranges (start < end)
+    - Refresh interval selector (dropdown)
+    - Manual refresh button
+    - Human-readable display text (e.g., "Last 5 minutes")
+  - Integrated TimeRangePicker into DashboardDetailView:
+    - Added to header alongside "Add Panel" button
+    - Connected to useTimeRange composable for shared state
+    - Set up refresh callback subscription for panel data updates
+    - Proper cleanup on unmount
+  - Added comprehensive tests:
+    - 23 tests for useTimeRange composable
+    - 13 tests for TimeRangePicker component
+    - All 85 frontend tests passing
+    - All backend tests passing
+- Files changed:
+  - frontend/src/composables/useTimeRange.ts (new)
+  - frontend/src/composables/useTimeRange.spec.ts (new)
+  - frontend/src/components/TimeRangePicker.vue (new)
+  - frontend/src/components/TimeRangePicker.spec.ts (new)
+  - frontend/src/views/DashboardDetailView.vue - integrated TimeRangePicker
+- Blockers/notes for next iteration:
+  - None. Ready to proceed with Prometheus Data Source Integration.

--- a/frontend/src/components/TimeRangePicker.spec.ts
+++ b/frontend/src/components/TimeRangePicker.spec.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TimeRangePicker from './TimeRangePicker.vue'
+import { useTimeRange } from '../composables/useTimeRange'
+
+describe('TimeRangePicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-02T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    // Clean up shared state
+    const { cleanup, setPreset, setRefreshInterval } = useTimeRange()
+    cleanup()
+    setPreset('1h') // Reset to default
+    setRefreshInterval('off')
+  })
+
+  it('should render with default time range display', () => {
+    const wrapper = mount(TimeRangePicker)
+
+    expect(wrapper.find('.time-display').exists()).toBe(true)
+    expect(wrapper.find('.display-text').text()).toBe('Last 1 hour')
+  })
+
+  it('should render refresh button', () => {
+    const wrapper = mount(TimeRangePicker)
+
+    expect(wrapper.find('.refresh-btn').exists()).toBe(true)
+  })
+
+  it('should render refresh interval selector', () => {
+    const wrapper = mount(TimeRangePicker)
+
+    const select = wrapper.find('.refresh-interval-selector select')
+    expect(select.exists()).toBe(true)
+
+    const options = select.findAll('option')
+    expect(options).toHaveLength(5) // Off, 5s, 15s, 30s, 1m
+  })
+
+  it('should toggle dropdown when clicking time display', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    expect(wrapper.find('.dropdown').exists()).toBe(false)
+
+    await wrapper.find('.time-display').trigger('click')
+    expect(wrapper.find('.dropdown').exists()).toBe(true)
+
+    await wrapper.find('.time-display').trigger('click')
+    expect(wrapper.find('.dropdown').exists()).toBe(false)
+  })
+
+  it('should display preset options in dropdown', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    await wrapper.find('.time-display').trigger('click')
+
+    const presetItems = wrapper.findAll('.preset-item')
+    // 7 presets + 1 custom range button
+    expect(presetItems.length).toBeGreaterThanOrEqual(7)
+
+    expect(wrapper.text()).toContain('Last 5 minutes')
+    expect(wrapper.text()).toContain('Last 15 minutes')
+    expect(wrapper.text()).toContain('Last 30 minutes')
+    expect(wrapper.text()).toContain('Last 1 hour')
+    expect(wrapper.text()).toContain('Last 6 hours')
+    expect(wrapper.text()).toContain('Last 24 hours')
+    expect(wrapper.text()).toContain('Last 7 days')
+  })
+
+  it('should select preset and close dropdown', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    await wrapper.find('.time-display').trigger('click')
+
+    // Find and click '5 minutes' preset
+    const presetButtons = wrapper.findAll('.preset-item')
+    const fiveMinButton = presetButtons.find(btn => btn.text() === 'Last 5 minutes')
+    expect(fiveMinButton).toBeDefined()
+
+    await fiveMinButton!.trigger('click')
+
+    // Dropdown should close
+    expect(wrapper.find('.dropdown').exists()).toBe(false)
+
+    // Display should update
+    expect(wrapper.find('.display-text').text()).toBe('Last 5 minutes')
+  })
+
+  it('should show custom range form when clicking custom range option', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    await wrapper.find('.time-display').trigger('click')
+
+    const customRangeBtn = wrapper.find('.custom-range-btn')
+    expect(customRangeBtn.exists()).toBe(true)
+
+    await customRangeBtn.trigger('click')
+
+    // Should show custom range form
+    expect(wrapper.find('.custom-range-form').exists()).toBe(true)
+    expect(wrapper.find('#custom-from').exists()).toBe(true)
+    expect(wrapper.find('#custom-to').exists()).toBe(true)
+  })
+
+  it('should apply custom range', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    await wrapper.find('.time-display').trigger('click')
+    await wrapper.find('.custom-range-btn').trigger('click')
+
+    // Set custom dates
+    const fromInput = wrapper.find('#custom-from')
+    const toInput = wrapper.find('#custom-to')
+
+    await fromInput.setValue('2026-02-01T10:00')
+    await toInput.setValue('2026-02-02T14:00')
+
+    // Click apply
+    await wrapper.find('.btn-apply').trigger('click')
+
+    // Dropdown should close
+    expect(wrapper.find('.dropdown').exists()).toBe(false)
+
+    // Display should show custom range
+    expect(wrapper.find('.display-text').text()).toContain('2026-02-01')
+    expect(wrapper.find('.display-text').text()).toContain('2026-02-02')
+  })
+
+  it('should show error when start time is after end time', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    await wrapper.find('.time-display').trigger('click')
+    await wrapper.find('.custom-range-btn').trigger('click')
+
+    // Set invalid dates (start after end)
+    await wrapper.find('#custom-from').setValue('2026-02-02T14:00')
+    await wrapper.find('#custom-to').setValue('2026-02-01T10:00')
+
+    // Click apply
+    await wrapper.find('.btn-apply').trigger('click')
+
+    // Should show error
+    expect(wrapper.find('.error-message').exists()).toBe(true)
+    expect(wrapper.find('.error-message').text()).toContain('Start time must be before end time')
+
+    // Dropdown should still be open
+    expect(wrapper.find('.dropdown').exists()).toBe(true)
+  })
+
+  it('should cancel custom range and go back to presets', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    await wrapper.find('.time-display').trigger('click')
+    await wrapper.find('.custom-range-btn').trigger('click')
+
+    expect(wrapper.find('.custom-range-form').exists()).toBe(true)
+
+    await wrapper.find('.btn-cancel').trigger('click')
+
+    // Should go back to presets
+    expect(wrapper.find('.custom-range-form').exists()).toBe(false)
+    expect(wrapper.find('.preset-list').exists()).toBe(true)
+  })
+
+  it('should change refresh interval', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    const select = wrapper.find('.refresh-interval-selector select')
+
+    await select.setValue('5s')
+
+    const { refreshIntervalValue } = useTimeRange()
+    expect(refreshIntervalValue.value).toBe('5s')
+  })
+
+  it('should highlight selected preset', async () => {
+    const wrapper = mount(TimeRangePicker)
+
+    // Set to 5m preset first
+    const { setPreset } = useTimeRange()
+    setPreset('5m')
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('.time-display').trigger('click')
+
+    const selectedItem = wrapper.find('.preset-item.selected')
+    expect(selectedItem.exists()).toBe(true)
+    expect(selectedItem.text()).toBe('Last 5 minutes')
+  })
+
+  it('should call refresh when clicking refresh button', async () => {
+    const wrapper = mount(TimeRangePicker)
+    const { onRefresh } = useTimeRange()
+
+    const callback = vi.fn()
+    onRefresh(callback)
+
+    await wrapper.find('.refresh-btn').trigger('click')
+
+    expect(callback).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/TimeRangePicker.vue
+++ b/frontend/src/components/TimeRangePicker.vue
@@ -1,0 +1,437 @@
+<script setup lang="ts">
+import { ref, computed, onUnmounted } from 'vue'
+import { useTimeRange } from '../composables/useTimeRange'
+
+const {
+  displayText,
+  selectedPreset,
+  isCustomRange,
+  refreshInterval,
+  refreshIntervalValue,
+  presets,
+  refreshIntervals,
+  setPreset,
+  setCustomRange,
+  setRefreshInterval,
+  refresh,
+} = useTimeRange()
+
+const isOpen = ref(false)
+const showCustomRange = ref(false)
+const customFrom = ref('')
+const customTo = ref('')
+const customRangeError = ref<string | null>(null)
+
+const currentDisplayText = computed(() => displayText.value)
+
+function toggleDropdown() {
+  isOpen.value = !isOpen.value
+  if (!isOpen.value) {
+    showCustomRange.value = false
+    customRangeError.value = null
+  }
+}
+
+function closeDropdown() {
+  isOpen.value = false
+  showCustomRange.value = false
+  customRangeError.value = null
+}
+
+function selectPreset(presetValue: string) {
+  setPreset(presetValue)
+  closeDropdown()
+}
+
+function openCustomRange() {
+  showCustomRange.value = true
+  // Initialize with current date/time values
+  const now = new Date()
+  const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
+  customFrom.value = formatDateTimeLocal(oneHourAgo)
+  customTo.value = formatDateTimeLocal(now)
+}
+
+function applyCustomRange() {
+  const fromDate = new Date(customFrom.value)
+  const toDate = new Date(customTo.value)
+
+  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+    customRangeError.value = 'Please enter valid dates'
+    return
+  }
+
+  if (fromDate >= toDate) {
+    customRangeError.value = 'Start time must be before end time'
+    return
+  }
+
+  setCustomRange(fromDate.getTime(), toDate.getTime())
+  closeDropdown()
+}
+
+function cancelCustomRange() {
+  showCustomRange.value = false
+  customRangeError.value = null
+}
+
+function selectRefreshInterval(intervalValue: string) {
+  setRefreshInterval(intervalValue)
+}
+
+function handleRefresh() {
+  refresh()
+}
+
+function formatDateTimeLocal(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+// Close dropdown when clicking outside
+function handleClickOutside(event: MouseEvent) {
+  const target = event.target as HTMLElement
+  if (!target.closest('.time-range-picker')) {
+    closeDropdown()
+  }
+}
+
+// Add/remove click listener
+if (typeof window !== 'undefined') {
+  window.addEventListener('click', handleClickOutside)
+}
+
+onUnmounted(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('click', handleClickOutside)
+  }
+})
+</script>
+
+<template>
+  <div class="time-range-picker">
+    <div class="picker-controls">
+      <button
+        class="time-display"
+        @click.stop="toggleDropdown"
+        :class="{ active: isOpen }"
+      >
+        <span class="clock-icon">&#128337;</span>
+        <span class="display-text">{{ currentDisplayText }}</span>
+        <span class="dropdown-arrow">{{ isOpen ? '&#9650;' : '&#9660;' }}</span>
+      </button>
+
+      <button
+        class="refresh-btn"
+        @click="handleRefresh"
+        title="Refresh now"
+      >
+        &#8635;
+      </button>
+
+      <div class="refresh-interval-selector">
+        <select
+          :value="refreshIntervalValue"
+          @change="selectRefreshInterval(($event.target as HTMLSelectElement).value)"
+          title="Auto-refresh interval"
+        >
+          <option
+            v-for="interval in refreshIntervals"
+            :key="interval.value"
+            :value="interval.value"
+          >
+            {{ interval.label }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <div v-if="isOpen" class="dropdown" @click.stop>
+      <div v-if="!showCustomRange" class="preset-list">
+        <div class="dropdown-section">
+          <div class="section-title">Quick ranges</div>
+          <button
+            v-for="preset in presets"
+            :key="preset.value"
+            class="preset-item"
+            :class="{ selected: !isCustomRange && selectedPreset === preset.value }"
+            @click="selectPreset(preset.value)"
+          >
+            {{ preset.label }}
+          </button>
+        </div>
+
+        <div class="dropdown-divider"></div>
+
+        <button class="preset-item custom-range-btn" @click="openCustomRange">
+          Custom range...
+        </button>
+      </div>
+
+      <div v-else class="custom-range-form">
+        <div class="section-title">Custom time range</div>
+
+        <div class="form-group">
+          <label for="custom-from">From</label>
+          <input
+            id="custom-from"
+            type="datetime-local"
+            v-model="customFrom"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="custom-to">To</label>
+          <input
+            id="custom-to"
+            type="datetime-local"
+            v-model="customTo"
+          />
+        </div>
+
+        <div v-if="customRangeError" class="error-message">
+          {{ customRangeError }}
+        </div>
+
+        <div class="form-actions">
+          <button class="btn-cancel" @click="cancelCustomRange">Cancel</button>
+          <button class="btn-apply" @click="applyCustomRange">Apply</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.time-range-picker {
+  position: relative;
+  display: inline-block;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.picker-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.time-display {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #333;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.time-display:hover {
+  border-color: #3498db;
+}
+
+.time-display.active {
+  border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.clock-icon {
+  font-size: 16px;
+}
+
+.display-text {
+  min-width: 120px;
+}
+
+.dropdown-arrow {
+  font-size: 10px;
+  color: #666;
+}
+
+.refresh-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 18px;
+  color: #333;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.refresh-btn:hover {
+  border-color: #3498db;
+  background: #f5f5f5;
+}
+
+.refresh-btn:active {
+  background: #e8e8e8;
+}
+
+.refresh-interval-selector select {
+  padding: 8px 12px;
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.refresh-interval-selector select:hover {
+  border-color: #3498db;
+}
+
+.refresh-interval-selector select:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 220px;
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+}
+
+.dropdown-section {
+  padding: 8px 0;
+}
+
+.section-title {
+  padding: 8px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.preset-item {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.preset-item:hover {
+  background: #f5f5f5;
+}
+
+.preset-item.selected {
+  background: #e6f4ff;
+  color: #3498db;
+  font-weight: 500;
+}
+
+.dropdown-divider {
+  height: 1px;
+  background: #e8e8e8;
+  margin: 4px 0;
+}
+
+.custom-range-btn {
+  color: #3498db;
+}
+
+.custom-range-form {
+  padding: 16px;
+}
+
+.form-group {
+  margin-bottom: 12px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #666;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.error-message {
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background: #fff2f0;
+  border: 1px solid #ffccc7;
+  border-radius: 4px;
+  color: #e74c3c;
+  font-size: 13px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.btn-cancel,
+.btn-apply {
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.btn-cancel {
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  color: #333;
+}
+
+.btn-cancel:hover {
+  border-color: #999;
+}
+
+.btn-apply {
+  background: #3498db;
+  border: 1px solid #3498db;
+  color: #fff;
+}
+
+.btn-apply:hover {
+  background: #2980b9;
+  border-color: #2980b9;
+}
+</style>

--- a/frontend/src/composables/useTimeRange.spec.ts
+++ b/frontend/src/composables/useTimeRange.spec.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useTimeRange, TIME_RANGE_PRESETS, REFRESH_INTERVALS } from './useTimeRange'
+
+describe('useTimeRange', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-02T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    // Clean up between tests - must be done before restoring timers
+    const { cleanup, setPreset, setRefreshInterval } = useTimeRange()
+    cleanup()
+    // Reset to default values
+    setPreset('1h')
+    setRefreshInterval('off')
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  describe('TIME_RANGE_PRESETS', () => {
+    it('should have all expected presets', () => {
+      expect(TIME_RANGE_PRESETS).toHaveLength(7)
+      expect(TIME_RANGE_PRESETS.map(p => p.value)).toEqual([
+        '5m', '15m', '30m', '1h', '6h', '24h', '7d'
+      ])
+    })
+
+    it('should have correct durations', () => {
+      const presetMap = Object.fromEntries(TIME_RANGE_PRESETS.map(p => [p.value, p.duration]))
+      expect(presetMap['5m']).toBe(5 * 60 * 1000)
+      expect(presetMap['15m']).toBe(15 * 60 * 1000)
+      expect(presetMap['30m']).toBe(30 * 60 * 1000)
+      expect(presetMap['1h']).toBe(60 * 60 * 1000)
+      expect(presetMap['6h']).toBe(6 * 60 * 60 * 1000)
+      expect(presetMap['24h']).toBe(24 * 60 * 60 * 1000)
+      expect(presetMap['7d']).toBe(7 * 24 * 60 * 60 * 1000)
+    })
+  })
+
+  describe('REFRESH_INTERVALS', () => {
+    it('should have all expected intervals', () => {
+      expect(REFRESH_INTERVALS).toHaveLength(5)
+      expect(REFRESH_INTERVALS.map(r => r.value)).toEqual([
+        'off', '5s', '15s', '30s', '1m'
+      ])
+    })
+
+    it('should have correct intervals in milliseconds', () => {
+      const intervalMap = Object.fromEntries(REFRESH_INTERVALS.map(r => [r.value, r.interval]))
+      expect(intervalMap['off']).toBe(0)
+      expect(intervalMap['5s']).toBe(5000)
+      expect(intervalMap['15s']).toBe(15000)
+      expect(intervalMap['30s']).toBe(30000)
+      expect(intervalMap['1m']).toBe(60000)
+    })
+  })
+
+  describe('timeRange', () => {
+    it('should default to 1 hour range', () => {
+      const { timeRange } = useTimeRange()
+      const now = Date.now()
+      const oneHour = 60 * 60 * 1000
+
+      expect(timeRange.value.end).toBe(now)
+      expect(timeRange.value.start).toBe(now - oneHour)
+    })
+
+    it('should calculate correct range for Last 5 minutes preset', () => {
+      const { setPreset, timeRange } = useTimeRange()
+      setPreset('5m')
+
+      const now = Date.now()
+      const fiveMinutes = 5 * 60 * 1000
+
+      expect(timeRange.value.end).toBe(now)
+      expect(timeRange.value.start).toBe(now - fiveMinutes)
+    })
+
+    it('should calculate correct range for Last 7 days preset', () => {
+      const { setPreset, timeRange } = useTimeRange()
+      setPreset('7d')
+
+      const now = Date.now()
+      const sevenDays = 7 * 24 * 60 * 60 * 1000
+
+      expect(timeRange.value.end).toBe(now)
+      expect(timeRange.value.start).toBe(now - sevenDays)
+    })
+  })
+
+  describe('setPreset', () => {
+    it('should update selectedPreset', () => {
+      const { setPreset, selectedPreset } = useTimeRange()
+
+      setPreset('15m')
+      expect(selectedPreset.value).toBe('15m')
+
+      setPreset('6h')
+      expect(selectedPreset.value).toBe('6h')
+    })
+
+    it('should clear custom range when setting preset', () => {
+      const { setCustomRange, setPreset, isCustomRange } = useTimeRange()
+
+      setCustomRange(Date.now() - 1000, Date.now())
+      expect(isCustomRange.value).toBe(true)
+
+      setPreset('1h')
+      expect(isCustomRange.value).toBe(false)
+    })
+
+    it('should not update for invalid preset', () => {
+      const { setPreset, selectedPreset } = useTimeRange()
+      const originalValue = selectedPreset.value
+
+      setPreset('invalid')
+      expect(selectedPreset.value).toBe(originalValue)
+    })
+  })
+
+  describe('setCustomRange', () => {
+    it('should set custom range', () => {
+      const { setCustomRange, customRange, isCustomRange, timeRange } = useTimeRange()
+      const start = Date.now() - 2 * 60 * 60 * 1000
+      const end = Date.now()
+
+      setCustomRange(start, end)
+
+      expect(isCustomRange.value).toBe(true)
+      expect(customRange.value).toEqual({ start, end })
+      expect(timeRange.value).toEqual({ start, end })
+    })
+  })
+
+  describe('displayText', () => {
+    it('should show preset label for preset ranges', () => {
+      const { setPreset, displayText } = useTimeRange()
+
+      setPreset('5m')
+      expect(displayText.value).toBe('Last 5 minutes')
+
+      setPreset('24h')
+      expect(displayText.value).toBe('Last 24 hours')
+    })
+
+    it('should show date range for custom ranges', () => {
+      const { setCustomRange, displayText } = useTimeRange()
+
+      // Set a custom range
+      const start = new Date('2026-02-01T10:30:00Z').getTime()
+      const end = new Date('2026-02-02T14:45:00Z').getTime()
+      setCustomRange(start, end)
+
+      // The display text should contain date-time values
+      expect(displayText.value).toContain('2026-02-01')
+      expect(displayText.value).toContain('2026-02-02')
+    })
+  })
+
+  describe('refresh', () => {
+    it('should update lastRefreshTime', () => {
+      const { refresh, lastRefreshTime } = useTimeRange()
+      const initialTime = lastRefreshTime.value
+
+      vi.advanceTimersByTime(1000)
+      refresh()
+
+      expect(lastRefreshTime.value).toBeGreaterThan(initialTime)
+    })
+
+    it('should call registered callbacks', () => {
+      const { refresh, onRefresh } = useTimeRange()
+      const callback = vi.fn()
+
+      onRefresh(callback)
+      refresh()
+
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call multiple registered callbacks', () => {
+      const { refresh, onRefresh } = useTimeRange()
+      const callback1 = vi.fn()
+      const callback2 = vi.fn()
+
+      onRefresh(callback1)
+      onRefresh(callback2)
+      refresh()
+
+      expect(callback1).toHaveBeenCalledTimes(1)
+      expect(callback2).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('onRefresh', () => {
+    it('should return unsubscribe function', () => {
+      const { refresh, onRefresh } = useTimeRange()
+      const callback = vi.fn()
+
+      const unsubscribe = onRefresh(callback)
+      refresh()
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      unsubscribe()
+      refresh()
+      expect(callback).toHaveBeenCalledTimes(1) // Should not be called again
+    })
+  })
+
+  describe('setRefreshInterval', () => {
+    it('should update refresh interval', () => {
+      const { setRefreshInterval, refreshIntervalValue } = useTimeRange()
+
+      setRefreshInterval('5s')
+      expect(refreshIntervalValue.value).toBe('5s')
+
+      setRefreshInterval('1m')
+      expect(refreshIntervalValue.value).toBe('1m')
+    })
+
+    it('should not update for invalid interval', () => {
+      const { setRefreshInterval, refreshIntervalValue } = useTimeRange()
+      const originalValue = refreshIntervalValue.value
+
+      setRefreshInterval('invalid')
+      expect(refreshIntervalValue.value).toBe(originalValue)
+    })
+  })
+
+  describe('auto-refresh', () => {
+    it('should trigger callbacks at specified interval', () => {
+      const { setRefreshInterval, onRefresh } = useTimeRange()
+      const callback = vi.fn()
+
+      onRefresh(callback)
+      setRefreshInterval('5s')
+
+      // Should not be called immediately
+      expect(callback).not.toHaveBeenCalled()
+
+      // Advance time by 5 seconds
+      vi.advanceTimersByTime(5000)
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      // Advance time by another 5 seconds
+      vi.advanceTimersByTime(5000)
+      expect(callback).toHaveBeenCalledTimes(2)
+    })
+
+    it('should stop refresh when set to off', () => {
+      const { setRefreshInterval, onRefresh } = useTimeRange()
+      const callback = vi.fn()
+
+      onRefresh(callback)
+      setRefreshInterval('5s')
+
+      vi.advanceTimersByTime(5000)
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      setRefreshInterval('off')
+      vi.advanceTimersByTime(5000)
+      expect(callback).toHaveBeenCalledTimes(1) // Should not be called again
+    })
+
+    it('should change interval when updated', () => {
+      const { setRefreshInterval, onRefresh } = useTimeRange()
+      const callback = vi.fn()
+
+      onRefresh(callback)
+      setRefreshInterval('5s')
+
+      vi.advanceTimersByTime(5000)
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      // Change to 15s interval
+      setRefreshInterval('15s')
+
+      vi.advanceTimersByTime(5000)
+      expect(callback).toHaveBeenCalledTimes(1) // Not yet (only 5s of 15s)
+
+      vi.advanceTimersByTime(10000)
+      expect(callback).toHaveBeenCalledTimes(2) // Now 15s has passed
+    })
+  })
+
+  describe('cleanup', () => {
+    it('should clear callbacks and stop auto-refresh', () => {
+      const { setRefreshInterval, onRefresh, cleanup, refresh } = useTimeRange()
+      const callback = vi.fn()
+
+      onRefresh(callback)
+      setRefreshInterval('5s')
+
+      cleanup()
+
+      // Manual refresh should not call callback
+      refresh()
+      expect(callback).not.toHaveBeenCalled()
+
+      // Auto-refresh should not trigger
+      vi.advanceTimersByTime(5000)
+      expect(callback).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/composables/useTimeRange.ts
+++ b/frontend/src/composables/useTimeRange.ts
@@ -1,0 +1,177 @@
+import { ref, computed, readonly, watch } from 'vue'
+
+export interface TimeRange {
+  start: number // Unix timestamp in milliseconds
+  end: number // Unix timestamp in milliseconds
+}
+
+export interface TimeRangePreset {
+  label: string
+  value: string
+  duration: number // Duration in milliseconds
+}
+
+export interface RefreshInterval {
+  label: string
+  value: string
+  interval: number // Interval in milliseconds, 0 means off
+}
+
+export const TIME_RANGE_PRESETS: TimeRangePreset[] = [
+  { label: 'Last 5 minutes', value: '5m', duration: 5 * 60 * 1000 },
+  { label: 'Last 15 minutes', value: '15m', duration: 15 * 60 * 1000 },
+  { label: 'Last 30 minutes', value: '30m', duration: 30 * 60 * 1000 },
+  { label: 'Last 1 hour', value: '1h', duration: 60 * 60 * 1000 },
+  { label: 'Last 6 hours', value: '6h', duration: 6 * 60 * 60 * 1000 },
+  { label: 'Last 24 hours', value: '24h', duration: 24 * 60 * 60 * 1000 },
+  { label: 'Last 7 days', value: '7d', duration: 7 * 24 * 60 * 60 * 1000 },
+]
+
+export const REFRESH_INTERVALS: RefreshInterval[] = [
+  { label: 'Off', value: 'off', interval: 0 },
+  { label: '5s', value: '5s', interval: 5 * 1000 },
+  { label: '15s', value: '15s', interval: 15 * 1000 },
+  { label: '30s', value: '30s', interval: 30 * 1000 },
+  { label: '1m', value: '1m', interval: 60 * 1000 },
+]
+
+// Shared state across all components using this composable
+const selectedPreset = ref<string>('1h')
+const customRange = ref<TimeRange | null>(null)
+const isCustomRange = ref(false)
+const refreshIntervalValue = ref<string>('off')
+const lastRefreshTime = ref<number>(Date.now())
+
+// Callbacks to be invoked on refresh
+const refreshCallbacks = new Set<() => void>()
+
+let refreshIntervalId: number | null = null
+
+function calculateTimeRange(): TimeRange {
+  if (isCustomRange.value && customRange.value) {
+    return customRange.value
+  }
+
+  const preset = TIME_RANGE_PRESETS.find(p => p.value === selectedPreset.value)
+  if (!preset) {
+    // Default to 1 hour if preset not found
+    const now = Date.now()
+    return { start: now - 60 * 60 * 1000, end: now }
+  }
+
+  const now = Date.now()
+  return { start: now - preset.duration, end: now }
+}
+
+function startAutoRefresh(intervalMs: number) {
+  stopAutoRefresh()
+  if (intervalMs > 0) {
+    refreshIntervalId = window.setInterval(() => {
+      lastRefreshTime.value = Date.now()
+      refreshCallbacks.forEach(callback => callback())
+    }, intervalMs)
+  }
+}
+
+function stopAutoRefresh() {
+  if (refreshIntervalId !== null) {
+    window.clearInterval(refreshIntervalId)
+    refreshIntervalId = null
+  }
+}
+
+export function useTimeRange() {
+  const timeRange = computed(() => calculateTimeRange())
+
+  const displayText = computed(() => {
+    if (isCustomRange.value && customRange.value) {
+      const start = new Date(customRange.value.start)
+      const end = new Date(customRange.value.end)
+      return `${formatDateTime(start)} - ${formatDateTime(end)}`
+    }
+
+    const preset = TIME_RANGE_PRESETS.find(p => p.value === selectedPreset.value)
+    return preset?.label || 'Last 1 hour'
+  })
+
+  const refreshInterval = computed(() => {
+    return REFRESH_INTERVALS.find(r => r.value === refreshIntervalValue.value) || REFRESH_INTERVALS[0]
+  })
+
+  function setPreset(presetValue: string) {
+    const preset = TIME_RANGE_PRESETS.find(p => p.value === presetValue)
+    if (preset) {
+      selectedPreset.value = presetValue
+      isCustomRange.value = false
+      customRange.value = null
+      lastRefreshTime.value = Date.now()
+      refreshCallbacks.forEach(callback => callback())
+    }
+  }
+
+  function setCustomRange(start: number, end: number) {
+    customRange.value = { start, end }
+    isCustomRange.value = true
+    lastRefreshTime.value = Date.now()
+    refreshCallbacks.forEach(callback => callback())
+  }
+
+  function setRefreshInterval(intervalValue: string) {
+    const interval = REFRESH_INTERVALS.find(r => r.value === intervalValue)
+    if (interval) {
+      refreshIntervalValue.value = intervalValue
+      startAutoRefresh(interval.interval)
+    }
+  }
+
+  function refresh() {
+    lastRefreshTime.value = Date.now()
+    refreshCallbacks.forEach(callback => callback())
+  }
+
+  function onRefresh(callback: () => void) {
+    refreshCallbacks.add(callback)
+    // Return cleanup function
+    return () => {
+      refreshCallbacks.delete(callback)
+    }
+  }
+
+  function cleanup() {
+    stopAutoRefresh()
+    refreshCallbacks.clear()
+  }
+
+  return {
+    // State (readonly)
+    timeRange,
+    displayText,
+    selectedPreset: readonly(selectedPreset),
+    isCustomRange: readonly(isCustomRange),
+    customRange: readonly(customRange),
+    refreshInterval,
+    refreshIntervalValue: readonly(refreshIntervalValue),
+    lastRefreshTime: readonly(lastRefreshTime),
+
+    // Constants
+    presets: TIME_RANGE_PRESETS,
+    refreshIntervals: REFRESH_INTERVALS,
+
+    // Actions
+    setPreset,
+    setCustomRange,
+    setRefreshInterval,
+    refresh,
+    onRefresh,
+    cleanup,
+  }
+}
+
+function formatDateTime(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hours}:${minutes}`
+}


### PR DESCRIPTION
## Summary
- Add global time range selector component for dashboard panels
- Implement useTimeRange composable with shared reactive state
- Support 7 preset ranges (5m, 15m, 30m, 1h, 6h, 24h, 7d)
- Add custom range selection with datetime pickers
- Implement auto-refresh with intervals (Off, 5s, 15s, 30s, 1m)
- Add manual refresh button and human-readable display

## Test plan
- [ ] Verify TimeRangePicker renders in dashboard detail view header
- [ ] Test selecting preset ranges updates display text correctly
- [ ] Test custom range form validates start < end dates
- [ ] Test auto-refresh triggers callbacks at specified intervals
- [ ] Run `cd frontend && npm run type-check && npm run test` (85 tests pass)

Implements: PRD feature "UI - Time Range Picker Component"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time range picker with preset options (Last 5 minutes through Last 7 days)
  * Custom date range selection with validation
  * Auto-refresh capability with configurable intervals (5 seconds to 1 minute, or disabled)
  * Manual refresh button integrated into dashboard

* **Tests**
  * Comprehensive test coverage for new time range functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->