### PR TITLE
feat: #433 dark/light mode — CSS token system, useTheme, localStorage + browser preference

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -23,7 +23,7 @@ const showSidebar = computed(() => {
   <div class="relative flex min-h-screen w-full" :class="{ 'block': !showSidebar }">
     <Sidebar v-if="showSidebar" ref="sidebarRef" />
     <main
-      class="min-h-screen flex-1 bg-slate-50 transition-[margin-left] duration-200 ease-out"
+      class="min-h-screen flex-1 bg-surface-base transition-[margin-left] duration-200 ease-out"
       :style="showSidebar ? { marginLeft: sidebarWidth } : {}"
     >
       <RouterView />

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -8,13 +8,17 @@ import {
   Database,
   LayoutDashboard,
   LogOut,
+  Monitor,
+  Moon,
   Settings,
   Shield,
+  Sun,
 } from 'lucide-vue-next'
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '../composables/useAuth'
 import { useOrganization } from '../composables/useOrganization'
+import { useTheme } from '../composables/useTheme'
 import CreateOrganizationModal from './CreateOrganizationModal.vue'
 import OrganizationDropdown from './OrganizationDropdown.vue'
 
@@ -22,6 +26,7 @@ const route = useRoute()
 const router = useRouter()
 const { fetchOrganizations, clearOrganizations, currentOrg } = useOrganization()
 const { logout, user } = useAuth()
+const { mode, cycle } = useTheme()
 
 const isExpanded = ref(typeof window !== 'undefined' ? window.innerWidth > 1100 : true)
 const isHoverExpanded = ref(false)
@@ -145,7 +150,7 @@ defineExpose({ isExpanded })
 <template>
   <aside
     :class="[
-      'fixed inset-y-0 left-0 z-50 flex flex-col border-r border-slate-800 bg-slate-950 transition-[width] duration-200',
+      'fixed inset-y-0 left-0 z-50 flex flex-col border-r border-slate-800 bg-surface-sidebar transition-[width] duration-200',
       isVisuallyExpanded ? 'w-58' : 'w-16'
     ]"
     @mouseenter="handleSidebarMouseEnter"
@@ -267,6 +272,23 @@ defineExpose({ isExpanded })
             v-if="!isVisuallyExpanded"
             class="pointer-events-none invisible absolute left-[calc(100%+12px)] top-1/2 z-[100] -translate-y-1/2 whitespace-nowrap rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-medium text-slate-200 opacity-0 transition group-hover/item:visible group-hover/item:opacity-100"
           >Privacy</span>
+        </button>
+        <button
+          :class="[
+            'group/item relative mx-2 flex h-10 items-center gap-3 rounded-lg border border-transparent px-3 text-sm font-medium text-slate-400 transition hover:bg-slate-800 hover:text-slate-200',
+            !isVisuallyExpanded && 'mx-auto w-11 justify-center px-0'
+          ]"
+          @click="cycle()"
+          :title="`Theme: ${mode} (click to cycle)`"
+        >
+          <Moon v-if="mode === 'dark'" :size="20" />
+          <Sun v-if="mode === 'light'" :size="20" />
+          <Monitor v-if="mode === 'system'" :size="20" />
+          <span v-if="isVisuallyExpanded" class="truncate text-xs capitalize">{{ mode }}</span>
+          <span
+            v-if="!isVisuallyExpanded"
+            class="pointer-events-none invisible absolute left-[calc(100%+12px)] top-1/2 z-[100] -translate-y-1/2 whitespace-nowrap rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-medium text-slate-200 opacity-0 transition group-hover/item:visible group-hover/item:opacity-100"
+          >Theme: {{ mode }}</span>
         </button>
         <div v-if="isVisuallyExpanded && user" class="mx-3 mt-2 truncate rounded-lg bg-slate-900 px-3 py-2 font-mono text-xs text-slate-500">
           {{ user.email }}

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -1,0 +1,52 @@
+import { ref, watchEffect } from 'vue'
+
+export type ThemeMode = 'dark' | 'light' | 'system'
+
+const STORAGE_KEY = 'ace-theme'
+const mode = ref<ThemeMode>((localStorage.getItem(STORAGE_KEY) as ThemeMode) || 'system')
+
+function getEffectiveTheme(m: ThemeMode): 'dark' | 'light' {
+  if (m === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return m
+}
+
+function applyTheme(m: ThemeMode) {
+  const effective = getEffectiveTheme(m)
+  if (effective === 'dark') {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
+}
+
+// Watch system preference changes when in 'system' mode
+const mq = window.matchMedia('(prefers-color-scheme: dark)')
+mq.addEventListener('change', () => {
+  if (mode.value === 'system') applyTheme('system')
+})
+
+// Apply immediately on import (before Vue renders)
+applyTheme(mode.value)
+
+export function useTheme() {
+  function setMode(newMode: ThemeMode) {
+    mode.value = newMode
+    localStorage.setItem(STORAGE_KEY, newMode)
+    applyTheme(newMode)
+  }
+
+  function cycle() {
+    const order: ThemeMode[] = ['dark', 'light', 'system']
+    const next = order[(order.indexOf(mode.value) + 1) % order.length] ?? 'system'
+    setMode(next)
+  }
+
+  const isDark = ref(getEffectiveTheme(mode.value) === 'dark')
+  watchEffect(() => {
+    isDark.value = getEffectiveTheme(mode.value) === 'dark'
+  })
+
+  return { mode, isDark, setMode, cycle }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import './composables/useTheme'  // initialize theme before render
 import './style.css'
 import App from './App.vue'
 import { createPostHogPlugin } from './plugins/posthog'

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2,9 +2,85 @@
 
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@400;500;600;700&display=swap");
 
+@variant dark (&:where(.dark, .dark *));
+
+/* Semantic colour tokens — light (default) */
+:root {
+  /* Surface */
+  --color-surface-base:    #f8fafc;   /* slate-50 — page background */
+  --color-surface-raised:  #ffffff;   /* white — cards, panels */
+  --color-surface-overlay: #f1f5f9;   /* slate-100 — hover, subtle panels */
+  --color-surface-input:   #ffffff;   /* input backgrounds */
+  --color-surface-sidebar: #0f172a;   /* sidebar stays dark in both modes */
+
+  /* Text */
+  --color-text-primary:    #0f172a;   /* slate-950 */
+  --color-text-secondary:  #475569;   /* slate-600 */
+  --color-text-muted:      #94a3b8;   /* slate-400 */
+  --color-text-inverse:    #f8fafc;   /* for use on dark surfaces */
+
+  /* Border */
+  --color-border:          #e2e8f0;   /* slate-200 */
+  --color-border-strong:   #cbd5e1;   /* slate-300 */
+
+  /* Accent (same in both modes) */
+  --color-accent:          #10b981;   /* emerald-500 */
+  --color-accent-muted:    rgba(16,185,129,0.15);
+
+  /* Amber (Ace's primary CTA accent) */
+  --color-amber:           #f59e0b;
+  --color-amber-muted:     rgba(245,158,11,0.15);
+
+  /* Status */
+  --color-danger:          #f43f5e;   /* rose-500 */
+  --color-warning:         #f59e0b;
+  --color-success:         #10b981;
+}
+
+.dark {
+  /* Surface */
+  --color-surface-base:    #0f172a;   /* slate-950 */
+  --color-surface-raised:  #1e293b;   /* slate-800 */
+  --color-surface-overlay: #334155;   /* slate-700 */
+  --color-surface-input:   #1e293b;
+  --color-surface-sidebar: #0f172a;
+
+  /* Text */
+  --color-text-primary:    #f1f5f9;   /* slate-100 */
+  --color-text-secondary:  #94a3b8;   /* slate-400 */
+  --color-text-muted:      #64748b;   /* slate-500 */
+  --color-text-inverse:    #0f172a;
+
+  /* Border */
+  --color-border:          #334155;   /* slate-700 */
+  --color-border-strong:   #475569;   /* slate-600 */
+
+  /* Accents unchanged in dark */
+  --color-accent:          #10b981;
+  --color-accent-muted:    rgba(16,185,129,0.15);
+  --color-amber:           #f59e0b;
+  --color-amber-muted:     rgba(245,158,11,0.15);
+  --color-danger:          #f43f5e;
+  --color-warning:         #f59e0b;
+  --color-success:         #10b981;
+}
+
 @theme {
   --font-sans: "Space Grotesk", "Segoe UI", sans-serif;
   --font-mono: "IBM Plex Mono", "Cascadia Mono", monospace;
+
+  --color-surface-base: var(--color-surface-base);
+  --color-surface-raised: var(--color-surface-raised);
+  --color-surface-overlay: var(--color-surface-overlay);
+  --color-surface-input: var(--color-surface-input);
+  --color-surface-sidebar: var(--color-surface-sidebar);
+  --color-text-primary: var(--color-text-primary);
+  --color-text-secondary: var(--color-text-secondary);
+  --color-text-muted: var(--color-text-muted);
+  --color-text-inverse: var(--color-text-inverse);
+  --color-border: var(--color-border);
+  --color-border-strong: var(--color-border-strong);
+  --color-accent: var(--color-accent);
 }
 
 /* Base styles */
@@ -29,8 +105,9 @@
     font-family: var(--font-sans);
     line-height: 1.5;
     font-weight: 400;
-    color: #475569;
-    background-color: #f8fafc;
+    color: var(--color-text-primary);
+    background-color: var(--color-surface-base);
+    transition: background-color 0.15s ease, color 0.15s ease;
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -49,7 +126,7 @@
   h4,
   h5,
   h6 {
-    color: #0f172a;
+    color: var(--color-text-primary);
     font-weight: 600;
     margin: 0;
     letter-spacing: -0.02em;
@@ -70,7 +147,7 @@
   }
 
   p {
-    color: #475569;
+    color: var(--color-text-secondary);
     margin: 0;
   }
 

--- a/frontend/src/views/DashboardDetailView.vue
+++ b/frontend/src/views/DashboardDetailView.vue
@@ -364,7 +364,7 @@ onUnmounted(() => {
 
 <template>
   <div class="mx-auto max-w-[1600px] px-6 py-5">
-    <header class="relative z-20 mb-4 flex flex-col gap-3 rounded-xl border border-slate-200 bg-white px-6 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+    <header class="relative z-20 mb-4 flex flex-col gap-3 rounded-xl border border-border bg-surface-raised px-6 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between">
       <div class="flex items-center gap-4">
         <button
           class="flex h-[38px] w-[38px] items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-slate-700"
@@ -374,7 +374,7 @@ onUnmounted(() => {
           <ArrowLeft :size="20" />
         </button>
         <div v-if="dashboard">
-          <h1 class="mb-0.5 font-mono text-lg font-semibold uppercase tracking-wide text-slate-900">{{ dashboard.title }}</h1>
+          <h1 class="mb-0.5 font-mono text-lg font-semibold uppercase tracking-wide text-text-primary">{{ dashboard.title }}</h1>
           <p v-if="dashboard.description" class="text-sm text-slate-500">
             {{ dashboard.description }}
           </p>
@@ -404,7 +404,7 @@ onUnmounted(() => {
       </div>
     </header>
 
-    <div v-if="loading" class="flex min-h-[320px] flex-col items-center justify-center rounded-xl border border-slate-200 bg-white py-20 text-center text-slate-500">
+    <div v-if="loading" class="flex min-h-[320px] flex-col items-center justify-center rounded-xl border border-border bg-surface-raised py-20 text-center text-text-muted">
       <div class="mb-4 h-10 w-10 animate-spin rounded-full border-3 border-slate-200 border-t-emerald-600"></div>
       <p>Loading dashboard...</p>
     </div>
@@ -419,11 +419,11 @@ onUnmounted(() => {
     </div>
 
     <template v-else>
-      <div v-if="panels.length === 0" class="flex min-h-[320px] flex-col items-center justify-center rounded-xl border border-slate-200 bg-white px-8 py-16 text-center text-slate-500">
+      <div v-if="panels.length === 0" class="flex min-h-[320px] flex-col items-center justify-center rounded-xl border border-border bg-surface-raised px-8 py-16 text-center text-text-muted">
         <div class="mb-4 flex h-[120px] w-[120px] items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 text-slate-400">
           <LayoutGrid :size="64" />
         </div>
-        <h2 class="mb-2 mt-4 text-slate-900">No panels yet</h2>
+        <h2 class="mb-2 mt-4 text-text-primary">No panels yet</h2>
         <p class="mb-6">Add your first panel to start visualizing data</p>
         <button
           class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-emerald-700"
@@ -486,11 +486,11 @@ onUnmounted(() => {
       class="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/60 backdrop-blur-sm animate-fade-in"
       @click.self="cancelDelete"
     >
-      <div class="w-full max-w-[400px] rounded-xl border border-slate-200 bg-white p-8 text-center shadow-lg animate-slide-up">
+      <div class="w-full max-w-[400px] rounded-xl border border-border bg-surface-raised p-8 text-center shadow-lg animate-slide-up">
         <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-rose-50 text-rose-600">
           <Trash2 :size="24" />
         </div>
-        <h2 class="mb-2 text-slate-900">Delete Panel</h2>
+        <h2 class="mb-2 text-text-primary">Delete Panel</h2>
         <p class="mb-1 text-slate-500">Are you sure you want to delete "{{ deletingPanel?.title }}"?</p>
         <p class="text-sm text-rose-600">This action cannot be undone.</p>
         <div class="mt-6 flex justify-center gap-3">

--- a/frontend/src/views/DataSourceSettings.vue
+++ b/frontend/src/views/DataSourceSettings.vue
@@ -157,8 +157,8 @@ watch(
   <div class="px-8 py-6 max-w-[1120px] mx-auto">
     <header class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-lg font-bold text-slate-900">Data Sources</h1>
-        <p class="text-sm text-slate-500 mt-1">Manage connections to your monitoring systems</p>
+        <h1 class="text-lg font-bold text-text-primary">Data Sources</h1>
+        <p class="text-sm text-text-muted mt-1">Manage connections to your monitoring systems</p>
       </div>
       <div class="flex items-center gap-2.5">
         <button
@@ -190,8 +190,8 @@ watch(
 
     <div v-else-if="datasources.length === 0" class="flex flex-col items-center justify-center py-16 px-8 text-center gap-4">
       <Database :size="48" class="text-slate-300" />
-      <h3 class="text-lg font-semibold text-slate-900 m-0">No data sources configured</h3>
-      <p class="text-sm text-slate-500 m-0">Add a data source to start querying your monitoring systems.</p>
+      <h3 class="text-lg font-semibold text-text-primary m-0">No data sources configured</h3>
+      <p class="text-sm text-text-muted m-0">Add a data source to start querying your monitoring systems.</p>
       <button
         class="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed"
         :disabled="!canCreate"
@@ -206,7 +206,7 @@ watch(
       <div
         v-for="ds in datasources"
         :key="ds.id"
-        class="rounded-xl border border-slate-200 bg-white transition hover:border-emerald-300 hover:shadow-md"
+        class="rounded-xl border border-border bg-surface-raised transition hover:border-emerald-300 hover:shadow-md"
       >
         <div class="flex justify-between items-start p-4 pb-0 gap-3">
           <div class="flex items-start flex-wrap gap-2.5 min-w-0">
@@ -218,7 +218,7 @@ watch(
               <Database v-else :size="26" class="shrink-0 text-slate-400" />
               <div class="flex flex-col gap-px min-w-0">
                 <span class="text-[0.64rem] tracking-[0.05em] uppercase text-slate-400">Source Type</span>
-                <strong class="text-sm font-bold text-slate-900 leading-tight">{{ dataSourceTypeLabels[ds.type] }}</strong>
+                <strong class="text-sm font-bold text-text-primary leading-tight">{{ dataSourceTypeLabels[ds.type] }}</strong>
               </div>
             </div>
             <span v-if="ds.is_default" class="inline-flex items-center gap-1 rounded-full bg-emerald-50 text-emerald-700 px-2 py-0.5 text-xs font-medium">
@@ -237,7 +237,7 @@ watch(
         </div>
         <div class="flex flex-col gap-3 p-4">
           <div class="flex flex-col gap-2">
-            <h3 class="text-sm font-semibold text-slate-900 m-0">{{ ds.name }}</h3>
+            <h3 class="text-sm font-semibold text-text-primary m-0">{{ ds.name }}</h3>
             <div class="flex items-center gap-1.5 text-xs text-slate-400 break-all">
               <ExternalLink :size="14" class="shrink-0" />
               <span class="truncate">{{ ds.url }}</span>

--- a/frontend/src/views/Explore.vue
+++ b/frontend/src/views/Explore.vue
@@ -531,7 +531,7 @@ watch(selectedDatasourceId, () => {
     <div class="flex flex-col flex-1 min-w-0 px-8 py-6">
     <header class="flex items-center justify-between mb-6">
       <div class="flex items-center flex-wrap gap-3">
-        <h1 class="text-2xl font-bold text-slate-900 m-0">Explore</h1>
+        <h1 class="text-2xl font-bold text-text-primary m-0">Explore</h1>
         <span class="rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-emerald-700">Metrics</span>
       </div>
       <button
@@ -546,7 +546,7 @@ watch(selectedDatasourceId, () => {
     </header>
 
     <div class="flex flex-col gap-6 flex-1">
-      <div class="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4">
+      <div class="flex flex-col gap-4 rounded-xl border border-border bg-surface-raised p-4">
         <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4 items-end max-md:grid-cols-1">
           <div class="flex flex-col gap-2.5">
             <label class="text-xs font-semibold uppercase tracking-wide text-slate-500">Data Source</label>
@@ -699,14 +699,14 @@ watch(selectedDatasourceId, () => {
       </div>
 
       <!-- Results section -->
-      <div class="flex flex-1 flex-col rounded-xl border border-slate-200 bg-white overflow-hidden min-h-[400px]">
+      <div class="flex flex-1 flex-col rounded-xl border border-border bg-surface-raised overflow-hidden min-h-[400px]">
         <div v-if="loading" class="flex flex-col items-center justify-center gap-4 py-12 text-slate-500 flex-1">
           <div class="animate-spin h-8 w-8 rounded-full border-[3px] border-slate-200 border-t-emerald-600"></div>
           <span class="text-sm">Executing query...</span>
         </div>
 
         <div v-else-if="hasResults" class="flex flex-col flex-1">
-          <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 bg-slate-50">
+          <div class="flex items-center justify-between px-4 py-3 border-b border-border bg-surface-overlay">
             <span class="text-sm text-slate-500">{{ seriesCount }} {{ seriesCount === 1 ? 'series' : 'series' }}</span>
           </div>
           <div class="flex-1 p-4 min-h-[400px]">

--- a/frontend/src/views/ExploreLogs.vue
+++ b/frontend/src/views/ExploreLogs.vue
@@ -907,7 +907,7 @@ watch(
     <div class="flex flex-col flex-1 min-w-0 px-8 py-6">
     <header class="flex items-center justify-between mb-6">
       <div class="flex items-center flex-wrap gap-3">
-        <h1 class="text-2xl font-bold text-slate-900 m-0">Explore</h1>
+        <h1 class="text-2xl font-bold text-text-primary m-0">Explore</h1>
         <span class="rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-emerald-700">Logs</span>
       </div>
       <button
@@ -922,7 +922,7 @@ watch(
     </header>
 
     <div class="flex flex-col gap-6 flex-1">
-      <div class="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4">
+      <div class="flex flex-col gap-4 rounded-xl border border-border bg-surface-raised p-4">
         <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4 items-end max-md:grid-cols-1">
           <div class="flex flex-col gap-2.5">
             <label class="text-xs font-semibold uppercase tracking-wide text-slate-500">Data Source</label>
@@ -1115,14 +1115,14 @@ watch(
       </div>
 
       <!-- Results section -->
-      <div class="flex flex-1 flex-col rounded-xl border border-slate-200 bg-white overflow-hidden min-h-[400px]">
+      <div class="flex flex-1 flex-col rounded-xl border border-border bg-surface-raised overflow-hidden min-h-[400px]">
         <div v-if="loading" class="flex flex-col items-center justify-center gap-4 py-12 text-slate-500 flex-1">
           <div class="animate-spin h-8 w-8 rounded-full border-[3px] border-slate-200 border-t-emerald-600"></div>
           <span class="text-sm">Executing query...</span>
         </div>
 
         <div v-else-if="hasResults" class="flex flex-col flex-1 min-h-0">
-          <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 bg-slate-50">
+          <div class="flex items-center justify-between px-4 py-3 border-b border-border bg-surface-overlay">
             <span class="text-sm text-slate-500">{{ logs.length }} {{ logs.length === 1 ? 'entry' : 'entries' }}</span>
             <span
               v-if="liveStatusLabel"

--- a/frontend/src/views/ExploreTraces.vue
+++ b/frontend/src/views/ExploreTraces.vue
@@ -794,7 +794,7 @@ onUnmounted(() => {
     <!-- Page header -->
     <header class="flex items-center justify-between mb-6">
       <div class="flex items-center flex-wrap gap-3">
-        <h1 class="text-2xl font-bold text-slate-900 m-0">Explore</h1>
+        <h1 class="text-2xl font-bold text-text-primary m-0">Explore</h1>
         <span class="rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-emerald-700">Tracing</span>
       </div>
       <button
@@ -810,7 +810,7 @@ onUnmounted(() => {
 
     <div class="flex flex-col gap-6 flex-1">
       <!-- Query / filter section -->
-      <div class="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4">
+      <div class="flex flex-col gap-4 rounded-xl border border-border bg-surface-raised p-4">
         <!-- Datasource + time range row -->
         <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4 items-end max-md:grid-cols-1">
           <div class="flex flex-col gap-2.5">
@@ -980,7 +980,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Results section -->
-      <div class="flex flex-1 flex-col rounded-xl border border-slate-200 bg-white overflow-hidden min-h-[440px]">
+      <div class="flex flex-1 flex-col rounded-xl border border-border bg-surface-raised overflow-hidden min-h-[440px]">
         <!-- No datasources -->
         <div v-if="!hasTracingDatasources" class="flex flex-col items-center justify-center py-12 text-center text-sm text-slate-500 flex-1">
           <p class="m-0">No tracing datasource configured.</p>
@@ -1007,8 +1007,8 @@ onUnmounted(() => {
         <!-- Standard trace layout: list + detail -->
         <div v-else class="grid grid-cols-[320px_minmax(0,1fr)] min-h-[460px] flex-1 max-lg:grid-cols-1">
           <!-- Trace results sidebar -->
-          <aside class="flex flex-col border-r border-slate-200 max-lg:border-r-0 max-lg:border-b max-lg:max-h-[320px]">
-            <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 bg-slate-50">
+          <aside class="flex flex-col border-r border-border max-lg:border-r-0 max-lg:border-b max-lg:max-h-[320px]">
+            <div class="flex items-center justify-between px-4 py-3 border-b border-border bg-surface-overlay">
               <h2 class="m-0 text-xs font-semibold uppercase tracking-wide text-slate-700">Matching traces</h2>
               <span class="text-xs text-slate-400">{{ traceSummaries.length }} result{{ traceSummaries.length === 1 ? '' : 's' }}</span>
             </div>
@@ -1046,7 +1046,7 @@ onUnmounted(() => {
 
           <!-- Timeline / detail panel -->
           <section class="flex flex-col">
-            <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 bg-slate-50">
+            <div class="flex items-center justify-between px-4 py-3 border-b border-border bg-surface-overlay">
               <h2 class="m-0 text-xs font-semibold uppercase tracking-wide text-slate-700">Timeline waterfall</h2>
               <span v-if="activeTrace" class="text-xs text-slate-400">{{ activeTrace.spans.length }} spans</span>
             </div>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -39,17 +39,17 @@ function switchMode() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-slate-950 px-4">
-    <div class="w-full max-w-md rounded-xl border border-slate-800 bg-slate-900 p-8">
+  <div class="flex min-h-screen items-center justify-center bg-surface-base px-4">
+    <div class="w-full max-w-md rounded-xl border border-border bg-surface-raised p-8">
       <div class="mb-8 text-center">
         <div class="mb-6 flex flex-col items-center justify-center">
           <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-600 font-mono text-sm font-bold text-white">
             A
           </div>
-          <span class="mt-2 font-mono text-xs uppercase tracking-[0.16em] text-slate-400">Ace</span>
+          <span class="mt-2 font-mono text-xs uppercase tracking-[0.16em] text-text-muted">Ace</span>
         </div>
-        <h1 class="text-2xl font-bold text-slate-100 text-center">{{ mode === 'login' ? 'Welcome back' : 'Create account' }}</h1>
-        <p class="text-sm text-slate-400 text-center mt-2">
+        <h1 class="text-2xl font-bold text-text-primary text-center">{{ mode === 'login' ? 'Welcome back' : 'Create account' }}</h1>
+        <p class="text-sm text-text-muted text-center mt-2">
           {{ mode === 'login' ? 'Sign in to your account to continue' : 'Get started with your new account' }}
         </p>
       </div>
@@ -61,24 +61,24 @@ function switchMode() {
         </div>
 
         <div v-if="mode === 'register'" class="flex flex-col">
-          <label for="name" class="block text-sm font-medium text-slate-300 mb-1.5">Name</label>
+          <label for="name" class="block text-sm font-medium text-text-secondary mb-1.5">Name</label>
           <div class="relative flex items-center">
-            <User :size="18" class="absolute left-3.5 text-slate-500 pointer-events-none" />
+            <User :size="18" class="absolute left-3.5 text-text-muted pointer-events-none" />
             <input
               id="name"
               v-model="name"
               type="text"
               placeholder="Your name (optional)"
               :disabled="loading"
-              class="w-full rounded-lg border border-slate-700 bg-slate-800 pl-11 pr-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
+              class="w-full rounded-lg border border-border bg-surface-input pl-11 pr-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </div>
         </div>
 
         <div class="flex flex-col">
-          <label for="email" class="block text-sm font-medium text-slate-300 mb-1.5">Email</label>
+          <label for="email" class="block text-sm font-medium text-text-secondary mb-1.5">Email</label>
           <div class="relative flex items-center">
-            <Mail :size="18" class="absolute left-3.5 text-slate-500 pointer-events-none" />
+            <Mail :size="18" class="absolute left-3.5 text-text-muted pointer-events-none" />
             <input
               id="email"
               v-model="email"
@@ -86,15 +86,15 @@ function switchMode() {
               placeholder="you@example.com"
               required
               :disabled="loading"
-              class="w-full rounded-lg border border-slate-700 bg-slate-800 pl-11 pr-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
+              class="w-full rounded-lg border border-border bg-surface-input pl-11 pr-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </div>
         </div>
 
         <div class="flex flex-col">
-          <label for="password" class="block text-sm font-medium text-slate-300 mb-1.5">Password</label>
+          <label for="password" class="block text-sm font-medium text-text-secondary mb-1.5">Password</label>
           <div class="relative flex items-center">
-            <Lock :size="18" class="absolute left-3.5 text-slate-500 pointer-events-none" />
+            <Lock :size="18" class="absolute left-3.5 text-text-muted pointer-events-none" />
             <input
               id="password"
               v-model="password"
@@ -102,10 +102,10 @@ function switchMode() {
               placeholder="Enter your password"
               required
               :disabled="loading"
-              class="w-full rounded-lg border border-slate-700 bg-slate-800 pl-11 pr-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
+              class="w-full rounded-lg border border-border bg-surface-input pl-11 pr-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </div>
-          <p v-if="mode === 'register'" class="text-xs text-slate-500 mt-1">
+          <p v-if="mode === 'register'" class="text-xs text-text-muted mt-1">
             Min 8 characters with uppercase, lowercase, and number
           </p>
         </div>
@@ -124,7 +124,7 @@ function switchMode() {
       </form>
 
       <div class="mt-6 text-center">
-        <p class="text-sm text-slate-400">
+        <p class="text-sm text-text-muted">
           {{ mode === 'login' ? "Don't have an account?" : 'Already have an account?' }}
           <button type="button" class="ml-1 text-sm text-emerald-400 hover:text-emerald-300 cursor-pointer bg-transparent border-none p-0 font-medium" @click="switchMode">
             {{ mode === 'login' ? 'Create one' : 'Sign in' }}

--- a/frontend/src/views/OrganizationSettings.vue
+++ b/frontend/src/views/OrganizationSettings.vue
@@ -757,16 +757,16 @@ function goBack() {
 <template>
   <div class="px-8 py-6 max-w-4xl mx-auto">
     <!-- Back link -->
-    <button class="flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700 mb-4 bg-transparent border-none cursor-pointer transition" @click="goBack">
+    <button class="flex items-center gap-1 text-sm text-text-muted hover:text-text-primary mb-4 bg-transparent border-none cursor-pointer transition" @click="goBack">
       <ArrowLeft :size="16" />
       <span>Back</span>
     </button>
 
     <!-- Title -->
-    <h1 class="text-2xl font-bold text-slate-900 m-0">Organization Settings</h1>
-    <p v-if="org" class="text-sm text-slate-500 mt-1 mb-0">{{ org.name }}</p>
+    <h1 class="text-2xl font-bold text-text-primary m-0">Organization Settings</h1>
+    <p v-if="org" class="text-sm text-text-muted mt-1 mb-0">{{ org.name }}</p>
 
-    <div v-if="loading" class="text-center py-8 text-slate-500">Loading...</div>
+    <div v-if="loading" class="text-center py-8 text-text-muted">Loading...</div>
     <div v-else-if="error" class="text-center py-8 text-rose-600">{{ error }}</div>
     <div v-else-if="org">
       <!-- Tab bar -->


### PR DESCRIPTION
CSS custom property semantic tokens, @variant dark class-based toggle, useTheme composable with localStorage + prefers-color-scheme, Moon/Sun/Monitor toggle in sidebar. Structural components updated to use semantic token classes.