### PR TITLE
fix: handle expired token errors on organization settings page

### DIFF
--- a/frontend/src/api/organizations.ts
+++ b/frontend/src/api/organizations.ts
@@ -24,6 +24,9 @@ export async function listOrganizations(): Promise<Organization[]> {
     headers: getAuthHeaders(),
   })
   if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Session expired, please log in again')
+    }
     throw new Error('Failed to fetch organizations')
   }
   return response.json()
@@ -34,10 +37,17 @@ export async function getOrganization(id: string): Promise<Organization> {
     headers: getAuthHeaders(),
   })
   if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Session expired, please log in again')
+    }
     if (response.status === 403) {
       throw new Error('Not a member of this organization')
     }
-    throw new Error('Organization not found')
+    if (response.status === 404) {
+      throw new Error('Organization not found')
+    }
+    const body = await response.json().catch(() => ({}))
+    throw new Error(body.error || 'Failed to load organization')
   }
   return response.json()
 }
@@ -138,6 +148,9 @@ export async function listMembers(orgId: string): Promise<Member[]> {
     headers: getAuthHeaders(),
   })
   if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Session expired, please log in again')
+    }
     if (response.status === 403) {
       throw new Error('Not a member of this organization')
     }


### PR DESCRIPTION
## Summary

The organization settings page showed "Organization not found" when the user's access token expired (after 15 minutes), because `getOrganization()` caught all non-OK responses and threw a generic error — masking 401 Unauthorized as a 404-style message.

This fix adds explicit 401 handling to `getOrganization()`, `listOrganizations()`, and `listMembers()` so expired tokens surface as "Session expired, please log in again" instead of misleading messages. Additionally, `getOrganization()` now correctly distinguishes 404 from other error statuses and attempts to parse the backend's JSON error body for better diagnostics.

### Changes

- `listOrganizations()`: Added 401 check before generic error
- `getOrganization()`: Added 401 check, moved "Organization not found" to 404-only, added fallback JSON error parsing
- `listMembers()`: Added 401 check before generic error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for expired sessions with clearer messaging to help users log in again.
  * Enhanced error messages when organizations cannot be found or users lack access permissions.
  * Better error feedback for API failures with more informative messages from server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->