### PR TITLE
feat: #432 log→trace correlation — trace_id_field config, clickable trace IDs, seed data generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: help backend seed frontend backend-test frontend-test test backend-lint frontend-lint lint security-local check tilt-up tilt-down compose-up compose-down compose-reset compose-logs telemetrygen
+.PHONY: help backend seed seed-correlated frontend backend-test frontend-test test backend-lint frontend-lint lint security-local check tilt-up tilt-down compose-up compose-down compose-reset compose-logs telemetrygen
 
 EMAIL ?= admin@admin.com
 PASSWORD ?= Admin1234
 PROFILES ?=
+LOKI_URL ?= http://localhost:3100
+TEMPO_URL ?= http://localhost:3200
+COUNT ?= 20
 COMPOSE_FILE := deploy/docker/docker-compose.yml
 
 comma := ,
@@ -80,6 +83,21 @@ seed:
 		exit 1; \
 	fi; \
 	cd backend && "$$GO_BIN" run ./cmd/seed -email "$(EMAIL)" -password "$(PASSWORD)"
+
+seed-correlated:
+	@set -e; \
+	GO_BIN=""; \
+	if [ -x "$$HOME/.go-sdk/go1.25.7/bin/go" ]; then \
+		GO_BIN="$$HOME/.go-sdk/go1.25.7/bin/go"; \
+	elif command -v go >/dev/null 2>&1; then \
+		GO_BIN="$$(command -v go)"; \
+	fi; \
+	if [ -z "$$GO_BIN" ]; then \
+		printf "Go is not installed.\n"; \
+		printf "Install Go 1.25+ and retry make seed-correlated.\n"; \
+		exit 1; \
+	fi; \
+	cd backend && "$$GO_BIN" run ./cmd/seed-correlated --loki-url $(LOKI_URL) --tempo-url $(TEMPO_URL) --count $(COUNT)
 
 tilt-up:
 	@tilt up

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -188,6 +188,7 @@ func main() {
 	mux.HandleFunc("POST /api/orgs/{orgId}/datasources/test", auth.RequireAuth(jwtManager, dsHandler.TestConnectionDraft))
 	mux.HandleFunc("POST /api/orgs/{orgId}/datasources", auth.RequireAuth(jwtManager, dsHandler.Create))
 	mux.HandleFunc("GET /api/orgs/{orgId}/datasources", auth.RequireAuth(jwtManager, dsHandler.List))
+	mux.HandleFunc("GET /api/orgs/{orgId}/datasources/{dsId}/trace-datasources", auth.RequireAuth(jwtManager, dsHandler.ListTraceDatasources))
 	mux.HandleFunc("GET /api/datasources/{id}", auth.RequireAuth(jwtManager, dsHandler.Get))
 	mux.HandleFunc("PUT /api/datasources/{id}", auth.RequireAuth(jwtManager, dsHandler.Update))
 	mux.HandleFunc("DELETE /api/datasources/{id}", auth.RequireAuth(jwtManager, dsHandler.Delete))

--- a/backend/cmd/seed-correlated/main.go
+++ b/backend/cmd/seed-correlated/main.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	mrand "math/rand"
+	"net/http"
+	"time"
+)
+
+var (
+	lokiURL  = flag.String("loki-url", "http://localhost:3100", "Loki push URL")
+	tempoURL = flag.String("tempo-url", "http://localhost:3200", "Tempo OTLP HTTP URL")
+	count    = flag.Int("count", 20, "Number of correlated trace+log pairs to generate")
+)
+
+var services = []string{"api-gateway", "user-service", "payment-service", "order-service", "notification-service"}
+var endpoints = []string{"/api/users", "/api/orders", "/api/payments", "/api/health", "/api/products"}
+var statusCodes = []int{200, 200, 200, 201, 400, 404, 500, 503}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func generateTraceID() string { return randomHex(16) }
+func generateSpanID() string  { return randomHex(8) }
+
+func pushToTempo(tempoEndpoint, traceID, spanID, serviceName, endpoint string, durationMs int, statusCode int) error {
+	now := time.Now()
+	startNano := now.Add(-time.Duration(durationMs) * time.Millisecond).UnixNano()
+	endNano := now.UnixNano()
+
+	statusCodeVal := 1
+	if statusCode >= 500 {
+		statusCodeVal = 2
+	}
+
+	payload := map[string]interface{}{
+		"resourceSpans": []map[string]interface{}{
+			{
+				"resource": map[string]interface{}{
+					"attributes": []map[string]interface{}{
+						{"key": "service.name", "value": map[string]string{"stringValue": serviceName}},
+					},
+				},
+				"scopeSpans": []map[string]interface{}{
+					{
+						"spans": []map[string]interface{}{
+							{
+								"traceId":              traceID,
+								"spanId":               spanID,
+								"name":                 endpoint,
+								"kind":                 2,
+								"startTimeUnixNano":    fmt.Sprintf("%d", startNano),
+								"endTimeUnixNano":      fmt.Sprintf("%d", endNano),
+								"attributes": []map[string]interface{}{
+									{"key": "http.method", "value": map[string]string{"stringValue": "GET"}},
+									{"key": "http.url", "value": map[string]string{"stringValue": endpoint}},
+									{"key": "http.status_code", "value": map[string]interface{}{"intValue": statusCode}},
+								},
+								"status": map[string]interface{}{
+									"code": statusCodeVal,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(payload)
+	resp, err := http.Post(tempoEndpoint+"/v1/traces", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("tempo returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func pushToLoki(lokiEndpoint, traceID, serviceName, endpoint string, statusCode int, durationMs int, level string) error {
+	now := time.Now()
+
+	logLine := fmt.Sprintf(`{"timestamp":"%s","level":"%s","service":"%s","trace_id":"%s","span_id":"%s","method":"GET","path":"%s","status":%d,"duration_ms":%d,"message":"%s"}`,
+		now.Format(time.RFC3339Nano),
+		level,
+		serviceName,
+		traceID,
+		randomHex(8),
+		endpoint,
+		statusCode,
+		durationMs,
+		logMessage(level, endpoint, statusCode),
+	)
+
+	payload := map[string]interface{}{
+		"streams": []map[string]interface{}{
+			{
+				"stream": map[string]string{
+					"service":  serviceName,
+					"level":    level,
+					"trace_id": traceID,
+				},
+				"values": [][]string{
+					{fmt.Sprintf("%d", now.UnixNano()), logLine},
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(payload)
+	resp, err := http.Post(lokiEndpoint+"/loki/api/v1/push", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("loki returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func logMessage(level, endpoint string, statusCode int) string {
+	switch level {
+	case "error":
+		return fmt.Sprintf("Request to %s failed with status %d", endpoint, statusCode)
+	case "warn":
+		return fmt.Sprintf("Slow request to %s took longer than expected", endpoint)
+	default:
+		return fmt.Sprintf("Handled request to %s with status %d", endpoint, statusCode)
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	log.Printf("Generating %d correlated trace+log pairs...", *count)
+
+	for i := 0; i < *count; i++ {
+		traceID := generateTraceID()
+		spanID := generateSpanID()
+		svc := services[i%len(services)]
+		ep := endpoints[i%len(endpoints)]
+		status := statusCodes[mrand.Intn(len(statusCodes))]
+		duration := 10 + mrand.Intn(990)
+		level := "info"
+		if status >= 500 {
+			level = "error"
+		} else if status >= 400 {
+			level = "warn"
+		}
+
+		if err := pushToTempo(*tempoURL, traceID, spanID, svc, ep, duration, status); err != nil {
+			log.Printf("Warning: failed to push trace %s: %v", traceID[:8], err)
+		}
+
+		if err := pushToLoki(*lokiURL, traceID, svc, ep, status, duration, level); err != nil {
+			log.Printf("Warning: failed to push log for trace %s: %v", traceID[:8], err)
+		}
+
+		log.Printf("[%d/%d] trace_id=%s service=%s status=%d duration=%dms", i+1, *count, traceID[:16], svc, status, duration)
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	log.Printf("Done! Generated %d correlated trace+log pairs.", *count)
+	log.Printf("In Ace: select your Loki datasource with trace_id_field=trace_id, link your Tempo datasource, then explore logs.")
+}

--- a/backend/internal/db/migrations/008_log_trace_correlation.sql
+++ b/backend/internal/db/migrations/008_log_trace_correlation.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+ALTER TABLE datasources
+    ADD COLUMN IF NOT EXISTS trace_id_field VARCHAR(255) DEFAULT 'trace_id',
+    ADD COLUMN IF NOT EXISTS linked_trace_datasource_id UUID REFERENCES datasources(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_datasources_linked_trace ON datasources(linked_trace_datasource_id);
+
+-- +migrate Down
+ALTER TABLE datasources
+    DROP COLUMN IF EXISTS trace_id_field,
+    DROP COLUMN IF EXISTS linked_trace_datasource_id;
+
+DROP INDEX IF EXISTS idx_datasources_linked_trace;

--- a/backend/internal/handlers/datasource.go
+++ b/backend/internal/handlers/datasource.go
@@ -91,13 +91,18 @@ func (h *DataSourceHandler) Create(w http.ResponseWriter, r *http.Request) {
 		isDefault = *req.IsDefault
 	}
 
+	traceIDField := "trace_id"
+	if req.TraceIDField != nil && *req.TraceIDField != "" {
+		traceIDField = *req.TraceIDField
+	}
+
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`INSERT INTO datasources (organization_id, name, type, url, is_default, auth_type, auth_config)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)
-		 RETURNING id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at`,
-		orgID, req.Name, req.Type, req.URL, isDefault, authType, req.AuthConfig,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+		`INSERT INTO datasources (organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 RETURNING id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at`,
+		orgID, req.Name, req.Type, req.URL, isDefault, authType, req.AuthConfig, traceIDField, req.LinkedTraceDatasourceID,
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":"failed to create datasource: %s"}`, err.Error()), http.StatusInternalServerError)
@@ -146,7 +151,7 @@ func (h *DataSourceHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := h.pool.Query(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources
 		 WHERE organization_id = $1
 		 ORDER BY name ASC`, orgID)
@@ -159,7 +164,7 @@ func (h *DataSourceHandler) List(w http.ResponseWriter, r *http.Request) {
 	datasources := []models.DataSource{}
 	for rows.Next() {
 		var ds models.DataSource
-		if err := rows.Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt); err != nil {
+		if err := rows.Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt); err != nil {
 			http.Error(w, `{"error":"failed to scan datasource"}`, http.StatusInternalServerError)
 			return
 		}
@@ -189,9 +194,9 @@ func (h *DataSourceHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -262,11 +267,13 @@ func (h *DataSourceHandler) Update(w http.ResponseWriter, r *http.Request) {
 		     is_default = COALESCE($4, is_default),
 		     auth_type = COALESCE($5, auth_type),
 		     auth_config = COALESCE($6, auth_config),
+		     trace_id_field = COALESCE($7, trace_id_field),
+		     linked_trace_datasource_id = COALESCE($8, linked_trace_datasource_id),
 		     updated_at = NOW()
-		 WHERE id = $7
-		 RETURNING id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at`,
-		req.Name, req.Type, req.URL, req.IsDefault, req.AuthType, req.AuthConfig, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+		 WHERE id = $9
+		 RETURNING id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at`,
+		req.Name, req.Type, req.URL, req.IsDefault, req.AuthType, req.AuthConfig, req.TraceIDField, req.LinkedTraceDatasourceID, id,
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"failed to update datasource"}`, http.StatusInternalServerError)
 		return
@@ -346,6 +353,59 @@ func (h *DataSourceHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// ListTraceDatasources returns tracing datasources in the same org for linking
+func (h *DataSourceHandler) ListTraceDatasources(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	orgID, err := uuid.Parse(r.PathValue("orgId"))
+	if err != nil {
+		http.Error(w, `{"error":"invalid organization id"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	_, err = h.checkOrgMembership(ctx, userID, orgID)
+	if err != nil {
+		http.Error(w, `{"error":"not a member of this organization"}`, http.StatusForbidden)
+		return
+	}
+
+	type traceDatasource struct {
+		ID   uuid.UUID `json:"id"`
+		Name string    `json:"name"`
+		Type string    `json:"type"`
+	}
+
+	rows, err := h.pool.Query(ctx,
+		`SELECT id, name, type FROM datasources
+		 WHERE organization_id = $1 AND type IN ('tempo', 'victoriatraces')
+		 ORDER BY name ASC`, orgID)
+	if err != nil {
+		http.Error(w, `{"error":"failed to fetch trace datasources"}`, http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	results := []traceDatasource{}
+	for rows.Next() {
+		var td traceDatasource
+		if err := rows.Scan(&td.ID, &td.Name, &td.Type); err != nil {
+			http.Error(w, `{"error":"failed to scan trace datasource"}`, http.StatusInternalServerError)
+			return
+		}
+		results = append(results, td)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(results)
+}
+
 // Query executes a query against a datasource
 func (h *DataSourceHandler) Query(w http.ResponseWriter, r *http.Request) {
 	userID, ok := auth.GetUserID(r.Context())
@@ -366,9 +426,9 @@ func (h *DataSourceHandler) Query(w http.ResponseWriter, r *http.Request) {
 	// Fetch datasource
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -673,9 +733,9 @@ func (h *DataSourceHandler) TestConnection(w http.ResponseWriter, r *http.Reques
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -752,9 +812,9 @@ func (h *DataSourceHandler) GetTrace(w http.ResponseWriter, r *http.Request) {
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -824,9 +884,9 @@ func (h *DataSourceHandler) TraceServiceGraph(w http.ResponseWriter, r *http.Req
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -898,9 +958,9 @@ func (h *DataSourceHandler) SearchTraces(w http.ResponseWriter, r *http.Request)
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -964,9 +1024,9 @@ func (h *DataSourceHandler) TraceServices(w http.ResponseWriter, r *http.Request
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -1054,9 +1114,9 @@ func (h *DataSourceHandler) Stream(w http.ResponseWriter, r *http.Request) {
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(dbCtx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -1199,9 +1259,9 @@ func (h *DataSourceHandler) Labels(w http.ResponseWriter, r *http.Request) {
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -1286,9 +1346,9 @@ func (h *DataSourceHandler) LabelValues(w http.ResponseWriter, r *http.Request) 
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, id,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
 		return
@@ -1381,9 +1441,9 @@ func (h *DataSourceHandler) QueryByParams(w http.ResponseWriter, r *http.Request
 
 	var ds models.DataSource
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, created_at, updated_at
+		`SELECT id, organization_id, name, type, url, is_default, auth_type, auth_config, trace_id_field, linked_trace_datasource_id, created_at, updated_at
 		 FROM datasources WHERE id = $1`, dsID,
-	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
+	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.TraceIDField, &ds.LinkedTraceDatasourceID, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "datasource not found"})

--- a/backend/internal/models/datasource.go
+++ b/backend/internal/models/datasource.go
@@ -24,34 +24,40 @@ const (
 )
 
 type DataSource struct {
-	ID             uuid.UUID       `json:"id"`
-	OrganizationID uuid.UUID       `json:"organization_id"`
-	Name           string          `json:"name"`
-	Type           DataSourceType  `json:"type"`
-	URL            string          `json:"url"`
-	IsDefault      bool            `json:"is_default"`
-	AuthType       string          `json:"auth_type"`
-	AuthConfig     json.RawMessage `json:"auth_config,omitempty"`
-	CreatedAt      time.Time       `json:"created_at"`
-	UpdatedAt      time.Time       `json:"updated_at"`
+	ID                        uuid.UUID       `json:"id"`
+	OrganizationID            uuid.UUID       `json:"organization_id"`
+	Name                      string          `json:"name"`
+	Type                      DataSourceType  `json:"type"`
+	URL                       string          `json:"url"`
+	IsDefault                 bool            `json:"is_default"`
+	AuthType                  string          `json:"auth_type"`
+	AuthConfig                json.RawMessage `json:"auth_config,omitempty"`
+	TraceIDField              string          `json:"trace_id_field"`
+	LinkedTraceDatasourceID   *uuid.UUID      `json:"linked_trace_datasource_id,omitempty"`
+	CreatedAt                 time.Time       `json:"created_at"`
+	UpdatedAt                 time.Time       `json:"updated_at"`
 }
 
 type CreateDataSourceRequest struct {
-	Name       string          `json:"name"`
-	Type       DataSourceType  `json:"type"`
-	URL        string          `json:"url"`
-	IsDefault  *bool           `json:"is_default,omitempty"`
-	AuthType   *string         `json:"auth_type,omitempty"`
-	AuthConfig json.RawMessage `json:"auth_config,omitempty"`
+	Name                      string          `json:"name"`
+	Type                      DataSourceType  `json:"type"`
+	URL                       string          `json:"url"`
+	IsDefault                 *bool           `json:"is_default,omitempty"`
+	AuthType                  *string         `json:"auth_type,omitempty"`
+	AuthConfig                json.RawMessage `json:"auth_config,omitempty"`
+	TraceIDField              *string         `json:"trace_id_field,omitempty"`
+	LinkedTraceDatasourceID   *uuid.UUID      `json:"linked_trace_datasource_id,omitempty"`
 }
 
 type UpdateDataSourceRequest struct {
-	Name       *string         `json:"name,omitempty"`
-	Type       *DataSourceType `json:"type,omitempty"`
-	URL        *string         `json:"url,omitempty"`
-	IsDefault  *bool           `json:"is_default,omitempty"`
-	AuthType   *string         `json:"auth_type,omitempty"`
-	AuthConfig json.RawMessage `json:"auth_config,omitempty"`
+	Name                      *string         `json:"name,omitempty"`
+	Type                      *DataSourceType `json:"type,omitempty"`
+	URL                       *string         `json:"url,omitempty"`
+	IsDefault                 *bool           `json:"is_default,omitempty"`
+	AuthType                  *string         `json:"auth_type,omitempty"`
+	AuthConfig                json.RawMessage `json:"auth_config,omitempty"`
+	TraceIDField              *string         `json:"trace_id_field,omitempty"`
+	LinkedTraceDatasourceID   *uuid.UUID      `json:"linked_trace_datasource_id,omitempty"`
 }
 
 func (t DataSourceType) Valid() bool {

--- a/frontend/src/api/datasources.ts
+++ b/frontend/src/api/datasources.ts
@@ -7,6 +7,7 @@ import type {
   DataSourceQueryResult,
   LogEntry,
   Trace,
+  TraceDatasource,
   TraceSearchRequest,
   TraceServiceGraph,
   TraceSummary,
@@ -482,6 +483,21 @@ interface LabelsResponse {
   status: 'success' | 'error'
   data?: string[]
   error?: string
+}
+
+export async function fetchTraceDatasources(orgId: string, datasourceId: string): Promise<TraceDatasource[]> {
+  const response = await fetch(
+    `${API_BASE}/api/orgs/${orgId}/datasources/${datasourceId}/trace-datasources`,
+    {
+      headers: getAuthHeaders(),
+    },
+  )
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch trace datasources')
+  }
+
+  return response.json()
 }
 
 export async function fetchDataSourceLabels(id: string): Promise<string[]> {

--- a/frontend/src/components/LogViewer.vue
+++ b/frontend/src/components/LogViewer.vue
@@ -1,16 +1,52 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import type { LogEntry } from '../types/datasource'
+
+const router = useRouter()
 
 const props = withDefaults(
   defineProps<{
     logs: LogEntry[]
     highlightedLogKeys?: string[]
+    traceIdField?: string
+    linkedTraceDatasourceId?: string | null
   }>(),
   {
     highlightedLogKeys: () => [],
+    traceIdField: 'trace_id',
+    linkedTraceDatasourceId: null,
   },
 )
+
+function extractTraceId(entry: LogEntry): string | null {
+  const field = props.traceIdField || 'trace_id'
+
+  if (entry.labels && entry.labels[field]) {
+    return entry.labels[field]
+  }
+
+  try {
+    const parsed = JSON.parse(entry.line)
+    if (parsed[field]) return String(parsed[field])
+  } catch {}
+
+  const regex = new RegExp(`(?:${field}[=:]["']?)([a-f0-9]{16,64})`, 'i')
+  const match = entry.line.match(regex)
+  if (match) return match[1]
+
+  return null
+}
+
+function navigateToTrace(traceId: string) {
+  router.push({
+    name: 'explore-traces',
+    query: {
+      datasourceId: props.linkedTraceDatasourceId,
+      traceId: traceId,
+    },
+  })
+}
 
 interface DetectedField {
   key: string
@@ -224,6 +260,19 @@ watch(displayLogs, () => {
             >
               {{ log.level }}
             </span>
+          </span>
+
+          <!-- Trace ID badge -->
+          <span class="shrink-0 w-40">
+            <button
+              v-if="linkedTraceDatasourceId && extractTraceId(log)"
+              class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-mono bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/30 transition-colors cursor-pointer border border-emerald-500/30"
+              @click.stop="navigateToTrace(extractTraceId(log)!)"
+              :title="`View trace ${extractTraceId(log)}`"
+            >
+              <svg class="h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+              {{ extractTraceId(log)?.slice(0, 16) }}…
+            </button>
           </span>
 
           <!-- Message -->

--- a/frontend/src/types/datasource.ts
+++ b/frontend/src/types/datasource.ts
@@ -20,6 +20,8 @@ export interface DataSource {
   is_default: boolean
   auth_type: string
   auth_config?: Record<string, unknown>
+  trace_id_field: string
+  linked_trace_datasource_id?: string | null
   created_at: string
   updated_at: string
 }
@@ -31,6 +33,8 @@ export interface CreateDataSourceRequest {
   is_default?: boolean
   auth_type?: string
   auth_config?: Record<string, unknown>
+  trace_id_field?: string
+  linked_trace_datasource_id?: string | null
 }
 
 export interface UpdateDataSourceRequest {
@@ -40,6 +44,14 @@ export interface UpdateDataSourceRequest {
   is_default?: boolean
   auth_type?: string
   auth_config?: Record<string, unknown>
+  trace_id_field?: string
+  linked_trace_datasource_id?: string | null
+}
+
+export interface TraceDatasource {
+  id: string
+  name: string
+  type: string
 }
 
 export interface DataSourceQueryRequest {

--- a/frontend/src/views/DataSourceCreateView.vue
+++ b/frontend/src/views/DataSourceCreateView.vue
@@ -9,11 +9,11 @@ import {
 } from 'lucide-vue-next'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { getDataSource, testDataSourceDraftConnection } from '../api/datasources'
+import { fetchTraceDatasources, getDataSource, testDataSourceDraftConnection } from '../api/datasources'
 import { useDatasource } from '../composables/useDatasource'
 import { useOrganization } from '../composables/useOrganization'
-import type { CreateDataSourceRequest, DataSource, DataSourceType } from '../types/datasource'
-import { dataSourceTypeLabels, isAlertingType, isTracingType } from '../types/datasource'
+import type { CreateDataSourceRequest, DataSource, DataSourceType, TraceDatasource } from '../types/datasource'
+import { dataSourceTypeLabels, isAlertingType, isLogsType, isTracingType } from '../types/datasource'
 
 const route = useRoute()
 const router = useRouter()
@@ -41,6 +41,9 @@ const formElasticsearchIndex = ref('')
 const formElasticsearchTimestampField = ref('')
 const formElasticsearchMessageField = ref('')
 const formElasticsearchLevelField = ref('')
+const formTraceIdField = ref('trace_id')
+const formLinkedTraceDatasourceId = ref<string | null>(null)
+const traceDatasources = ref<TraceDatasource[]>([])
 
 const saveLoading = ref(false)
 const testLoading = ref(false)
@@ -73,6 +76,7 @@ const isClickHouseType = computed(() => formType.value === 'clickhouse')
 const isCloudWatchType = computed(() => formType.value === 'cloudwatch')
 const isElasticsearchType = computed(() => formType.value === 'elasticsearch')
 const isVMAlertType = computed(() => formType.value === 'vmalert')
+const showLogCorrelation = computed(() => isLogsType(formType.value) && !isClickHouseType.value)
 const showAuthSettings = computed(
   () =>
     (isTracingType(formType.value) ||
@@ -130,6 +134,8 @@ function resetAuthForm() {
   formElasticsearchTimestampField.value = ''
   formElasticsearchMessageField.value = ''
   formElasticsearchLevelField.value = ''
+  formTraceIdField.value = 'trace_id'
+  formLinkedTraceDatasourceId.value = null
 }
 
 function resetCreateForm() {
@@ -226,6 +232,8 @@ function hydrateForm(ds: DataSource) {
   formUrl.value = ds.url
   formIsDefault.value = ds.is_default
   hydrateAuthForm(ds)
+  formTraceIdField.value = ds.trace_id_field || 'trace_id'
+  formLinkedTraceDatasourceId.value = ds.linked_trace_datasource_id || null
   loadedDatasourceOrgId.value = ds.organization_id
   formError.value = null
   loadError.value = null
@@ -254,6 +262,20 @@ async function loadDatasourceForEdit() {
     loadError.value = e instanceof Error ? e.message : 'Failed to load datasource'
   } finally {
     pageLoading.value = false
+  }
+}
+
+async function loadTraceDatasources() {
+  const orgId = activeOrgId()
+  if (!orgId || !showLogCorrelation.value) {
+    traceDatasources.value = []
+    return
+  }
+
+  try {
+    traceDatasources.value = await fetchTraceDatasources(orgId, datasourceId.value || 'new')
+  } catch {
+    traceDatasources.value = []
   }
 }
 
@@ -397,7 +419,7 @@ function buildCreatePayload(requireName: boolean): CreateDataSourceRequest {
 
   const finalAuthConfig = Object.keys(authConfig).length > 0 ? authConfig : undefined
 
-  return {
+  const payload: CreateDataSourceRequest = {
     name: trimmedName || `Untitled ${dataSourceTypeLabels[formType.value]}`,
     type: formType.value,
     url: submitURL,
@@ -405,6 +427,13 @@ function buildCreatePayload(requireName: boolean): CreateDataSourceRequest {
     auth_type: authPayload.auth_type,
     auth_config: finalAuthConfig,
   }
+
+  if (showLogCorrelation.value) {
+    payload.trace_id_field = formTraceIdField.value.trim() || 'trace_id'
+    payload.linked_trace_datasource_id = formLinkedTraceDatasourceId.value || null
+  }
+
+  return payload
 }
 
 async function handleTestConnection() {
@@ -511,10 +540,23 @@ watch(formType, () => {
   }
 })
 
+watch(showLogCorrelation, (show) => {
+  if (show) {
+    loadTraceDatasources()
+  } else {
+    traceDatasources.value = []
+    formTraceIdField.value = 'trace_id'
+    formLinkedTraceDatasourceId.value = null
+  }
+})
+
 resetCreateForm()
 
 onMounted(() => {
   loadDatasourceForEdit()
+  if (showLogCorrelation.value) {
+    loadTraceDatasources()
+  }
 })
 
 watch(
@@ -756,6 +798,37 @@ watch(
             autocomplete="off"
             class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition"
           />
+        </div>
+      </section>
+
+      <section v-if="showLogCorrelation" class="rounded-xl border border-slate-200 bg-white p-6">
+        <h2 class="text-sm font-semibold text-slate-900 mb-3 mt-0">Log Correlation</h2>
+        <div class="mb-4">
+          <label for="ds-trace-id-field" class="block text-sm font-medium text-slate-700 mb-1.5">Trace ID Field</label>
+          <input
+            id="ds-trace-id-field"
+            v-model="formTraceIdField"
+            type="text"
+            placeholder="trace_id"
+            :disabled="saveLoading"
+            autocomplete="off"
+            class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition"
+          />
+          <p class="text-xs text-slate-400 mt-1 m-0">The log field name that contains distributed trace IDs. Default: trace_id</p>
+        </div>
+        <div class="mb-0">
+          <label for="ds-linked-trace-ds" class="block text-sm font-medium text-slate-700 mb-1.5">Linked Tracing Datasource (optional)</label>
+          <select
+            id="ds-linked-trace-ds"
+            :value="formLinkedTraceDatasourceId || ''"
+            :disabled="saveLoading"
+            class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-9"
+            @change="formLinkedTraceDatasourceId = ($event.target as HTMLSelectElement).value || null"
+          >
+            <option value="">None — disable trace linking</option>
+            <option v-for="td in traceDatasources" :key="td.id" :value="td.id">{{ td.name }} ({{ td.type }})</option>
+          </select>
+          <p class="text-xs text-slate-400 mt-1 m-0">When a user clicks a trace ID in logs, they'll be taken to this tracing datasource.</p>
         </div>
       </section>
 

--- a/frontend/src/views/ExploreLogs.vue
+++ b/frontend/src/views/ExploreLogs.vue
@@ -1125,7 +1125,12 @@ watch(
             </span>
           </div>
           <div class="flex-1 min-h-0 p-4">
-            <LogViewer :logs="newestFirstLogs" :highlighted-log-keys="highlightedLogKeyList" />
+            <LogViewer
+              :logs="newestFirstLogs"
+              :highlighted-log-keys="highlightedLogKeyList"
+              :trace-id-field="activeDatasource?.trace_id_field || 'trace_id'"
+              :linked-trace-datasource-id="activeDatasource?.linked_trace_datasource_id || null"
+            />
           </div>
         </div>
 

--- a/frontend/src/views/ExploreTraces.vue
+++ b/frontend/src/views/ExploreTraces.vue
@@ -11,7 +11,7 @@ import {
   Waypoints,
 } from 'lucide-vue-next'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import {
   fetchDataSourceTrace,
   fetchDataSourceTraceServiceGraph,
@@ -75,6 +75,7 @@ const TRACE_METRICS_NAVIGATION_CONTEXT_KEY = 'trace_metrics_navigation'
 const TRACE_NAVIGATION_MAX_AGE_MS = 5 * 60 * 1000
 const TRACE_TO_X_PADDING_MS = 5 * 60 * 1000
 
+const route = useRoute()
 const router = useRouter()
 const { timeRange, isCustomRange, onRefresh } = useTimeRange()
 const { currentOrg } = useOrganization()
@@ -744,6 +745,16 @@ async function handleOpenTraceFromList(traceId: string) {
 }
 
 onMounted(() => {
+  const queryTraceId = route.query.traceId
+  const queryDatasourceId = route.query.datasourceId
+  if (queryTraceId && typeof queryTraceId === 'string') {
+    pendingTraceId.value = queryTraceId
+    traceIdInput.value = queryTraceId
+  }
+  if (queryDatasourceId && typeof queryDatasourceId === 'string') {
+    pendingTraceDatasourceId.value = queryDatasourceId
+  }
+
   consumeTraceNavigationContext()
   void tryLoadPendingTrace()
   document.addEventListener('click', handleDocumentClick)


### PR DESCRIPTION
Adds trace_id_field + linked_trace_datasource_id to datasources. Clickable trace ID badges in LogViewer navigate to ExploreTraces. New seed-correlated CLI generates fake correlated log+trace pairs.