### PR TITLE
feat: Add pie/donut chart visualization

### DIFF
--- a/frontend/src/components/PieChart.spec.ts
+++ b/frontend/src/components/PieChart.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PieChart from './PieChart.vue'
+
+// Mock ECharts components
+vi.mock('vue-echarts', () => ({
+  default: {
+    name: 'VChart',
+    props: ['option', 'autoresize'],
+    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)"></div>',
+    methods: {
+      resize: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+}))
+
+vi.mock('echarts/renderers', () => ({
+  CanvasRenderer: {},
+}))
+
+vi.mock('echarts/charts', () => ({
+  PieChart: {},
+}))
+
+vi.mock('echarts/components', () => ({
+  TitleComponent: {},
+  TooltipComponent: {},
+  LegendComponent: {},
+}))
+
+describe('PieChart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the pie chart container', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 50 }] },
+    })
+    expect(wrapper.find('.pie-chart').exists()).toBe(true)
+  })
+
+  it('passes data to ECharts', () => {
+    const data = [
+      { name: 'Series A', value: 50 },
+      { name: 'Series B', value: 30 },
+      { name: 'Series C', value: 20 },
+    ]
+    const wrapper = mount(PieChart, {
+      props: { data },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    expect(chart.exists()).toBe(true)
+
+    const optionStr = chart.attributes('data-option')
+    const option = JSON.parse(optionStr || '{}')
+
+    expect(option.series).toHaveLength(1)
+    expect(option.series[0].type).toBe('pie')
+    expect(option.series[0].data).toHaveLength(3)
+    expect(option.series[0].data[0].name).toBe('Series A')
+    expect(option.series[0].data[0].value).toBe(50)
+  })
+
+  it('renders as pie by default', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    // Pie has radius starting from 0
+    expect(option.series[0].radius[0]).toBe(0)
+  })
+
+  it('renders as donut when displayAs is donut', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }], displayAs: 'donut' },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    // Donut has inner radius > 0
+    expect(option.series[0].radius[0]).toBe('40%')
+    expect(option.series[0].radius[1]).toBe('70%')
+  })
+
+  it('shows legend by default', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.legend.show).toBe(true)
+  })
+
+  it('hides legend when showLegend is false', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }], showLegend: false },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.legend.show).toBe(false)
+  })
+
+  it('shows labels by default', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].label.show).toBe(true)
+    expect(option.series[0].labelLine.show).toBe(true)
+  })
+
+  it('hides labels when showLabels is false', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }], showLabels: false },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].label.show).toBe(false)
+    expect(option.series[0].labelLine.show).toBe(false)
+  })
+
+  it('applies custom height when provided', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }], height: 400 },
+    })
+    expect(wrapper.find('.pie-chart').attributes('style')).toContain('height: 400px')
+  })
+
+  it('applies default height when not provided', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }] },
+    })
+    expect(wrapper.find('.pie-chart').attributes('style')).toContain('height: 100%')
+  })
+
+  it('includes title when provided', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }], title: 'Traffic Distribution' },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.title.text).toBe('Traffic Distribution')
+  })
+
+  it('handles empty data array', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data).toHaveLength(0)
+  })
+
+  it('handles single data item', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'Only', value: 100 }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data).toHaveLength(1)
+    expect(option.series[0].data[0].value).toBe(100)
+  })
+
+  it('applies colors from palette', () => {
+    const data = [
+      { name: 'A', value: 40 },
+      { name: 'B', value: 30 },
+      { name: 'C', value: 30 },
+    ]
+    const wrapper = mount(PieChart, {
+      props: { data },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    // Each data item should have a color from the palette
+    expect(option.series[0].data[0].itemStyle.color).toBe('#667eea')
+    expect(option.series[0].data[1].itemStyle.color).toBe('#764ba2')
+    expect(option.series[0].data[2].itemStyle.color).toBe('#00d4aa')
+  })
+
+  it('configures tooltip', () => {
+    const wrapper = mount(PieChart, {
+      props: { data: [{ name: 'A', value: 100 }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.tooltip.trigger).toBe('item')
+  })
+
+  it('handles many data items', () => {
+    const data = Array.from({ length: 15 }, (_, i) => ({
+      name: `Series ${i + 1}`,
+      value: (i + 1) * 10,
+    }))
+    const wrapper = mount(PieChart, {
+      props: { data },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data).toHaveLength(15)
+    // Colors should cycle through the palette
+    expect(option.series[0].data[10].itemStyle.color).toBe('#667eea') // Index 10 % 10 = 0
+  })
+
+  it('handles zero values correctly', () => {
+    const data = [
+      { name: 'A', value: 0 },
+      { name: 'B', value: 50 },
+      { name: 'C', value: 50 },
+    ]
+    const wrapper = mount(PieChart, {
+      props: { data },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data[0].value).toBe(0)
+    expect(option.series[0].data[1].value).toBe(50)
+  })
+})

--- a/frontend/src/components/PieChart.vue
+++ b/frontend/src/components/PieChart.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted } from 'vue'
+import VChart from 'vue-echarts'
+import { use } from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { PieChart as EChartsPieChart } from 'echarts/charts'
+import { TitleComponent, TooltipComponent, LegendComponent } from 'echarts/components'
+import type { EChartsOption } from 'echarts'
+
+// Register ECharts components
+use([CanvasRenderer, EChartsPieChart, TitleComponent, TooltipComponent, LegendComponent])
+
+export interface PieDataItem {
+  name: string
+  value: number
+}
+
+const props = withDefaults(
+  defineProps<{
+    data: PieDataItem[]
+    displayAs?: 'pie' | 'donut'
+    showLegend?: boolean
+    showLabels?: boolean
+    title?: string
+    height?: string | number
+  }>(),
+  {
+    displayAs: 'pie',
+    showLegend: true,
+    showLabels: true,
+    title: '',
+    height: '100%',
+  }
+)
+
+const chartRef = ref<typeof VChart | null>(null)
+
+// Color palette matching the dashboard theme
+const pieColors = [
+  '#667eea', // Primary purple-blue
+  '#764ba2', // Secondary purple
+  '#00d4aa', // Success green
+  '#feca57', // Warning yellow
+  '#ff6b6b', // Danger red
+  '#a78bfa', // Light purple
+  '#60a5fa', // Light blue
+  '#34d399', // Emerald
+  '#f472b6', // Pink
+  '#fb923c', // Orange
+]
+
+// Calculate total for percentage display
+const total = computed(() => props.data.reduce((sum, item) => sum + item.value, 0))
+
+// Calculate percentage for a value
+function getPercentage(value: number): string {
+  if (total.value === 0) return '0%'
+  return ((value / total.value) * 100).toFixed(1) + '%'
+}
+
+const chartOption = computed<EChartsOption>(() => {
+  const radius = props.displayAs === 'donut' ? ['40%', '70%'] : [0, '70%']
+
+  return {
+    backgroundColor: 'transparent',
+    title: props.title
+      ? {
+          text: props.title,
+          left: 'center',
+          textStyle: {
+            color: '#f5f5f5',
+            fontSize: 13,
+            fontWeight: 500,
+          },
+        }
+      : undefined,
+    tooltip: {
+      trigger: 'item',
+      backgroundColor: '#1a1a1a',
+      borderColor: '#2a2a2a',
+      borderWidth: 1,
+      textStyle: {
+        color: '#f5f5f5',
+        fontSize: 12,
+      },
+      formatter: (params: any) => {
+        const percent = getPercentage(params.value)
+        return `<div style="display: flex; align-items: center; gap: 8px;">
+          <span style="display: inline-block; width: 10px; height: 10px; background: ${params.color}; border-radius: 50%;"></span>
+          <span style="color: #a0a0a0;">${params.name}</span>
+        </div>
+        <div style="margin-top: 4px; font-weight: 600;">
+          ${params.value.toLocaleString()} (${percent})
+        </div>`
+      },
+    },
+    legend: {
+      show: props.showLegend,
+      orient: 'horizontal',
+      bottom: 0,
+      textStyle: {
+        color: '#a0a0a0',
+        fontSize: 11,
+      },
+      itemWidth: 12,
+      itemHeight: 12,
+    },
+    series: [
+      {
+        type: 'pie',
+        radius,
+        center: ['50%', props.showLegend ? '45%' : '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: {
+          borderRadius: 4,
+          borderColor: '#1a1a1a',
+          borderWidth: 2,
+        },
+        label: {
+          show: props.showLabels,
+          position: 'outside',
+          color: '#a0a0a0',
+          fontSize: 11,
+          formatter: (params: any) => {
+            const percent = getPercentage(params.value)
+            return `${params.name}\n${percent}`
+          },
+        },
+        labelLine: {
+          show: props.showLabels,
+          lineStyle: {
+            color: '#444444',
+          },
+        },
+        emphasis: {
+          itemStyle: {
+            shadowBlur: 10,
+            shadowOffsetX: 0,
+            shadowColor: 'rgba(0, 0, 0, 0.5)',
+          },
+          label: {
+            show: true,
+            fontSize: 12,
+            fontWeight: 600,
+            color: '#f5f5f5',
+          },
+        },
+        data: props.data.map((item, index) => ({
+          ...item,
+          itemStyle: {
+            color: pieColors[index % pieColors.length],
+          },
+        })),
+      },
+    ],
+  }
+})
+
+// Handle resize
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  const container = chartRef.value?.$el?.parentElement
+  if (container) {
+    resizeObserver = new ResizeObserver(() => {
+      chartRef.value?.resize()
+    })
+    resizeObserver.observe(container)
+  }
+})
+
+onUnmounted(() => {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+})
+</script>
+
+<template>
+  <div class="pie-chart" :style="{ height: typeof height === 'number' ? `${height}px` : height }">
+    <VChart ref="chartRef" :option="chartOption" :autoresize="true" class="chart" />
+  </div>
+</template>
+
+<style scoped>
+.pie-chart {
+  width: 100%;
+  min-height: 200px;
+}
+
+.chart {
+  width: 100%;
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- Add PieChart.vue component using ECharts pie type with configurable pie/donut display mode
- Support for legend visibility and label display toggles
- Automatic percentage calculation and color palette application
- Integrate pie chart type into Panel.vue to render pie visualization
- Add pie configuration options (display style, legend, labels) to PanelEditModal.vue
- Include comprehensive test coverage (17 tests) for PieChart component

## Test plan
- [x] All existing tests pass (185 tests)
- [x] New PieChart tests pass (pie/donut modes, legend, labels, colors)
- [ ] Manual verification: Create a pie panel and verify rendering
- [ ] Manual verification: Toggle between pie and donut display modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)