### PR TITLE
fix: use K8s service names instead of localhost in seed datasource URLs

### DIFF
--- a/backend/cmd/seed-admin/main.go
+++ b/backend/cmd/seed-admin/main.go
@@ -146,11 +146,11 @@ func main() {
 		Type string
 		URL  string
 	}{
-		{Name: "Prometheus", Type: "prometheus", URL: "http://localhost:9090"},
-		{Name: "VictoriaMetrics", Type: "victoriametrics", URL: "http://localhost:8428"},
-		{Name: "Loki", Type: "loki", URL: "http://localhost:3100"},
-		{Name: "Victoria Logs", Type: "victorialogs", URL: "http://localhost:9428"},
-		{Name: "Tempo", Type: "tempo", URL: "http://localhost:3200"},
+		{Name: "Prometheus", Type: "prometheus", URL: "http://prometheus:9090"},
+		{Name: "VictoriaMetrics", Type: "victoriametrics", URL: "http://victoria-metrics:8428"},
+		{Name: "Loki", Type: "loki", URL: "http://loki:3100"},
+		{Name: "Victoria Logs", Type: "victorialogs", URL: "http://victoria-logs:9428"},
+		{Name: "Tempo", Type: "tempo", URL: "http://tempo:3200"},
 	}
 
 	for _, connector := range defaultConnectors {

--- a/backend/cmd/seed-datasources/main.go
+++ b/backend/cmd/seed-datasources/main.go
@@ -20,11 +20,11 @@ type connector struct {
 }
 
 var defaultConnectors = []connector{
-	{Name: "Prometheus", Type: "prometheus", URL: "http://localhost:9090"},
-	{Name: "VictoriaMetrics", Type: "victoriametrics", URL: "http://localhost:8428"},
-	{Name: "Loki", Type: "loki", URL: "http://localhost:3100"},
-	{Name: "Victoria Logs", Type: "victorialogs", URL: "http://localhost:9428"},
-	{Name: "Tempo", Type: "tempo", URL: "http://localhost:3200"},
+	{Name: "Prometheus", Type: "prometheus", URL: "http://prometheus:9090"},
+	{Name: "VictoriaMetrics", Type: "victoriametrics", URL: "http://victoria-metrics:8428"},
+	{Name: "Loki", Type: "loki", URL: "http://loki:3100"},
+	{Name: "Victoria Logs", Type: "victorialogs", URL: "http://victoria-logs:9428"},
+	{Name: "Tempo", Type: "tempo", URL: "http://tempo:3200"},
 }
 
 func main() {


### PR DESCRIPTION
## Summary

### Backend
- Updated `seed-admin` and `seed-datasources` commands to use K8s cluster-internal service names instead of hardcoded `localhost` URLs for default datasources
- `localhost:9090` → `prometheus:9090`, `localhost:8428` → `victoria-metrics:8428`, `localhost:3100` → `loki:3100`, `localhost:9428` → `victoria-logs:9428`, `localhost:3200` → `tempo:3200`
- Both seed commands run inside the cluster (via `kubectl exec` into the backend pod), so `localhost` never resolved to the actual services

`go build ./...` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default service connector configuration to use service hostnames instead of localhost for Prometheus, VictoriaMetrics, Loki, Victoria Logs, and Tempo, enabling proper connectivity in containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->