### PR TITLE
Correct name to Ace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dash - Monitoring Dashboard
+# Ace - Monitoring Dashboard
 
 [![CodeQL](https://github.com/janhoon/dash/actions/workflows/security.yml/badge.svg?branch=master)](https://github.com/janhoon/dash/actions/workflows/security.yml)
 [![Lint](https://github.com/janhoon/dash/actions/workflows/lint.yml/badge.svg?branch=master)](https://github.com/janhoon/dash/actions/workflows/lint.yml)


### PR DESCRIPTION
gib bug bounty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project branding - the monitoring dashboard has been renamed from "Dash" to "Ace".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->