### PR TITLE
feat: #434 org white-labelling — custom accent color, logo upload, app title per org

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -133,6 +133,7 @@ func main() {
 	mux.HandleFunc("GET /api/orgs/{id}/members", auth.RequireAuth(jwtManager, orgHandler.ListMembers))
 	mux.HandleFunc("PUT /api/orgs/{id}/members/{userId}/role", auth.RequireAuth(jwtManager, orgHandler.UpdateMemberRole))
 	mux.HandleFunc("DELETE /api/orgs/{id}/members/{userId}", auth.RequireAuth(jwtManager, orgHandler.RemoveMember))
+	mux.HandleFunc("PUT /api/orgs/{id}/branding", auth.RequireAuth(jwtManager, orgHandler.UpdateBranding))
 
 	// User group routes
 	groupHandler := handlers.NewGroupHandler(pool)

--- a/backend/internal/db/migrations/007_org_branding.sql
+++ b/backend/internal/db/migrations/007_org_branding.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+ALTER TABLE organizations
+    ADD COLUMN IF NOT EXISTS branding_primary_color VARCHAR(7),
+    ADD COLUMN IF NOT EXISTS branding_logo_data TEXT,
+    ADD COLUMN IF NOT EXISTS branding_logo_mime VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS branding_app_title VARCHAR(100);
+
+-- +migrate Down
+ALTER TABLE organizations
+    DROP COLUMN IF EXISTS branding_primary_color,
+    DROP COLUMN IF EXISTS branding_logo_data,
+    DROP COLUMN IF EXISTS branding_logo_mime,
+    DROP COLUMN IF EXISTS branding_app_title;

--- a/backend/internal/handlers/organization.go
+++ b/backend/internal/handlers/organization.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -61,6 +63,14 @@ type UpdateMemberRoleRequest struct {
 }
 
 var slugRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,98}[a-z0-9]$`)
+var hexColorRegex = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+
+// UpdateBrandingRequest represents branding update request
+type UpdateBrandingRequest struct {
+	PrimaryColor *string `json:"primary_color"`
+	LogoDataURI  *string `json:"logo_data_uri"`
+	AppTitle     *string `json:"app_title"`
+}
 
 // Create creates a new organization
 func (h *OrganizationHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -153,7 +163,8 @@ func (h *OrganizationHandler) List(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	rows, err := h.pool.Query(ctx,
-		`SELECT o.id, o.name, o.slug, o.created_at, o.updated_at, om.role
+		`SELECT o.id, o.name, o.slug, o.created_at, o.updated_at, om.role,
+		        o.branding_primary_color, o.branding_logo_data, o.branding_logo_mime, o.branding_app_title
 		 FROM organizations o
 		 JOIN organization_memberships om ON o.id = om.organization_id
 		 WHERE om.user_id = $1
@@ -174,9 +185,14 @@ func (h *OrganizationHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgs := []OrgWithRole{}
 	for rows.Next() {
 		var org OrgWithRole
-		if err := rows.Scan(&org.ID, &org.Name, &org.Slug, &org.CreatedAt, &org.UpdatedAt, &org.Role); err != nil {
+		var logoData, logoMime *string
+		if err := rows.Scan(&org.ID, &org.Name, &org.Slug, &org.CreatedAt, &org.UpdatedAt, &org.Role,
+			&org.Branding.PrimaryColor, &logoData, &logoMime, &org.Branding.AppTitle); err != nil {
 			http.Error(w, `{"error":"failed to scan organization"}`, http.StatusInternalServerError)
 			return
+		}
+		if logoData != nil {
+			org.Branding.LogoDataURI = logoData
 		}
 		orgs = append(orgs, org)
 	}
@@ -219,10 +235,14 @@ func (h *OrganizationHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	// Get organization
 	var org models.Organization
+	var logoData, logoMime *string
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, name, slug, created_at, updated_at FROM organizations WHERE id = $1`,
+		`SELECT id, name, slug, created_at, updated_at,
+		        branding_primary_color, branding_logo_data, branding_logo_mime, branding_app_title
+		 FROM organizations WHERE id = $1`,
 		orgID,
-	).Scan(&org.ID, &org.Name, &org.Slug, &org.CreatedAt, &org.UpdatedAt)
+	).Scan(&org.ID, &org.Name, &org.Slug, &org.CreatedAt, &org.UpdatedAt,
+		&org.Branding.PrimaryColor, &logoData, &logoMime, &org.Branding.AppTitle)
 	if err == pgx.ErrNoRows {
 		http.Error(w, `{"error":"organization not found"}`, http.StatusNotFound)
 		return
@@ -230,6 +250,9 @@ func (h *OrganizationHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, `{"error":"failed to get organization"}`, http.StatusInternalServerError)
 		return
+	}
+	if logoData != nil {
+		org.Branding.LogoDataURI = logoData
 	}
 
 	type OrgWithRole struct {
@@ -773,6 +796,97 @@ func (h *OrganizationHandler) RemoveMember(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "member removed"})
+}
+
+// UpdateBranding updates organization branding (admin only)
+func (h *OrganizationHandler) UpdateBranding(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	orgID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, `{"error":"invalid organization id"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	if !h.isOrgAdmin(ctx, orgID, userID) {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+
+	var req UpdateBrandingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Validate primary_color
+	if req.PrimaryColor != nil && *req.PrimaryColor != "" && !hexColorRegex.MatchString(*req.PrimaryColor) {
+		http.Error(w, `{"error":"primary_color must be a hex color like #6366f1"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Validate logo_data_uri
+	var logoData, logoMime *string
+	if req.LogoDataURI != nil && *req.LogoDataURI != "" {
+		if !strings.HasPrefix(*req.LogoDataURI, "data:image/") {
+			http.Error(w, `{"error":"logo_data_uri must be a data:image/ URI"}`, http.StatusBadRequest)
+			return
+		}
+		if len(*req.LogoDataURI) > 512000 {
+			http.Error(w, `{"error":"logo_data_uri exceeds 500KB limit"}`, http.StatusBadRequest)
+			return
+		}
+		// Extract MIME type from data URI (e.g. "data:image/png;base64,..." -> "image/png")
+		mime := strings.TrimPrefix(*req.LogoDataURI, "data:")
+		if idx := strings.Index(mime, ";"); idx > 0 {
+			mime = mime[:idx]
+		}
+		logoData = req.LogoDataURI
+		logoMime = &mime
+	}
+
+	// Validate app_title
+	if req.AppTitle != nil && len(*req.AppTitle) > 100 {
+		http.Error(w, `{"error":"app_title must be 100 characters or fewer"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Normalize empty strings to nil for DB storage
+	var primaryColor, appTitle *string
+	if req.PrimaryColor != nil && *req.PrimaryColor != "" {
+		primaryColor = req.PrimaryColor
+	}
+	if req.AppTitle != nil && *req.AppTitle != "" {
+		appTitle = req.AppTitle
+	}
+
+	_, err = h.pool.Exec(ctx,
+		`UPDATE organizations SET branding_primary_color=$1, branding_logo_data=$2,
+		        branding_logo_mime=$3, branding_app_title=$4, updated_at=NOW()
+		 WHERE id=$5`,
+		primaryColor, logoData, logoMime, appTitle, orgID,
+	)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"failed to update branding: %v"}`, err), http.StatusInternalServerError)
+		return
+	}
+
+	// Return updated branding
+	branding := models.OrgBranding{
+		PrimaryColor: primaryColor,
+		LogoDataURI:  logoData,
+		AppTitle:     appTitle,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(branding)
 }
 
 // isOrgAdmin checks if a user is an admin of the organization

--- a/backend/internal/models/organization.go
+++ b/backend/internal/models/organization.go
@@ -6,12 +6,19 @@ import (
 	"github.com/google/uuid"
 )
 
+type OrgBranding struct {
+	PrimaryColor *string `json:"primary_color,omitempty"`
+	LogoDataURI  *string `json:"logo_data_uri,omitempty"`
+	AppTitle     *string `json:"app_title,omitempty"`
+}
+
 type Organization struct {
-	ID        uuid.UUID `json:"id"`
-	Name      string    `json:"name"`
-	Slug      string    `json:"slug"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID        uuid.UUID   `json:"id"`
+	Name      string      `json:"name"`
+	Slug      string      `json:"slug"`
+	CreatedAt time.Time   `json:"created_at"`
+	UpdatedAt time.Time   `json:"updated_at"`
+	Branding  OrgBranding `json:"branding"`
 }
 
 type CreateOrganizationRequest struct {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,9 +4,11 @@ import { useRoute } from 'vue-router'
 import CookieConsentBanner from './components/CookieConsentBanner.vue'
 import Sidebar from './components/Sidebar.vue'
 import { useAuth } from './composables/useAuth'
+import { useOrgBranding } from './composables/useOrgBranding'
 
 const route = useRoute()
 const { isAuthenticated } = useAuth()
+useOrgBranding()
 
 const sidebarRef = ref<InstanceType<typeof Sidebar> | null>(null)
 

--- a/frontend/src/api/organizations.ts
+++ b/frontend/src/api/organizations.ts
@@ -5,6 +5,7 @@ import type {
   Invitation,
   Member,
   Organization,
+  UpdateBrandingRequest,
   UpdateMemberRoleRequest,
   UpdateOrganizationRequest,
 } from '../types/organization'
@@ -204,4 +205,26 @@ export async function removeMember(orgId: string, userId: string): Promise<void>
     org_id: orgId,
     user_id: userId,
   })
+}
+
+export async function updateOrgBranding(
+  orgId: string,
+  data: UpdateBrandingRequest,
+): Promise<Organization> {
+  const response = await fetch(`${API_BASE}/api/orgs/${orgId}/branding`, {
+    method: 'PUT',
+    headers: getAuthHeaders(),
+    body: JSON.stringify(data),
+  })
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error('Admin access required')
+    }
+    const error = await response.json().catch(() => ({}))
+    throw new Error(error.error || 'Failed to update branding')
+  }
+  trackEvent('organization_branding_updated', {
+    org_id: orgId,
+  })
+  return response.json()
 }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -23,6 +23,9 @@ const router = useRouter()
 const { fetchOrganizations, clearOrganizations, currentOrg } = useOrganization()
 const { logout, user } = useAuth()
 
+const logoSrc = computed(() => currentOrg.value?.branding?.logo_data_uri || null)
+const appTitle = computed(() => currentOrg.value?.branding?.app_title || 'Ace')
+
 const isExpanded = ref(typeof window !== 'undefined' ? window.innerWidth > 1100 : true)
 const isHoverExpanded = ref(false)
 const showCreateOrgModal = ref(false)
@@ -161,8 +164,17 @@ defineExpose({ isExpanded })
       ]"
     >
       <div class="flex items-center gap-2.5">
-        <span class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-600 font-mono text-xs font-bold text-white">A</span>
-        <span v-if="isVisuallyExpanded" class="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-200">Ace</span>
+        <img
+          v-if="logoSrc"
+          :src="logoSrc"
+          :alt="appTitle"
+          class="h-8 w-8 shrink-0 rounded-lg object-contain"
+        />
+        <span
+          v-else
+          class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-600 font-mono text-xs font-bold text-white"
+        >A</span>
+        <span v-if="isVisuallyExpanded" class="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-200">{{ appTitle }}</span>
       </div>
       <button
         :class="[

--- a/frontend/src/composables/useOrgBranding.ts
+++ b/frontend/src/composables/useOrgBranding.ts
@@ -1,0 +1,25 @@
+import { watch } from 'vue'
+import { useOrganization } from './useOrganization'
+
+export function useOrgBranding() {
+  const { currentOrg } = useOrganization()
+
+  function applyBranding(org: typeof currentOrg.value) {
+    const root = document.documentElement
+    if (org?.branding?.primary_color) {
+      root.style.setProperty('--color-accent', org.branding.primary_color)
+      const hex = org.branding.primary_color
+      const r = parseInt(hex.slice(1, 3), 16)
+      const g = parseInt(hex.slice(3, 5), 16)
+      const b = parseInt(hex.slice(5, 7), 16)
+      root.style.setProperty('--color-accent-muted', `rgba(${r},${g},${b},0.15)`)
+    } else {
+      root.style.removeProperty('--color-accent')
+      root.style.removeProperty('--color-accent-muted')
+    }
+  }
+
+  watch(currentOrg, (org) => applyBranding(org), { immediate: true })
+
+  return { applyBranding }
+}

--- a/frontend/src/types/organization.ts
+++ b/frontend/src/types/organization.ts
@@ -1,5 +1,11 @@
 export type MembershipRole = 'admin' | 'editor' | 'viewer'
 
+export interface OrgBranding {
+  primary_color?: string | null
+  logo_data_uri?: string | null
+  app_title?: string | null
+}
+
 export interface Organization {
   id: string
   name: string
@@ -7,6 +13,13 @@ export interface Organization {
   created_at: string
   updated_at: string
   role?: MembershipRole
+  branding?: OrgBranding
+}
+
+export interface UpdateBrandingRequest {
+  primary_color?: string | null
+  logo_data_uri?: string | null
+  app_title?: string | null
 }
 
 export interface CreateOrganizationRequest {

--- a/frontend/src/views/OrgBrandingSettings.vue
+++ b/frontend/src/views/OrgBrandingSettings.vue
@@ -1,0 +1,254 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { getOrganization, updateOrgBranding } from '../api/organizations'
+import { useOrganization } from '../composables/useOrganization'
+import type { Organization } from '../types/organization'
+
+const props = defineProps<{ orgId: string }>()
+
+const { fetchOrganizations } = useOrganization()
+
+const org = ref<Organization | null>(null)
+const loading = ref(true)
+const saving = ref(false)
+const error = ref<string | null>(null)
+const success = ref<string | null>(null)
+
+const appTitle = ref('')
+const primaryColor = ref('#10b981')
+const logoDataURI = ref<string | null>(null)
+const logoError = ref<string | null>(null)
+
+const isAdmin = computed(() => org.value?.role === 'admin')
+
+const previewColor = computed(() => primaryColor.value || '#10b981')
+const previewColorMuted = computed(() => {
+  const hex = previewColor.value
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return `rgba(${r},${g},${b},0.15)`
+})
+
+onMounted(async () => {
+  try {
+    org.value = await getOrganization(props.orgId)
+    if (org.value.branding?.primary_color) primaryColor.value = org.value.branding.primary_color
+    if (org.value.branding?.logo_data_uri) logoDataURI.value = org.value.branding.logo_data_uri
+    if (org.value.branding?.app_title) appTitle.value = org.value.branding.app_title
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load organization'
+  } finally {
+    loading.value = false
+  }
+})
+
+watch(() => props.orgId, async (newId) => {
+  loading.value = true
+  error.value = null
+  try {
+    org.value = await getOrganization(newId)
+    if (org.value.branding?.primary_color) primaryColor.value = org.value.branding.primary_color
+    else primaryColor.value = '#10b981'
+    if (org.value.branding?.logo_data_uri) logoDataURI.value = org.value.branding.logo_data_uri
+    else logoDataURI.value = null
+    if (org.value.branding?.app_title) appTitle.value = org.value.branding.app_title
+    else appTitle.value = ''
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load organization'
+  } finally {
+    loading.value = false
+  }
+})
+
+function handleLogoUpload(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  logoError.value = null
+
+  if (file.size > 512000) {
+    logoError.value = 'Logo must be under 500KB'
+    input.value = ''
+    return
+  }
+
+  const validTypes = ['image/png', 'image/jpeg', 'image/svg+xml', 'image/gif', 'image/webp']
+  if (!validTypes.includes(file.type)) {
+    logoError.value = 'Unsupported image type. Use PNG, JPEG, SVG, GIF, or WebP.'
+    input.value = ''
+    return
+  }
+
+  const reader = new FileReader()
+  reader.onload = () => {
+    logoDataURI.value = reader.result as string
+  }
+  reader.readAsDataURL(file)
+}
+
+function removeLogo() {
+  logoDataURI.value = null
+  logoError.value = null
+}
+
+async function handleSave() {
+  saving.value = true
+  error.value = null
+  success.value = null
+  try {
+    await updateOrgBranding(props.orgId, {
+      primary_color: primaryColor.value === '#10b981' ? null : primaryColor.value,
+      logo_data_uri: logoDataURI.value || null,
+      app_title: appTitle.value || null,
+    })
+    await fetchOrganizations()
+    success.value = 'Branding updated successfully'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to save branding'
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div v-if="loading" class="flex items-center justify-center py-12">
+    <div class="h-6 w-6 animate-spin rounded-full border-2 border-slate-300 border-t-emerald-600"></div>
+  </div>
+
+  <div v-else class="flex flex-col gap-6">
+    <!-- App Title -->
+    <section class="rounded-xl border border-slate-200 bg-white p-6">
+      <h2 class="m-0 mb-4 text-base font-semibold text-slate-900">App Title</h2>
+      <p class="m-0 mb-3 text-sm text-slate-500">Custom title replaces "Ace" in the sidebar header.</p>
+      <input
+        v-model="appTitle"
+        type="text"
+        maxlength="100"
+        placeholder="Ace"
+        :disabled="!isAdmin"
+        class="w-full max-w-sm rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+      />
+    </section>
+
+    <!-- Primary Accent Color -->
+    <section class="rounded-xl border border-slate-200 bg-white p-6">
+      <h2 class="m-0 mb-4 text-base font-semibold text-slate-900">Primary Accent Color</h2>
+      <p class="m-0 mb-3 text-sm text-slate-500">Replaces the default emerald accent across the app for your organisation.</p>
+      <div class="flex items-center gap-3">
+        <input
+          v-model="primaryColor"
+          type="color"
+          :disabled="!isAdmin"
+          class="h-10 w-12 cursor-pointer rounded border border-slate-200 bg-white p-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
+        />
+        <input
+          v-model="primaryColor"
+          type="text"
+          maxlength="7"
+          placeholder="#10b981"
+          :disabled="!isAdmin"
+          class="w-32 rounded-lg border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-900 outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+        />
+      </div>
+
+      <!-- Color Preview -->
+      <div class="mt-4 rounded-lg border border-slate-200 p-4">
+        <p class="m-0 mb-3 text-xs text-slate-500">Preview</p>
+        <div class="flex items-center gap-3 flex-wrap">
+          <button
+            class="rounded-md px-3 py-1.5 text-sm font-medium text-white cursor-default"
+            :style="{ backgroundColor: previewColor }"
+          >Primary button</button>
+          <span
+            class="rounded px-2 py-0.5 text-xs font-semibold"
+            :style="{ backgroundColor: previewColorMuted, color: previewColor }"
+          >Badge</span>
+          <div class="flex items-center gap-1.5">
+            <div class="h-3 w-3 rounded-full" :style="{ backgroundColor: previewColor }"></div>
+            <span class="text-sm text-slate-500">Active indicator</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Organisation Logo -->
+    <section class="rounded-xl border border-slate-200 bg-white p-6">
+      <h2 class="m-0 mb-4 text-base font-semibold text-slate-900">Organisation Logo</h2>
+      <p class="m-0 mb-3 text-sm text-slate-500">Upload a logo (PNG, JPEG, SVG, GIF, or WebP, max 500KB). Replaces the default "A" icon in the sidebar.</p>
+
+      <div v-if="logoDataURI" class="mb-4 flex items-center gap-4">
+        <img :src="logoDataURI" alt="Logo preview" class="h-14 w-14 rounded-lg border border-slate-200 object-contain bg-slate-50 p-1" />
+        <button
+          v-if="isAdmin"
+          class="inline-flex items-center gap-1.5 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 transition hover:bg-rose-50 cursor-pointer"
+          @click="removeLogo"
+        >Remove logo</button>
+      </div>
+
+      <input
+        type="file"
+        accept="image/png,image/jpeg,image/svg+xml,image/gif,image/webp"
+        :disabled="!isAdmin"
+        class="block w-full max-w-sm text-sm text-slate-500 file:mr-3 file:rounded-lg file:border-0 file:bg-emerald-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-emerald-700 file:cursor-pointer hover:file:bg-emerald-100 disabled:opacity-50"
+        @change="handleLogoUpload"
+      />
+
+      <div v-if="logoError" class="mt-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-600">{{ logoError }}</div>
+    </section>
+
+    <!-- Live Preview -->
+    <section class="rounded-xl border border-slate-200 bg-white p-6">
+      <h2 class="m-0 mb-4 text-base font-semibold text-slate-900">Sidebar Preview</h2>
+      <div class="w-56 rounded-xl border border-slate-700 bg-slate-950 p-4">
+        <div class="flex items-center gap-2.5">
+          <img
+            v-if="logoDataURI"
+            :src="logoDataURI"
+            :alt="appTitle || 'Ace'"
+            class="h-8 w-8 rounded-lg object-contain"
+          />
+          <span
+            v-else
+            class="inline-flex h-8 w-8 items-center justify-center rounded-lg font-mono text-xs font-bold text-white"
+            :style="{ backgroundColor: previewColor }"
+          >A</span>
+          <span class="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-200">{{ appTitle || 'Ace' }}</span>
+        </div>
+        <div class="mt-3 flex flex-col gap-1">
+          <div class="flex h-8 items-center gap-2 rounded-lg px-2 text-xs text-slate-400">
+            <div class="h-4 w-4 rounded bg-slate-700"></div>
+            <span>Dashboards</span>
+          </div>
+          <div
+            class="flex h-8 items-center gap-2 rounded-lg px-2 text-xs text-slate-100"
+            :style="{ backgroundColor: previewColorMuted, borderLeft: `2px solid ${previewColor}` }"
+          >
+            <div class="h-4 w-4 rounded" :style="{ backgroundColor: previewColor, opacity: 0.6 }"></div>
+            <span>Explore</span>
+          </div>
+          <div class="flex h-8 items-center gap-2 rounded-lg px-2 text-xs text-slate-400">
+            <div class="h-4 w-4 rounded bg-slate-700"></div>
+            <span>Alerts</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Save -->
+    <div class="flex items-center gap-3">
+      <button
+        v-if="isAdmin"
+        class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="saving"
+        @click="handleSave"
+      >{{ saving ? 'Saving...' : 'Save Branding' }}</button>
+      <p v-if="!isAdmin" class="m-0 text-sm text-slate-500">Only admins can change branding settings.</p>
+    </div>
+
+    <div v-if="error" class="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2.5 text-sm text-rose-600">{{ error }}</div>
+    <div v-if="success" class="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-700">{{ success }}</div>
+  </div>
+</template>

--- a/frontend/src/views/OrganizationSettings.vue
+++ b/frontend/src/views/OrganizationSettings.vue
@@ -29,6 +29,7 @@ import {
 import { useOrganization } from '../composables/useOrganization'
 import type { Member, MembershipRole, Organization } from '../types/organization'
 import type { UserGroup, UserGroupMembership } from '../types/rbac'
+import OrgBrandingSettings from './OrgBrandingSettings.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -134,16 +135,17 @@ const activeSsoLabel = computed(() => {
 
 const isAdmin = computed(() => org.value?.role === 'admin')
 
-type SettingsSection = 'general' | 'members' | 'groups'
+type SettingsSection = 'general' | 'members' | 'groups' | 'branding'
 
 const settingsSections: Array<{ key: SettingsSection; label: string }> = [
   { key: 'general', label: 'General' },
   { key: 'members', label: 'Members' },
   { key: 'groups', label: 'Groups' },
+  { key: 'branding', label: 'Branding' },
 ]
 
 function isSettingsSection(value: string | undefined): value is SettingsSection {
-  return value === 'general' || value === 'members' || value === 'groups'
+  return value === 'general' || value === 'members' || value === 'groups' || value === 'branding'
 }
 
 const activeSection = computed<SettingsSection>(() => {
@@ -1105,6 +1107,9 @@ function goBack() {
           </article>
         </div>
       </section>
+
+      <!-- Branding Section -->
+      <OrgBrandingSettings v-if="activeSection === 'branding'" :org-id="orgId" />
 
       <!-- SSO Section -->
       <section v-if="activeSection === 'general'" class="rounded-xl border border-slate-200 bg-white p-6">


### PR DESCRIPTION
Migration adds 4 branding columns to organizations. PUT /api/orgs/{id}/branding endpoint (admin). useOrgBranding composable applies --color-accent CSS var. Sidebar shows custom logo/title. OrgBrandingSettings.vue with color picker, file upload, live preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added organization branding customization—admins can now set a custom logo, primary accent color, and application title.
  * Branding automatically applies across the interface, including the sidebar and theme colors.
  * Live preview of branding changes before saving in the new Branding settings section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->