### PR TITLE
feat: #408 AlertManager datasource — silences management, receivers, active alerts UI

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -208,6 +208,15 @@ func main() {
 	mux.HandleFunc("GET /api/datasources/{id}/vmalert/rules", auth.RequireAuth(jwtManager, vmAlertHandler.Rules))
 	mux.HandleFunc("GET /api/datasources/{id}/vmalert/health", auth.RequireAuth(jwtManager, vmAlertHandler.Health))
 
+	// AlertManager proxy routes
+	alertManagerHandler := handlers.NewAlertManagerHandler(pool)
+	mux.HandleFunc("GET /api/datasources/{id}/alertmanager/alerts", auth.RequireAuth(jwtManager, alertManagerHandler.ListAlerts))
+	mux.HandleFunc("GET /api/datasources/{id}/alertmanager/silences", auth.RequireAuth(jwtManager, alertManagerHandler.ListSilences))
+	mux.HandleFunc("POST /api/datasources/{id}/alertmanager/silences", auth.RequireAuth(jwtManager, alertManagerHandler.CreateSilence))
+	mux.HandleFunc("DELETE /api/datasources/{id}/alertmanager/silences/{silenceId}", auth.RequireAuth(jwtManager, alertManagerHandler.ExpireSilence))
+	mux.HandleFunc("GET /api/datasources/{id}/alertmanager/receivers", auth.RequireAuth(jwtManager, alertManagerHandler.ListReceivers))
+	mux.HandleFunc("GET /api/datasources/{id}/alertmanager/health", auth.RequireAuth(jwtManager, alertManagerHandler.Health))
+
 	// Grafana conversion route
 	grafanaConverterHandler := handlers.NewGrafanaConverterHandler()
 	mux.HandleFunc("POST /api/convert/grafana", auth.RequireAuth(jwtManager, grafanaConverterHandler.Convert))

--- a/backend/internal/datasource/alertmanager.go
+++ b/backend/internal/datasource/alertmanager.go
@@ -1,0 +1,221 @@
+package datasource
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/janhoon/dash/backend/internal/models"
+)
+
+// AlertManagerClient wraps HTTP calls to AlertManager's v2 API.
+type AlertManagerClient struct {
+	baseURL    string
+	client     *http.Client
+	datasource models.DataSource
+}
+
+// NewAlertManagerClient creates a new AlertManager client from a datasource record.
+func NewAlertManagerClient(ds models.DataSource) (*AlertManagerClient, error) {
+	if ds.URL == "" {
+		return nil, fmt.Errorf("alertmanager datasource URL is required")
+	}
+	return &AlertManagerClient{
+		baseURL:    ds.URL,
+		client:     &http.Client{Timeout: 30 * time.Second},
+		datasource: ds,
+	}, nil
+}
+
+// AMAlert represents an alert returned by AlertManager.
+type AMAlert struct {
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+	State        string            `json:"state"`
+	ActiveAt     time.Time         `json:"activeAt"`
+	EndsAt       time.Time         `json:"endsAt"`
+	StartsAt     time.Time         `json:"startsAt"`
+	GeneratorURL string            `json:"generatorURL"`
+	Fingerprint  string            `json:"fingerprint"`
+	Status       AMAlertStatus     `json:"status"`
+	Receivers    []AMReceiver      `json:"receivers"`
+}
+
+// AMAlertStatus represents the status block inside an alert.
+type AMAlertStatus struct {
+	State       string   `json:"state"`
+	SilencedBy  []string `json:"silencedBy"`
+	InhibitedBy []string `json:"inhibitedBy"`
+}
+
+// AMMatcher represents a silence matcher.
+type AMMatcher struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	IsRegex bool   `json:"isRegex"`
+	IsEqual bool   `json:"isEqual"`
+}
+
+// AMSilenceStatus represents the status of a silence.
+type AMSilenceStatus struct {
+	State string `json:"state"`
+}
+
+// AMSilence represents a silence returned by AlertManager.
+type AMSilence struct {
+	ID        string          `json:"id"`
+	Matchers  []AMMatcher     `json:"matchers"`
+	StartsAt  time.Time       `json:"startsAt"`
+	EndsAt    time.Time       `json:"endsAt"`
+	CreatedBy string          `json:"createdBy"`
+	Comment   string          `json:"comment"`
+	Status    AMSilenceStatus `json:"status"`
+	UpdatedAt time.Time       `json:"updatedAt"`
+}
+
+// AMSilenceCreate is the payload for creating a silence.
+type AMSilenceCreate struct {
+	Matchers  []AMMatcher `json:"matchers"`
+	StartsAt  time.Time   `json:"startsAt"`
+	EndsAt    time.Time   `json:"endsAt"`
+	CreatedBy string      `json:"createdBy"`
+	Comment   string      `json:"comment"`
+}
+
+// AMSilenceResponse is the response from POST /api/v2/silences.
+type AMSilenceResponse struct {
+	SilenceID string `json:"silenceID"`
+}
+
+// AMReceiver represents a receiver from AlertManager.
+type AMReceiver struct {
+	Name string `json:"name"`
+}
+
+// AMVersionInfo holds version information from the status endpoint.
+type AMVersionInfo struct {
+	Version string `json:"version"`
+}
+
+// AMClusterStatus holds cluster status info.
+type AMClusterStatus struct {
+	Status string `json:"status"`
+}
+
+// AMStatus represents the status response from AlertManager.
+type AMStatus struct {
+	Cluster    AMClusterStatus `json:"cluster"`
+	VersionInfo AMVersionInfo  `json:"versionInfo"`
+	Uptime     time.Time       `json:"uptime"`
+}
+
+// GetAlerts fetches alerts from AlertManager.
+func (c *AlertManagerClient) GetAlerts(ctx context.Context, active, silenced, inhibited bool) ([]AMAlert, error) {
+	path := fmt.Sprintf("/api/v2/alerts?active=%t&silenced=%t&inhibited=%t", active, silenced, inhibited)
+	return doAlertManagerRequest[[]AMAlert](ctx, c, http.MethodGet, path, nil)
+}
+
+// GetSilences fetches all silences from AlertManager.
+func (c *AlertManagerClient) GetSilences(ctx context.Context) ([]AMSilence, error) {
+	return doAlertManagerRequest[[]AMSilence](ctx, c, http.MethodGet, "/api/v2/silences", nil)
+}
+
+// CreateSilence creates a new silence and returns its ID.
+func (c *AlertManagerClient) CreateSilence(ctx context.Context, silence AMSilenceCreate) (string, error) {
+	body, err := json.Marshal(silence)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal silence: %w", err)
+	}
+
+	result, err := doAlertManagerRequest[AMSilenceResponse](ctx, c, http.MethodPost, "/api/v2/silences", body)
+	if err != nil {
+		return "", err
+	}
+	return result.SilenceID, nil
+}
+
+// ExpireSilence expires (deletes) a silence by ID.
+func (c *AlertManagerClient) ExpireSilence(ctx context.Context, id string) error {
+	reqURL := c.baseURL + "/api/v2/silence/" + id
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create expire silence request: %w", err)
+	}
+	if err := applyDataSourceAuth(req, c.datasource); err != nil {
+		return err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("expire silence request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return fmt.Errorf("expire silence returned status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// GetReceivers fetches all receivers from AlertManager.
+func (c *AlertManagerClient) GetReceivers(ctx context.Context) ([]AMReceiver, error) {
+	return doAlertManagerRequest[[]AMReceiver](ctx, c, http.MethodGet, "/api/v2/receivers", nil)
+}
+
+// GetStatus fetches the status of AlertManager (used for health check).
+func (c *AlertManagerClient) GetStatus(ctx context.Context) (*AMStatus, error) {
+	result, err := doAlertManagerRequest[AMStatus](ctx, c, http.MethodGet, "/api/v2/status", nil)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func doAlertManagerRequest[T any](ctx context.Context, c *AlertManagerClient, method, path string, body []byte) (T, error) {
+	var zero T
+	reqURL := c.baseURL + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, bodyReader)
+	if err != nil {
+		return zero, fmt.Errorf("failed to create request for %s: %w", path, err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	if err := applyDataSourceAuth(req, c.datasource); err != nil {
+		return zero, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return zero, fmt.Errorf("request to %s failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return zero, fmt.Errorf("failed to read response from %s: %w", path, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return zero, fmt.Errorf("%s returned status %d: %s", path, resp.StatusCode, string(respBody))
+	}
+
+	var result T
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return zero, fmt.Errorf("failed to parse response from %s: %w", path, err)
+	}
+	return result, nil
+}

--- a/backend/internal/datasource/client.go
+++ b/backend/internal/datasource/client.go
@@ -126,6 +126,8 @@ func TestConnection(ctx context.Context, ds models.DataSource) error {
 		return runHTTPConnectionCheck(ctx, ds, []string{"/_cluster/health", "/_cat/indices?format=json&h=index&bytes=b", "/"})
 	case models.DataSourceVMAlert:
 		return runHTTPConnectionCheck(ctx, ds, []string{"/health", "/api/v1/alerts", "/"})
+	case models.DataSourceAlertManager:
+		return runHTTPConnectionCheck(ctx, ds, []string{"/api/v2/status", "/api/v2/alerts", "/"})
 	default:
 		return fmt.Errorf("unsupported datasource type: %s", ds.Type)
 	}

--- a/backend/internal/handlers/alertmanager.go
+++ b/backend/internal/handlers/alertmanager.go
@@ -1,0 +1,263 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/janhoon/dash/backend/internal/datasource"
+	"github.com/janhoon/dash/backend/internal/models"
+)
+
+// AlertManagerHandler proxies requests to an AlertManager datasource.
+type AlertManagerHandler struct {
+	pool *pgxpool.Pool
+}
+
+// NewAlertManagerHandler creates a new AlertManagerHandler.
+func NewAlertManagerHandler(pool *pgxpool.Pool) *AlertManagerHandler {
+	return &AlertManagerHandler{pool: pool}
+}
+
+// resolveAlertManagerDatasource loads the datasource, verifies membership and type.
+func (h *AlertManagerHandler) resolveAlertManagerDatasource(w http.ResponseWriter, r *http.Request) (*models.DataSource, bool) {
+	userID, ok := auth.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return nil, false
+	}
+
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, `{"error":"invalid datasource id"}`, http.StatusBadRequest)
+		return nil, false
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	var ds models.DataSource
+	err = h.pool.QueryRow(ctx,
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		 FROM datasources WHERE id = $1`, id,
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	if err != nil {
+		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
+		return nil, false
+	}
+
+	var role string
+	err = h.pool.QueryRow(ctx,
+		`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
+		userID, ds.OrganizationID,
+	).Scan(&role)
+	if err != nil {
+		http.Error(w, `{"error":"not a member of this organization"}`, http.StatusForbidden)
+		return nil, false
+	}
+
+	if ds.Type != models.DataSourceAlertManager {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "datasource is not of type alertmanager"})
+		return nil, false
+	}
+
+	return &ds, true
+}
+
+// ListAlerts proxies GET /api/datasources/{id}/alertmanager/alerts to AlertManager.
+func (h *AlertManagerHandler) ListAlerts(w http.ResponseWriter, r *http.Request) {
+	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	if !ok {
+		return
+	}
+
+	client, err := datasource.NewAlertManagerClient(*ds)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create alertmanager client: " + err.Error()})
+		return
+	}
+
+	active := r.URL.Query().Get("active") != "false"
+	silenced := r.URL.Query().Get("silenced") != "false"
+	inhibited := r.URL.Query().Get("inhibited") != "false"
+
+	result, err := client.GetAlerts(r.Context(), active, silenced, inhibited)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch alerts: " + err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// ListSilences proxies GET /api/datasources/{id}/alertmanager/silences to AlertManager.
+func (h *AlertManagerHandler) ListSilences(w http.ResponseWriter, r *http.Request) {
+	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	if !ok {
+		return
+	}
+
+	client, err := datasource.NewAlertManagerClient(*ds)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create alertmanager client: " + err.Error()})
+		return
+	}
+
+	result, err := client.GetSilences(r.Context())
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch silences: " + err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// CreateSilence proxies POST /api/datasources/{id}/alertmanager/silences to AlertManager.
+func (h *AlertManagerHandler) CreateSilence(w http.ResponseWriter, r *http.Request) {
+	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	if !ok {
+		return
+	}
+
+	client, err := datasource.NewAlertManagerClient(*ds)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create alertmanager client: " + err.Error()})
+		return
+	}
+
+	var silence datasource.AMSilenceCreate
+	if err := json.NewDecoder(r.Body).Decode(&silence); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "invalid request body"})
+		return
+	}
+
+	silenceID, err := client.CreateSilence(r.Context(), silence)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create silence: " + err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct {
+		SilenceID string `json:"silenceID"`
+	}{
+		SilenceID: silenceID,
+	})
+}
+
+// ExpireSilence proxies DELETE /api/datasources/{id}/alertmanager/silences/{silenceId} to AlertManager.
+func (h *AlertManagerHandler) ExpireSilence(w http.ResponseWriter, r *http.Request) {
+	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	if !ok {
+		return
+	}
+
+	silenceID := r.PathValue("silenceId")
+	if silenceID == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "silence id is required"})
+		return
+	}
+
+	client, err := datasource.NewAlertManagerClient(*ds)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create alertmanager client: " + err.Error()})
+		return
+	}
+
+	if err := client.ExpireSilence(r.Context(), silenceID); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to expire silence: " + err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct {
+		Status string `json:"status"`
+	}{
+		Status: "success",
+	})
+}
+
+// ListReceivers proxies GET /api/datasources/{id}/alertmanager/receivers to AlertManager.
+func (h *AlertManagerHandler) ListReceivers(w http.ResponseWriter, r *http.Request) {
+	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	if !ok {
+		return
+	}
+
+	client, err := datasource.NewAlertManagerClient(*ds)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create alertmanager client: " + err.Error()})
+		return
+	}
+
+	result, err := client.GetReceivers(r.Context())
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch receivers: " + err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// Health proxies GET /api/datasources/{id}/alertmanager/health to AlertManager.
+func (h *AlertManagerHandler) Health(w http.ResponseWriter, r *http.Request) {
+	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	if !ok {
+		return
+	}
+
+	client, err := datasource.NewAlertManagerClient(*ds)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create alertmanager client: " + err.Error()})
+		return
+	}
+
+	if _, err := client.GetStatus(r.Context()); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "alertmanager health check failed: " + err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct {
+		Status string `json:"status"`
+	}{
+		Status: "success",
+	})
+}

--- a/backend/internal/handlers/datasource.go
+++ b/backend/internal/handlers/datasource.go
@@ -60,7 +60,7 @@ func (h *DataSourceHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !req.Type.Valid() {
-		http.Error(w, `{"error":"invalid datasource type, must be one of: prometheus, loki, victorialogs, victoriametrics, tempo, victoriatraces, clickhouse, cloudwatch, elasticsearch, vmalert"}`, http.StatusBadRequest)
+		http.Error(w, `{"error":"invalid datasource type, must be one of: prometheus, loki, victorialogs, victoriametrics, tempo, victoriatraces, clickhouse, cloudwatch, elasticsearch, vmalert, alertmanager"}`, http.StatusBadRequest)
 		return
 	}
 	if req.URL == "" {
@@ -579,7 +579,7 @@ func (h *DataSourceHandler) TestConnectionDraft(w http.ResponseWriter, r *http.R
 	}
 
 	if !req.Type.Valid() {
-		http.Error(w, `{"error":"invalid datasource type, must be one of: prometheus, loki, victorialogs, victoriametrics, tempo, victoriatraces, clickhouse, cloudwatch, elasticsearch, vmalert"}`, http.StatusBadRequest)
+		http.Error(w, `{"error":"invalid datasource type, must be one of: prometheus, loki, victorialogs, victoriametrics, tempo, victoriatraces, clickhouse, cloudwatch, elasticsearch, vmalert, alertmanager"}`, http.StatusBadRequest)
 		return
 	}
 

--- a/backend/internal/models/datasource.go
+++ b/backend/internal/models/datasource.go
@@ -20,6 +20,7 @@ const (
 	DataSourceCloudWatch      DataSourceType = "cloudwatch"
 	DataSourceElasticsearch   DataSourceType = "elasticsearch"
 	DataSourceVMAlert         DataSourceType = "vmalert"
+	DataSourceAlertManager    DataSourceType = "alertmanager"
 )
 
 type DataSource struct {
@@ -55,7 +56,7 @@ type UpdateDataSourceRequest struct {
 
 func (t DataSourceType) Valid() bool {
 	switch t {
-	case DataSourcePrometheus, DataSourceLoki, DataSourceVictoriaLogs, DataSourceVictoriaMetrics, DataSourceTempo, DataSourceVictoriaTraces, DataSourceClickHouse, DataSourceCloudWatch, DataSourceElasticsearch, DataSourceVMAlert:
+	case DataSourcePrometheus, DataSourceLoki, DataSourceVictoriaLogs, DataSourceVictoriaMetrics, DataSourceTempo, DataSourceVictoriaTraces, DataSourceClickHouse, DataSourceCloudWatch, DataSourceElasticsearch, DataSourceVMAlert, DataSourceAlertManager:
 		return true
 	}
 	return false

--- a/frontend/src/composables/useAlertManager.ts
+++ b/frontend/src/composables/useAlertManager.ts
@@ -1,0 +1,89 @@
+import type { AMAlert, AMSilence, AMSilenceCreate, AMReceiver } from '../types/datasource'
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
+
+function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token')
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+export async function fetchAlertManagerAlerts(
+  datasourceId: string,
+  filters: { active: boolean; silenced: boolean; inhibited: boolean },
+): Promise<AMAlert[]> {
+  const params = new URLSearchParams({
+    active: String(filters.active),
+    silenced: String(filters.silenced),
+    inhibited: String(filters.inhibited),
+  })
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/alerts?${params}`,
+    { headers: getAuthHeaders() },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch alerts')
+  }
+  return response.json() as Promise<AMAlert[]>
+}
+
+export async function fetchSilences(datasourceId: string): Promise<AMSilence[]> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/silences`,
+    { headers: getAuthHeaders() },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch silences')
+  }
+  return response.json() as Promise<AMSilence[]>
+}
+
+export async function createSilence(
+  datasourceId: string,
+  silence: AMSilenceCreate,
+): Promise<string> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/silences`,
+    {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(silence),
+    },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to create silence')
+  }
+  const result = (await response.json()) as { silenceID: string }
+  return result.silenceID
+}
+
+export async function expireSilence(datasourceId: string, silenceId: string): Promise<void> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/silences/${silenceId}`,
+    {
+      method: 'DELETE',
+      headers: getAuthHeaders(),
+    },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to expire silence')
+  }
+}
+
+export async function fetchReceivers(datasourceId: string): Promise<AMReceiver[]> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/receivers`,
+    { headers: getAuthHeaders() },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch receivers')
+  }
+  return response.json() as Promise<AMReceiver[]>
+}

--- a/frontend/src/composables/useDatasource.ts
+++ b/frontend/src/composables/useDatasource.ts
@@ -93,6 +93,10 @@ export function useDatasource() {
     datasources.value.filter((d) => d.type === 'vmalert'),
   )
 
+  const alertingDatasources = computed(() =>
+    datasources.value.filter((d) => d.type === 'vmalert' || d.type === 'alertmanager'),
+  )
+
   return {
     datasources,
     loading,
@@ -101,6 +105,7 @@ export function useDatasource() {
     logsDatasources,
     tracingDatasources,
     vmalertDatasources,
+    alertingDatasources,
     fetchDatasources,
     addDatasource,
     editDatasource,

--- a/frontend/src/types/datasource.spec.ts
+++ b/frontend/src/types/datasource.spec.ts
@@ -98,6 +98,10 @@ describe('datasource types', () => {
       expect(isAlertingType('vmalert')).toBe(true)
     })
 
+    it('returns true for alertmanager', () => {
+      expect(isAlertingType('alertmanager')).toBe(true)
+    })
+
     it('returns false for prometheus', () => {
       expect(isAlertingType('prometheus')).toBe(false)
     })
@@ -116,6 +120,7 @@ describe('datasource types', () => {
         'cloudwatch',
         'elasticsearch',
         'vmalert',
+        'alertmanager',
       ]
       for (const type_ of types) {
         expect(dataSourceTypeLabels[type_]).toBeDefined()
@@ -161,6 +166,10 @@ describe('datasource types', () => {
 
     it('returns correct label for vmalert', () => {
       expect(dataSourceTypeLabels.vmalert).toBe('VMAlert')
+    })
+
+    it('returns correct label for alertmanager', () => {
+      expect(dataSourceTypeLabels.alertmanager).toBe('AlertManager')
     })
   })
 })

--- a/frontend/src/types/datasource.ts
+++ b/frontend/src/types/datasource.ts
@@ -9,6 +9,7 @@ export type DataSourceType =
   | 'cloudwatch'
   | 'elasticsearch'
   | 'vmalert'
+  | 'alertmanager'
 
 export interface DataSource {
   id: string
@@ -209,7 +210,7 @@ export interface VMAlertGroupsResponse {
 }
 
 export function isAlertingType(type_: DataSourceType): boolean {
-  return type_ === 'vmalert'
+  return type_ === 'vmalert' || type_ === 'alertmanager'
 }
 
 export const dataSourceTypeLabels: Record<DataSourceType, string> = {
@@ -223,4 +224,52 @@ export const dataSourceTypeLabels: Record<DataSourceType, string> = {
   cloudwatch: 'CloudWatch',
   elasticsearch: 'Elasticsearch',
   vmalert: 'VMAlert',
+  alertmanager: 'AlertManager',
+}
+
+export interface AMAlert {
+  labels: Record<string, string>
+  annotations: Record<string, string>
+  startsAt: string
+  endsAt: string
+  generatorURL: string
+  fingerprint: string
+  status: {
+    state: string
+    silencedBy: string[]
+    inhibitedBy: string[]
+  }
+  receivers: { name: string }[]
+}
+
+export interface AMMatcher {
+  name: string
+  value: string
+  isRegex: boolean
+  isEqual: boolean
+}
+
+export interface AMSilence {
+  id: string
+  matchers: AMMatcher[]
+  startsAt: string
+  endsAt: string
+  createdBy: string
+  comment: string
+  status: {
+    state: string
+  }
+  updatedAt: string
+}
+
+export interface AMSilenceCreate {
+  matchers: AMMatcher[]
+  startsAt: string
+  endsAt: string
+  createdBy: string
+  comment: string
+}
+
+export interface AMReceiver {
+  name: string
 }

--- a/frontend/src/views/AlertsView.vue
+++ b/frontend/src/views/AlertsView.vue
@@ -9,25 +9,65 @@ import {
   RefreshCw,
   AlertCircle,
   BellOff,
+  Plus,
+  X,
+  Trash2,
+  Radio,
 } from 'lucide-vue-next'
 import { useOrganization } from '../composables/useOrganization'
+import { useAuth } from '../composables/useAuth'
 import { useDatasource } from '../composables/useDatasource'
 import { fetchAlerts, fetchGroups } from '../composables/useVMAlert'
+import {
+  fetchAlertManagerAlerts,
+  fetchSilences,
+  createSilence,
+  expireSilence,
+  fetchReceivers,
+} from '../composables/useAlertManager'
 import type {
   VMAlertAlert,
   VMAlertRuleGroup,
+  AMAlert,
+  AMSilence,
+  AMMatcher,
+  AMReceiver,
+  DataSource,
 } from '../types/datasource'
 import { dataSourceTypeLabels } from '../types/datasource'
 
 const { currentOrg } = useOrganization()
-const { vmalertDatasources, fetchDatasources } = useDatasource()
+const { user } = useAuth()
+const { alertingDatasources, fetchDatasources } = useDatasource()
 
 const selectedDatasourceId = ref('')
-const activeTab = ref<'alerts' | 'groups'>('alerts')
+const activeTab = ref<'alerts' | 'groups' | 'am-alerts' | 'am-silences' | 'am-receivers'>('alerts')
 
-// Data state
+// VMAlert data state
 const alerts = ref<VMAlertAlert[]>([])
 const groups = ref<VMAlertRuleGroup[]>([])
+
+// AlertManager data state
+const amAlerts = ref<AMAlert[]>([])
+const amSilences = ref<AMSilence[]>([])
+const amReceivers = ref<AMReceiver[]>([])
+
+// AlertManager filter toggles
+const amFilterActive = ref(true)
+const amFilterSilenced = ref(true)
+const amFilterInhibited = ref(true)
+
+// Silence modal state
+const showSilenceModal = ref(false)
+const silenceMatchers = ref<AMMatcher[]>([{ name: '', value: '', isRegex: false, isEqual: true }])
+const silenceStart = ref('')
+const silenceEnd = ref('')
+const silenceCreatedBy = ref('')
+const silenceComment = ref('')
+const silenceSaving = ref(false)
+const silenceError = ref<string | null>(null)
+
+// Shared state
 const loading = ref(false)
 const error = ref<string | null>(null)
 
@@ -39,11 +79,19 @@ let refreshInterval: ReturnType<typeof setInterval> | null = null
 // Accordion state for rule groups
 const expandedGroups = ref<Record<string, boolean>>({})
 
+const selectedDatasource = computed<DataSource | undefined>(() =>
+  alertingDatasources.value.find((d) => d.id === selectedDatasourceId.value),
+)
+
+const isAlertManager = computed(() => selectedDatasource.value?.type === 'alertmanager')
+const isVMAlert = computed(() => selectedDatasource.value?.type === 'vmalert')
+
 const formattedLastRefreshed = computed(() => {
   if (!lastRefreshed.value) return ''
   return lastRefreshed.value.toLocaleTimeString()
 })
 
+// VMAlert computed
 const firingAlerts = computed(() =>
   alerts.value.filter((a) => a.state === 'firing'),
 )
@@ -61,6 +109,20 @@ const sortedAlerts = computed(() => [
   ...pendingAlerts.value,
   ...inactiveAlerts.value,
 ])
+
+// AlertManager computed
+const sortedAMAlerts = computed(() => {
+  const stateOrder: Record<string, number> = { active: 0, suppressed: 1, unprocessed: 2 }
+  return [...amAlerts.value].sort((a, b) => {
+    const aState = a.status?.state ?? 'unprocessed'
+    const bState = b.status?.state ?? 'unprocessed'
+    return (stateOrder[aState] ?? 3) - (stateOrder[bState] ?? 3)
+  })
+})
+
+const activeSilences = computed(() =>
+  amSilences.value.filter((s) => s.status.state === 'active' || s.status.state === 'pending'),
+)
 
 function toggleGroup(groupName: string) {
   expandedGroups.value[groupName] = !expandedGroups.value[groupName]
@@ -92,6 +154,111 @@ function stateClass(state: string): string {
   }
 }
 
+function amStateClass(state: string): string {
+  switch (state) {
+    case 'active':
+      return 'state-am-active'
+    case 'suppressed':
+      return 'state-am-silenced'
+    case 'unprocessed':
+      return 'state-am-inhibited'
+    default:
+      return 'state-inactive'
+  }
+}
+
+function severityClass(severity: string | undefined): string {
+  switch (severity) {
+    case 'critical':
+      return 'severity-critical'
+    case 'warning':
+      return 'severity-warning'
+    case 'info':
+      return 'severity-info'
+    default:
+      return 'severity-none'
+  }
+}
+
+function silenceStatusClass(state: string): string {
+  switch (state) {
+    case 'active':
+      return 'silence-active'
+    case 'pending':
+      return 'silence-pending'
+    case 'expired':
+      return 'silence-expired'
+    default:
+      return 'silence-expired'
+  }
+}
+
+function truncateId(id: string): string {
+  return id.length > 8 ? id.substring(0, 8) + '…' : id
+}
+
+function formatMatchersText(matchers: AMMatcher[]): string {
+  return matchers
+    .map((m) => {
+      const op = m.isEqual ? (m.isRegex ? '=~' : '=') : (m.isRegex ? '!~' : '!=')
+      return `${m.name}${op}"${m.value}"`
+    })
+    .join(', ')
+}
+
+function formatDateShort(dateStr: string): string {
+  if (!dateStr) return '—'
+  const d = new Date(dateStr)
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+async function loadVMAlertData() {
+  const [alertsRes, groupsRes] = await Promise.all([
+    fetchAlerts(selectedDatasourceId.value),
+    fetchGroups(selectedDatasourceId.value),
+  ])
+  alerts.value = alertsRes.data?.alerts ?? []
+  groups.value = groupsRes.data?.groups ?? []
+}
+
+async function loadAlertManagerData() {
+  const [alertsRes, silencesRes, receiversRes] = await Promise.all([
+    fetchAlertManagerAlerts(selectedDatasourceId.value, {
+      active: amFilterActive.value,
+      silenced: amFilterSilenced.value,
+      inhibited: amFilterInhibited.value,
+    }),
+    fetchSilences(selectedDatasourceId.value),
+    fetchReceivers(selectedDatasourceId.value),
+  ])
+  amAlerts.value = alertsRes ?? []
+  amSilences.value = silencesRes ?? []
+  amReceivers.value = receiversRes ?? []
+}
+
+async function loadAlertManagerAlerts() {
+  if (!selectedDatasourceId.value) return
+  loading.value = true
+  error.value = null
+  try {
+    amAlerts.value = await fetchAlertManagerAlerts(selectedDatasourceId.value, {
+      active: amFilterActive.value,
+      silenced: amFilterSilenced.value,
+      inhibited: amFilterInhibited.value,
+    })
+    lastRefreshed.value = new Date()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to fetch alerts'
+  } finally {
+    loading.value = false
+  }
+}
+
 async function loadData() {
   if (!selectedDatasourceId.value) return
 
@@ -99,12 +266,11 @@ async function loadData() {
   error.value = null
 
   try {
-    const [alertsRes, groupsRes] = await Promise.all([
-      fetchAlerts(selectedDatasourceId.value),
-      fetchGroups(selectedDatasourceId.value),
-    ])
-    alerts.value = alertsRes.data?.alerts ?? []
-    groups.value = groupsRes.data?.groups ?? []
+    if (isAlertManager.value) {
+      await loadAlertManagerData()
+    } else {
+      await loadVMAlertData()
+    }
     lastRefreshed.value = new Date()
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to fetch data'
@@ -136,17 +302,121 @@ function stopAutoRefresh() {
   }
 }
 
+function openSilenceModal() {
+  silenceMatchers.value = [{ name: '', value: '', isRegex: false, isEqual: true }]
+  const now = new Date()
+  const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000)
+  silenceStart.value = toLocalDatetimeString(now)
+  silenceEnd.value = toLocalDatetimeString(twoHoursLater)
+  silenceCreatedBy.value = user.value?.email || user.value?.name || ''
+  silenceComment.value = ''
+  silenceError.value = null
+  showSilenceModal.value = true
+}
+
+function closeSilenceModal() {
+  showSilenceModal.value = false
+}
+
+function addMatcher() {
+  silenceMatchers.value.push({ name: '', value: '', isRegex: false, isEqual: true })
+}
+
+function removeMatcher(idx: number) {
+  if (silenceMatchers.value.length > 1) {
+    silenceMatchers.value.splice(idx, 1)
+  }
+}
+
+function toLocalDatetimeString(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+async function handleCreateSilence() {
+  silenceError.value = null
+
+  const validMatchers = silenceMatchers.value.filter((m) => m.name.trim() !== '')
+  if (validMatchers.length === 0) {
+    silenceError.value = 'At least one matcher is required'
+    return
+  }
+
+  if (!silenceComment.value.trim()) {
+    silenceError.value = 'Comment is required'
+    return
+  }
+
+  const startDate = new Date(silenceStart.value)
+  const endDate = new Date(silenceEnd.value)
+  if (endDate <= startDate) {
+    silenceError.value = 'End time must be after start time'
+    return
+  }
+
+  silenceSaving.value = true
+  try {
+    await createSilence(selectedDatasourceId.value, {
+      matchers: validMatchers.map((m) => ({
+        name: m.name.trim(),
+        value: m.value.trim(),
+        isRegex: m.isRegex,
+        isEqual: m.isEqual,
+      })),
+      startsAt: startDate.toISOString(),
+      endsAt: endDate.toISOString(),
+      createdBy: silenceCreatedBy.value.trim() || 'unknown',
+      comment: silenceComment.value.trim(),
+    })
+    closeSilenceModal()
+    // Refresh silences
+    amSilences.value = await fetchSilences(selectedDatasourceId.value)
+  } catch (e) {
+    silenceError.value = e instanceof Error ? e.message : 'Failed to create silence'
+  } finally {
+    silenceSaving.value = false
+  }
+}
+
+async function handleExpireSilence(silenceId: string) {
+  try {
+    await expireSilence(selectedDatasourceId.value, silenceId)
+    amSilences.value = await fetchSilences(selectedDatasourceId.value)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to expire silence'
+  }
+}
+
+// Reset data on datasource change
 watch(selectedDatasourceId, () => {
   alerts.value = []
   groups.value = []
+  amAlerts.value = []
+  amSilences.value = []
+  amReceivers.value = []
   error.value = null
   expandedGroups.value = {}
+
+  // Set the first relevant tab
+  if (selectedDatasource.value?.type === 'alertmanager') {
+    activeTab.value = 'am-alerts'
+  } else {
+    activeTab.value = 'alerts'
+  }
+
   if (selectedDatasourceId.value) {
     loadData()
   }
 })
 
-watch(vmalertDatasources, (ds) => {
+// Re-fetch AM alerts when filter toggles change
+watch([amFilterActive, amFilterSilenced, amFilterInhibited], () => {
+  if (isAlertManager.value && selectedDatasourceId.value) {
+    loadAlertManagerAlerts()
+  }
+})
+
+watch(alertingDatasources, (ds) => {
   if (ds.length > 0 && !selectedDatasourceId.value) {
     selectedDatasourceId.value = ds[0].id
   }
@@ -186,13 +456,13 @@ onUnmounted(() => {
         <select
           v-model="selectedDatasourceId"
           class="ds-picker"
-          :disabled="vmalertDatasources.length === 0"
+          :disabled="alertingDatasources.length === 0"
         >
           <option value="" disabled>
-            {{ vmalertDatasources.length === 0 ? 'No VMAlert datasources' : 'Select datasource' }}
+            {{ alertingDatasources.length === 0 ? 'No alerting datasources' : 'Select datasource' }}
           </option>
           <option
-            v-for="ds in vmalertDatasources"
+            v-for="ds in alertingDatasources"
             :key="ds.id"
             :value="ds.id"
           >
@@ -225,10 +495,10 @@ onUnmounted(() => {
     </header>
 
     <!-- No datasource selected -->
-    <div v-if="!selectedDatasourceId && vmalertDatasources.length === 0" class="empty-state">
+    <div v-if="!selectedDatasourceId && alertingDatasources.length === 0" class="empty-state">
       <BellOff :size="48" class="empty-icon" />
-      <h3>No VMAlert datasources configured</h3>
-      <p>Add a VMAlert datasource in Data Sources settings to view alerts.</p>
+      <h3>No alerting datasources configured</h3>
+      <p>Add a VMAlert or AlertManager datasource in Data Sources settings to view alerts.</p>
     </div>
 
     <!-- Error state -->
@@ -238,7 +508,7 @@ onUnmounted(() => {
     </div>
 
     <!-- Loading skeleton -->
-    <div v-else-if="loading && alerts.length === 0 && groups.length === 0" class="loading-state">
+    <div v-else-if="loading && alerts.length === 0 && groups.length === 0 && amAlerts.length === 0 && amSilences.length === 0" class="loading-state">
       <div class="skeleton-row" v-for="i in 5" :key="i">
         <div class="skeleton-bar skeleton-name"></div>
         <div class="skeleton-bar skeleton-state"></div>
@@ -247,8 +517,8 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <!-- Tabs + content -->
-    <template v-else-if="selectedDatasourceId">
+    <!-- VMAlert Tabs + Content -->
+    <template v-else-if="selectedDatasourceId && isVMAlert">
       <div class="tabs">
         <button
           class="tab"
@@ -381,6 +651,303 @@ onUnmounted(() => {
         </div>
       </div>
     </template>
+
+    <!-- AlertManager Tabs + Content -->
+    <template v-else-if="selectedDatasourceId && isAlertManager">
+      <div class="tabs">
+        <button
+          class="tab"
+          :class="{ active: activeTab === 'am-alerts' }"
+          @click="activeTab = 'am-alerts'"
+        >
+          Active Alerts
+          <span v-if="amAlerts.length > 0" class="tab-badge tab-badge-firing">{{ amAlerts.length }}</span>
+        </button>
+        <button
+          class="tab"
+          :class="{ active: activeTab === 'am-silences' }"
+          @click="activeTab = 'am-silences'"
+        >
+          Silences
+          <span v-if="activeSilences.length > 0" class="tab-badge">{{ activeSilences.length }}</span>
+        </button>
+        <button
+          class="tab"
+          :class="{ active: activeTab === 'am-receivers' }"
+          @click="activeTab = 'am-receivers'"
+        >
+          Receivers
+          <span v-if="amReceivers.length > 0" class="tab-badge">{{ amReceivers.length }}</span>
+        </button>
+      </div>
+
+      <!-- AM Active Alerts tab -->
+      <div v-if="activeTab === 'am-alerts'" class="tab-content">
+        <div class="am-filter-row">
+          <span class="filter-label">Show:</span>
+          <button
+            class="filter-toggle"
+            :class="{ 'filter-active': amFilterActive }"
+            @click="amFilterActive = !amFilterActive"
+          >Active</button>
+          <button
+            class="filter-toggle"
+            :class="{ 'filter-active': amFilterSilenced }"
+            @click="amFilterSilenced = !amFilterSilenced"
+          >Silenced</button>
+          <button
+            class="filter-toggle"
+            :class="{ 'filter-active': amFilterInhibited }"
+            @click="amFilterInhibited = !amFilterInhibited"
+          >Inhibited</button>
+        </div>
+
+        <div v-if="sortedAMAlerts.length === 0" class="empty-state compact">
+          <BellOff :size="36" class="empty-icon" />
+          <h3>No alerts</h3>
+          <p>No alerts matching current filters.</p>
+        </div>
+
+        <table v-else class="alerts-table">
+          <thead>
+            <tr>
+              <th>Alert Name</th>
+              <th>Severity</th>
+              <th>Instance</th>
+              <th>State</th>
+              <th>Active Since</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(alert, idx) in sortedAMAlerts" :key="idx">
+              <td class="alert-name">{{ alert.labels?.alertname || '—' }}</td>
+              <td>
+                <span
+                  class="severity-badge"
+                  :class="severityClass(alert.labels?.severity)"
+                >
+                  {{ alert.labels?.severity || 'none' }}
+                </span>
+              </td>
+              <td class="alert-instance">{{ alert.labels?.instance || '—' }}</td>
+              <td>
+                <span class="state-badge" :class="amStateClass(alert.status?.state)">
+                  {{ alert.status?.state || 'unknown' }}
+                </span>
+              </td>
+              <td class="alert-since">
+                {{ formatDateShort(alert.startsAt) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- AM Silences tab -->
+      <div v-if="activeTab === 'am-silences'" class="tab-content">
+        <div class="silences-header">
+          <h3 class="section-title">Silences</h3>
+          <button class="btn btn-primary btn-sm" @click="openSilenceModal">
+            <Plus :size="14" />
+            New Silence
+          </button>
+        </div>
+
+        <div v-if="amSilences.length === 0" class="empty-state compact">
+          <BellOff :size="36" class="empty-icon" />
+          <h3>No silences</h3>
+          <p>No silence rules configured.</p>
+        </div>
+
+        <table v-else class="alerts-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Matchers</th>
+              <th>Created By</th>
+              <th>Comment</th>
+              <th>Ends At</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="silence in amSilences" :key="silence.id">
+              <td class="silence-id" :title="silence.id">{{ truncateId(silence.id) }}</td>
+              <td class="silence-matchers">
+                <span
+                  v-for="(m, mIdx) in silence.matchers"
+                  :key="mIdx"
+                  class="label-chip"
+                >
+                  {{ m.name }}{{ m.isEqual ? (m.isRegex ? '=~' : '=') : (m.isRegex ? '!~' : '!=') }}"{{ m.value }}"
+                </span>
+              </td>
+              <td>{{ silence.createdBy }}</td>
+              <td class="silence-comment">{{ silence.comment }}</td>
+              <td class="alert-since">{{ formatDateShort(silence.endsAt) }}</td>
+              <td>
+                <span
+                  class="state-badge"
+                  :class="silenceStatusClass(silence.status.state)"
+                >
+                  {{ silence.status.state }}
+                </span>
+              </td>
+              <td>
+                <button
+                  v-if="silence.status.state === 'active' || silence.status.state === 'pending'"
+                  class="btn btn-danger-outline btn-xs"
+                  title="Expire silence"
+                  @click="handleExpireSilence(silence.id)"
+                >
+                  <Trash2 :size="12" />
+                  Expire
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- AM Receivers tab -->
+      <div v-if="activeTab === 'am-receivers'" class="tab-content">
+        <div v-if="amReceivers.length === 0" class="empty-state compact">
+          <Radio :size="36" class="empty-icon" />
+          <h3>No receivers</h3>
+          <p>No receivers configured in AlertManager.</p>
+        </div>
+
+        <div v-else class="receivers-list">
+          <div
+            v-for="receiver in amReceivers"
+            :key="receiver.name"
+            class="receiver-card"
+          >
+            <Radio :size="16" class="receiver-icon" />
+            <span class="receiver-name">{{ receiver.name }}</span>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Create Silence Modal -->
+    <Teleport to="body">
+      <div v-if="showSilenceModal" class="modal-overlay" @click.self="closeSilenceModal">
+        <div class="modal">
+          <div class="modal-header">
+            <h2>Create Silence</h2>
+            <button class="btn-icon" @click="closeSilenceModal">
+              <X :size="18" />
+            </button>
+          </div>
+
+          <div class="modal-body">
+            <div class="form-group">
+              <label>Matchers <span class="required">*</span></label>
+              <div class="matchers-list">
+                <div
+                  v-for="(m, idx) in silenceMatchers"
+                  :key="idx"
+                  class="matcher-row"
+                >
+                  <input
+                    v-model="m.name"
+                    type="text"
+                    placeholder="Label name"
+                    class="matcher-input"
+                  />
+                  <select v-model="m.isEqual" class="matcher-op">
+                    <option :value="true">{{ m.isRegex ? '=~' : '=' }}</option>
+                    <option :value="false">{{ m.isRegex ? '!~' : '!=' }}</option>
+                  </select>
+                  <input
+                    v-model="m.value"
+                    type="text"
+                    placeholder="Value"
+                    class="matcher-input"
+                  />
+                  <label class="matcher-checkbox" title="Regex match">
+                    <input type="checkbox" v-model="m.isRegex" />
+                    Regex
+                  </label>
+                  <button
+                    class="btn-icon btn-icon-sm"
+                    :disabled="silenceMatchers.length <= 1"
+                    @click="removeMatcher(idx)"
+                    title="Remove matcher"
+                  >
+                    <X :size="14" />
+                  </button>
+                </div>
+              </div>
+              <button class="btn btn-secondary btn-xs" @click="addMatcher">
+                <Plus :size="12" />
+                Add Matcher
+              </button>
+            </div>
+
+            <div class="form-grid-2">
+              <div class="form-group">
+                <label for="silence-start">Start</label>
+                <input
+                  id="silence-start"
+                  v-model="silenceStart"
+                  type="datetime-local"
+                  class="form-input"
+                />
+              </div>
+              <div class="form-group">
+                <label for="silence-end">End</label>
+                <input
+                  id="silence-end"
+                  v-model="silenceEnd"
+                  type="datetime-local"
+                  class="form-input"
+                />
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="silence-created-by">Created By</label>
+              <input
+                id="silence-created-by"
+                v-model="silenceCreatedBy"
+                type="text"
+                placeholder="your-name@example.com"
+                class="form-input"
+              />
+            </div>
+
+            <div class="form-group">
+              <label for="silence-comment">Comment <span class="required">*</span></label>
+              <textarea
+                id="silence-comment"
+                v-model="silenceComment"
+                rows="3"
+                placeholder="Reason for silencing..."
+                class="form-input form-textarea"
+              ></textarea>
+            </div>
+
+            <div v-if="silenceError" class="error-banner modal-error">
+              <AlertCircle :size="14" />
+              {{ silenceError }}
+            </div>
+          </div>
+
+          <div class="modal-footer">
+            <button class="btn btn-secondary" @click="closeSilenceModal" :disabled="silenceSaving">
+              Cancel
+            </button>
+            <button class="btn btn-primary" @click="handleCreateSilence" :disabled="silenceSaving">
+              <Loader2 v-if="silenceSaving" :size="14" class="icon-spin" />
+              {{ silenceSaving ? 'Creating...' : 'Create Silence' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -505,6 +1072,41 @@ onUnmounted(() => {
   color: #ef4444;
 }
 
+/* AM Filter row */
+.am-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.filter-label {
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  font-weight: 500;
+}
+
+.filter-toggle {
+  padding: 0.3rem 0.65rem;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.filter-toggle.filter-active {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: var(--accent-primary);
+}
+
+.filter-toggle:hover {
+  background: var(--bg-hover);
+}
+
 /* Alerts table */
 .alerts-table {
   width: 100%;
@@ -536,6 +1138,12 @@ onUnmounted(() => {
 .alert-name {
   font-weight: 600;
   white-space: nowrap;
+}
+
+.alert-instance {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-secondary);
 }
 
 .alert-labels {
@@ -591,6 +1199,143 @@ onUnmounted(() => {
   background: rgba(100, 116, 139, 0.16);
   color: #94a3b8;
   border: 1px solid rgba(100, 116, 139, 0.35);
+}
+
+/* AM state badges */
+.state-am-active {
+  background: rgba(239, 68, 68, 0.16);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.state-am-silenced {
+  background: rgba(245, 158, 11, 0.16);
+  color: #f59e0b;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+.state-am-inhibited {
+  background: rgba(100, 116, 139, 0.16);
+  color: #94a3b8;
+  border: 1px solid rgba(100, 116, 139, 0.35);
+}
+
+/* Severity badges */
+.severity-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.severity-critical {
+  background: rgba(239, 68, 68, 0.16);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.severity-warning {
+  background: rgba(245, 158, 11, 0.16);
+  color: #f59e0b;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+.severity-info {
+  background: rgba(56, 189, 248, 0.16);
+  color: #38bdf8;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+}
+
+.severity-none {
+  background: rgba(100, 116, 139, 0.16);
+  color: #94a3b8;
+  border: 1px solid rgba(100, 116, 139, 0.35);
+}
+
+/* Silence status badges */
+.silence-active {
+  background: rgba(89, 161, 79, 0.16);
+  color: #59a14f;
+  border: 1px solid rgba(89, 161, 79, 0.35);
+}
+
+.silence-pending {
+  background: rgba(245, 158, 11, 0.16);
+  color: #f59e0b;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+.silence-expired {
+  background: rgba(100, 116, 139, 0.16);
+  color: #94a3b8;
+  border: 1px solid rgba(100, 116, 139, 0.35);
+}
+
+/* Silences */
+.silences-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.silence-id {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.silence-matchers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.silence-comment {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+}
+
+/* Receivers */
+.receivers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.receiver-card {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  background: var(--surface-1);
+}
+
+.receiver-icon {
+  color: var(--text-tertiary);
+}
+
+.receiver-name {
+  font-weight: 500;
+  font-size: 0.88rem;
+  color: var(--text-primary);
 }
 
 /* Rule Groups */
@@ -732,6 +1477,165 @@ onUnmounted(() => {
   color: var(--text-primary);
 }
 
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: var(--surface-1);
+  border: 1px solid var(--border-primary);
+  border-radius: 14px;
+  width: 100%;
+  max-width: 560px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.modal-body {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.65rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--border-primary);
+}
+
+.modal-error {
+  margin: 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-group label {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.required {
+  color: var(--accent-danger);
+}
+
+.form-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.8rem;
+}
+
+.form-input {
+  padding: 0.6rem 0.8rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  transition: border-color 0.2s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: var(--focus-ring);
+}
+
+.form-textarea {
+  resize: vertical;
+  font-family: inherit;
+  min-height: 68px;
+}
+
+.matchers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.matcher-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.matcher-input {
+  flex: 1;
+  padding: 0.45rem 0.6rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+}
+
+.matcher-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+.matcher-op {
+  width: 52px;
+  padding: 0.45rem 0.3rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 0.78rem;
+  font-family: var(--font-mono);
+  text-align: center;
+}
+
+.matcher-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.matcher-checkbox input {
+  width: 14px;
+  height: 14px;
+}
+
 /* Shared states */
 .empty-state {
   display: flex;
@@ -832,6 +1736,12 @@ onUnmounted(() => {
   font-size: 0.78rem;
 }
 
+.btn-xs {
+  padding: 0.25rem 0.45rem;
+  font-size: 0.72rem;
+  border-radius: 6px;
+}
+
 .btn-secondary {
   background: var(--bg-tertiary);
   border-color: var(--border-primary);
@@ -842,6 +1752,16 @@ onUnmounted(() => {
   background: var(--bg-hover);
 }
 
+.btn-primary {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--accent-primary-hover);
+}
+
 .btn-active {
   background: rgba(56, 189, 248, 0.16);
   border-color: rgba(56, 189, 248, 0.35);
@@ -850,6 +1770,41 @@ onUnmounted(() => {
 
 .btn-active:hover:not(:disabled) {
   background: rgba(56, 189, 248, 0.22);
+}
+
+.btn-danger-outline {
+  background: transparent;
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #ef4444;
+}
+
+.btn-danger-outline:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.btn-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-icon:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.btn-icon-sm {
+  width: 26px;
+  height: 26px;
 }
 
 .icon-spin {
@@ -881,6 +1836,10 @@ onUnmounted(() => {
   .alerts-table th,
   .alerts-table td {
     padding: 0.5rem 0.5rem;
+  }
+
+  .form-grid-2 {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/frontend/src/views/DataSourceCreateView.vue
+++ b/frontend/src/views/DataSourceCreateView.vue
@@ -566,6 +566,7 @@ watch(
               <option value="cloudwatch">CloudWatch (Metrics + Logs)</option>
               <option value="elasticsearch">Elasticsearch (ELK)</option>
               <option value="vmalert">VMAlert (Alerting)</option>
+              <option value="alertmanager">AlertManager (Alerting)</option>
             </select>
           </div>
         </div>

--- a/frontend/src/views/DataSourceSettings.vue
+++ b/frontend/src/views/DataSourceSettings.vue
@@ -83,6 +83,8 @@ function getTypeColor(type_: DataSourceType): string {
       return '#00bfb3'
     case 'vmalert':
       return '#ef4444'
+    case 'alertmanager':
+      return '#e45858'
   }
 }
 


### PR DESCRIPTION
## Fizzy #408 — AlertManager Datasource Integration

### Backend
- `DataSourceAlertManager = "alertmanager"` type constant
- `datasource/alertmanager.go` — full v2 API client (GetAlerts with filters, GetSilences, CreateSilence, ExpireSilence, GetReceivers, GetStatus)
- `handlers/alertmanager.go` — proxy handler with org-membership auth
- 6 routes under `/api/datasources/{id}/alertmanager/`
- TestConnection wired via `/api/v2/status`

### Frontend
- `alertmanager` added to DataSourceType, label map, `isAlertingType()`
- `useAlertManager.ts` composable
- `AlertsView.vue` extended: AlertManager tabs (Active Alerts + severity badges + filter toggles, Silences + expire action, Receivers list), Create Silence modal with matchers/datetime/validation
- DataSourceCreateView + DataSourceSettings updated

`go build ./...` ✅  `pnpm type-check` ✅