### PR TITLE
feat: Add stat/KPI panel visualization

### DIFF
--- a/frontend/src/components/StatPanel.spec.ts
+++ b/frontend/src/components/StatPanel.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StatPanel from './StatPanel.vue'
+
+// Mock ECharts components for sparkline
+vi.mock('vue-echarts', () => ({
+  default: {
+    name: 'VChart',
+    props: ['option', 'autoresize'],
+    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)"></div>',
+    methods: {
+      resize: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+}))
+
+vi.mock('echarts/renderers', () => ({
+  CanvasRenderer: {},
+}))
+
+vi.mock('echarts/charts', () => ({
+  LineChart: {},
+}))
+
+vi.mock('echarts/components', () => ({
+  GridComponent: {},
+}))
+
+describe('StatPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the stat panel container', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100 },
+    })
+    expect(wrapper.find('.stat-panel').exists()).toBe(true)
+  })
+
+  it('displays the value', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 75 },
+    })
+    expect(wrapper.find('.stat-value').text()).toContain('75')
+  })
+
+  it('formats large values with K suffix', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 1250, decimals: 2 },
+    })
+    expect(wrapper.find('.stat-value').text()).toBe('1.25K')
+  })
+
+  it('formats larger values with M suffix', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 1500000, decimals: 2 },
+    })
+    expect(wrapper.find('.stat-value').text()).toBe('1.50M')
+  })
+
+  it('formats very large values with B suffix', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 2500000000, decimals: 2 },
+    })
+    expect(wrapper.find('.stat-value').text()).toBe('2.50B')
+  })
+
+  it('includes unit in formatted value', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 75, unit: '%' },
+    })
+    expect(wrapper.find('.stat-value').text()).toContain('%')
+  })
+
+  it('respects decimals setting', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 3.14159, decimals: 1 },
+    })
+    expect(wrapper.find('.stat-value').text()).toBe('3.1')
+  })
+
+  it('displays label when provided', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100, label: 'CPU Usage' },
+    })
+    expect(wrapper.find('.stat-label').exists()).toBe(true)
+    expect(wrapper.find('.stat-label').text()).toBe('CPU Usage')
+  })
+
+  it('does not display label when not provided', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100 },
+    })
+    expect(wrapper.find('.stat-label').exists()).toBe(false)
+  })
+
+  it('shows upward trend when value is higher than previous', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100, previousValue: 80, showTrend: true },
+    })
+    expect(wrapper.find('.stat-trend').exists()).toBe(true)
+    expect(wrapper.find('.trend-up').exists()).toBe(true)
+  })
+
+  it('shows downward trend when value is lower than previous', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 60, previousValue: 80, showTrend: true },
+    })
+    expect(wrapper.find('.stat-trend').exists()).toBe(true)
+    expect(wrapper.find('.trend-down').exists()).toBe(true)
+  })
+
+  it('does not show trend when showTrend is false', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100, previousValue: 80, showTrend: false },
+    })
+    expect(wrapper.find('.stat-trend').exists()).toBe(false)
+  })
+
+  it('does not show trend when previousValue is not provided', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100, showTrend: true },
+    })
+    expect(wrapper.find('.stat-trend').exists()).toBe(false)
+  })
+
+  it('displays trend percentage', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100, previousValue: 80, showTrend: true },
+    })
+    const trendValue = wrapper.find('.trend-value')
+    expect(trendValue.exists()).toBe(true)
+    expect(trendValue.text()).toContain('+25.0%')
+  })
+
+  it('shows sparkline when data is provided', () => {
+    const data = [
+      { timestamp: 1000, value: 10 },
+      { timestamp: 2000, value: 20 },
+      { timestamp: 3000, value: 15 },
+    ]
+    const wrapper = mount(StatPanel, {
+      props: { value: 15, data, showSparkline: true },
+    })
+    expect(wrapper.find('.stat-sparkline').exists()).toBe(true)
+  })
+
+  it('does not show sparkline when showSparkline is false', () => {
+    const data = [
+      { timestamp: 1000, value: 10 },
+      { timestamp: 2000, value: 20 },
+    ]
+    const wrapper = mount(StatPanel, {
+      props: { value: 20, data, showSparkline: false },
+    })
+    expect(wrapper.find('.stat-sparkline').exists()).toBe(false)
+  })
+
+  it('does not show sparkline when no data is provided', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100, showSparkline: true },
+    })
+    expect(wrapper.find('.stat-sparkline').exists()).toBe(false)
+  })
+
+  it('applies threshold color when value exceeds threshold', () => {
+    const thresholds = [
+      { value: 50, color: '#feca57' },
+      { value: 80, color: '#ff6b6b' },
+    ]
+    const wrapper = mount(StatPanel, {
+      props: { value: 90, thresholds },
+    })
+    const statValue = wrapper.find('.stat-value')
+    expect(statValue.attributes('style')).toContain('color: #ff6b6b')
+  })
+
+  it('uses default color when below all thresholds', () => {
+    const thresholds = [
+      { value: 50, color: '#feca57' },
+      { value: 80, color: '#ff6b6b' },
+    ]
+    const wrapper = mount(StatPanel, {
+      props: { value: 30, thresholds },
+    })
+    const statValue = wrapper.find('.stat-value')
+    expect(statValue.attributes('style')).toContain('color: #f5f5f5')
+  })
+
+  it('applies custom height when provided', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100, height: 200 },
+    })
+    expect(wrapper.find('.stat-panel').attributes('style')).toContain('height: 200px')
+  })
+
+  it('applies default height when not provided', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 100 },
+    })
+    expect(wrapper.find('.stat-panel').attributes('style')).toContain('height: 100%')
+  })
+
+  it('handles zero value', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: 0 },
+    })
+    expect(wrapper.find('.stat-value').text()).toBe('0.00')
+  })
+
+  it('handles negative values', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: -50 },
+    })
+    expect(wrapper.find('.stat-value').text()).toContain('-50')
+  })
+
+  it('handles negative large values', () => {
+    const wrapper = mount(StatPanel, {
+      props: { value: -1500, decimals: 1 },
+    })
+    expect(wrapper.find('.stat-value').text()).toBe('-1.5K')
+  })
+})

--- a/frontend/src/components/StatPanel.vue
+++ b/frontend/src/components/StatPanel.vue
@@ -1,0 +1,323 @@
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { TrendingUp, TrendingDown, Minus } from 'lucide-vue-next'
+import VChart from 'vue-echarts'
+import { use } from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { LineChart } from 'echarts/charts'
+import { GridComponent } from 'echarts/components'
+import type { EChartsOption } from 'echarts'
+
+// Register ECharts components for sparkline
+use([CanvasRenderer, LineChart, GridComponent])
+
+export interface Threshold {
+  value: number
+  color: string
+  background?: string
+}
+
+export interface DataPoint {
+  timestamp: number
+  value: number
+}
+
+const props = withDefaults(
+  defineProps<{
+    value: number
+    previousValue?: number
+    data?: DataPoint[]
+    label?: string
+    unit?: string
+    decimals?: number
+    thresholds?: Threshold[]
+    showTrend?: boolean
+    showSparkline?: boolean
+    height?: string | number
+  }>(),
+  {
+    previousValue: undefined,
+    data: () => [],
+    label: '',
+    unit: '',
+    decimals: 2,
+    thresholds: () => [],
+    showTrend: true,
+    showSparkline: true,
+    height: '100%',
+  }
+)
+
+const chartRef = ref<typeof VChart | null>(null)
+
+// Format value with decimals and unit, with human-readable suffixes
+function formatValue(value: number): string {
+  if (Math.abs(value) >= 1000000000) {
+    return (value / 1000000000).toFixed(props.decimals) + 'B' + props.unit
+  }
+  if (Math.abs(value) >= 1000000) {
+    return (value / 1000000).toFixed(props.decimals) + 'M' + props.unit
+  }
+  if (Math.abs(value) >= 1000) {
+    return (value / 1000).toFixed(props.decimals) + 'K' + props.unit
+  }
+  return value.toFixed(props.decimals) + props.unit
+}
+
+// Get the color based on thresholds
+function getValueColor(): string {
+  if (!props.thresholds || props.thresholds.length === 0) {
+    return '#f5f5f5' // Default text color
+  }
+
+  const sortedThresholds = [...props.thresholds].sort((a, b) => a.value - b.value)
+  let color = '#f5f5f5' // Default
+
+  for (const threshold of sortedThresholds) {
+    if (props.value >= threshold.value) {
+      color = threshold.color
+    }
+  }
+  return color
+}
+
+// Get the background color based on thresholds
+function getBackgroundColor(): string {
+  if (!props.thresholds || props.thresholds.length === 0) {
+    return 'transparent'
+  }
+
+  const sortedThresholds = [...props.thresholds].sort((a, b) => a.value - b.value)
+  let background = 'transparent'
+
+  for (const threshold of sortedThresholds) {
+    if (props.value >= threshold.value && threshold.background) {
+      background = threshold.background
+    }
+  }
+  return background
+}
+
+// Calculate trend
+const trend = computed(() => {
+  if (props.previousValue === undefined || props.previousValue === null) {
+    return 'neutral'
+  }
+  if (props.value > props.previousValue) {
+    return 'up'
+  }
+  if (props.value < props.previousValue) {
+    return 'down'
+  }
+  return 'neutral'
+})
+
+// Calculate trend percentage
+const trendPercentage = computed(() => {
+  if (props.previousValue === undefined || props.previousValue === null || props.previousValue === 0) {
+    return null
+  }
+  const change = ((props.value - props.previousValue) / Math.abs(props.previousValue)) * 100
+  return change.toFixed(1)
+})
+
+// Sparkline chart option
+const sparklineOption = computed<EChartsOption>(() => {
+  if (!props.data || props.data.length === 0) {
+    return {}
+  }
+
+  const valueColor = getValueColor()
+
+  return {
+    backgroundColor: 'transparent',
+    grid: {
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+    },
+    xAxis: {
+      type: 'category',
+      show: false,
+      data: props.data.map((d) => d.timestamp),
+    },
+    yAxis: {
+      type: 'value',
+      show: false,
+      min: 'dataMin',
+      max: 'dataMax',
+    },
+    series: [
+      {
+        type: 'line',
+        data: props.data.map((d) => d.value),
+        smooth: true,
+        symbol: 'none',
+        lineStyle: {
+          width: 2,
+          color: valueColor,
+        },
+        areaStyle: {
+          color: {
+            type: 'linear' as const,
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: valueColor + '40' },
+              { offset: 1, color: valueColor + '05' },
+            ],
+          },
+        },
+      },
+    ],
+  }
+})
+
+const formattedValue = computed(() => formatValue(props.value))
+const valueColor = computed(() => getValueColor())
+const backgroundColor = computed(() => getBackgroundColor())
+const hasSparklineData = computed(() => props.data && props.data.length > 0)
+
+// Handle resize
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  if (chartRef.value) {
+    const container = chartRef.value.$el?.parentElement
+    if (container) {
+      resizeObserver = new ResizeObserver(() => {
+        chartRef.value?.resize()
+      })
+      resizeObserver.observe(container)
+    }
+  }
+})
+
+onUnmounted(() => {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+})
+</script>
+
+<template>
+  <div
+    class="stat-panel"
+    :style="{
+      height: typeof height === 'number' ? `${height}px` : height,
+      backgroundColor: backgroundColor,
+    }"
+  >
+    <div class="stat-content">
+      <div class="stat-value" :style="{ color: valueColor }">
+        {{ formattedValue }}
+      </div>
+
+      <div v-if="label" class="stat-label">
+        {{ label }}
+      </div>
+
+      <div v-if="showTrend && trend !== 'neutral'" class="stat-trend" :class="`trend-${trend}`">
+        <TrendingUp v-if="trend === 'up'" :size="16" />
+        <TrendingDown v-if="trend === 'down'" :size="16" />
+        <Minus v-if="trend === 'neutral'" :size="16" />
+        <span v-if="trendPercentage" class="trend-value">
+          {{ trend === 'up' ? '+' : '' }}{{ trendPercentage }}%
+        </span>
+      </div>
+    </div>
+
+    <div v-if="showSparkline && hasSparklineData" class="stat-sparkline">
+      <VChart
+        ref="chartRef"
+        :option="sparklineOption"
+        :autoresize="true"
+        class="sparkline-chart"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.stat-panel {
+  width: 100%;
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  border-radius: 8px;
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  z-index: 1;
+}
+
+.stat-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.stat-label {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  text-align: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stat-trend {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-top: 0.25rem;
+}
+
+.trend-up {
+  color: #4ecdc4;
+}
+
+.trend-down {
+  color: #ff6b6b;
+}
+
+.trend-neutral {
+  color: var(--text-tertiary);
+}
+
+.trend-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-sparkline {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40%;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.sparkline-chart {
+  width: 100%;
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- Add StatPanel.vue component for displaying large metric values prominently
- Support trend indicators (up/down arrows with percentage change)
- Optional sparkline showing metric history over time
- Configurable thresholds for dynamic color changes based on value
- Unit formatting with automatic K/M/B suffixes for large numbers
- Integrate stat panel type into Panel.vue to render stat visualization
- Add stat configuration options (unit, decimals, show trend, show sparkline, thresholds) to PanelEditModal.vue
- Include comprehensive test coverage (24 tests) for StatPanel component

## Test plan
- [x] All existing tests pass (192 tests)
- [x] New StatPanel tests pass (value formatting, trend, sparkline, thresholds)
- [ ] Manual verification: Create a stat panel and verify rendering
- [ ] Manual verification: Configure thresholds and verify color changes
- [ ] Manual verification: Toggle trend and sparkline display options

🤖 Generated with [Claude Code](https://claude.com/claude-code)