### PR TITLE
feat: #435 GitHub Copilot per-org OAuth App credentials — replaces global env vars with org-scoped sso_configs

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -226,6 +226,8 @@ func main() {
 	mux.HandleFunc("GET /api/auth/github/connection", auth.RequireAuth(jwtManager, githubCopilotHandler.GetConnection))
 	mux.HandleFunc("DELETE /api/auth/github/connection", auth.RequireAuth(jwtManager, githubCopilotHandler.Disconnect))
 	mux.HandleFunc("POST /api/copilot/chat", auth.RequireAuth(jwtManager, githubCopilotHandler.Chat))
+	mux.HandleFunc("POST /api/orgs/{id}/github-app", auth.RequireAuth(jwtManager, githubCopilotHandler.ConfigureGitHubApp))
+	mux.HandleFunc("GET /api/orgs/{id}/github-app", auth.RequireAuth(jwtManager, githubCopilotHandler.GetGitHubApp))
 
 	// Grafana conversion route
 	grafanaConverterHandler := handlers.NewGrafanaConverterHandler()

--- a/backend/internal/db/migrations/009_github_copilot_per_org.sql
+++ b/backend/internal/db/migrations/009_github_copilot_per_org.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+-- Widen the provider CHECK constraint to include github_copilot
+-- PostgreSQL: drop old constraint, add new one
+ALTER TABLE sso_configs DROP CONSTRAINT IF EXISTS sso_configs_provider_check;
+ALTER TABLE sso_configs ADD CONSTRAINT sso_configs_provider_check
+    CHECK (provider IN ('google', 'microsoft', 'github_copilot'));
+
+-- +migrate Down
+ALTER TABLE sso_configs DROP CONSTRAINT IF EXISTS sso_configs_provider_check;
+ALTER TABLE sso_configs ADD CONSTRAINT sso_configs_provider_check
+    CHECK (provider IN ('google', 'microsoft'));

--- a/backend/internal/handlers/github_copilot.go
+++ b/backend/internal/handlers/github_copilot.go
@@ -11,21 +11,21 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/janhoon/dash/backend/internal/auth"
 )
 
 type GitHubCopilotHandler struct {
-	pool         *pgxpool.Pool
-	jwtManager   *auth.JWTManager
-	baseURL      string
-	clientID     string
-	clientSecret string
+	pool       *pgxpool.Pool
+	jwtManager *auth.JWTManager
+	baseURL    string
 }
 
 func NewGitHubCopilotHandler(pool *pgxpool.Pool, jwtManager *auth.JWTManager) *GitHubCopilotHandler {
@@ -34,12 +34,45 @@ func NewGitHubCopilotHandler(pool *pgxpool.Pool, jwtManager *auth.JWTManager) *G
 		baseURL = "http://localhost:8080"
 	}
 	return &GitHubCopilotHandler{
-		pool:         pool,
-		jwtManager:   jwtManager,
-		baseURL:      baseURL,
-		clientID:     os.Getenv("GITHUB_CLIENT_ID"),
-		clientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
+		pool:       pool,
+		jwtManager: jwtManager,
+		baseURL:    baseURL,
 	}
+}
+
+// GitHubAppConfigRequest represents the request body for configuring a GitHub OAuth App per org.
+type GitHubAppConfigRequest struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Enabled      *bool  `json:"enabled,omitempty"`
+}
+
+// GitHubAppConfigResponse represents the response for GitHub App config.
+type GitHubAppConfigResponse struct {
+	ClientID  string    `json:"client_id"`
+	Enabled   bool      `json:"enabled"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// getOAuthConfig looks up org-specific GitHub OAuth credentials from the sso_configs table.
+func (h *GitHubCopilotHandler) getOAuthConfig(ctx context.Context, orgID uuid.UUID) (clientID string, clientSecret string, err error) {
+	var enabled bool
+	err = h.pool.QueryRow(ctx,
+		`SELECT client_id, client_secret, enabled FROM sso_configs
+		 WHERE organization_id = $1 AND provider = 'github_copilot'`,
+		orgID,
+	).Scan(&clientID, &clientSecret, &enabled)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return "", "", fmt.Errorf("github copilot not configured for this organization")
+		}
+		return "", "", err
+	}
+	if !enabled {
+		return "", "", fmt.Errorf("github copilot is not enabled for this organization")
+	}
+	return clientID, clientSecret, nil
 }
 
 type gitHubUser struct {
@@ -213,13 +246,24 @@ func decryptToken(encoded string) (string, error) {
 
 // Login initiates the GitHub OAuth flow for connecting Copilot.
 func (h *GitHubCopilotHandler) Login(w http.ResponseWriter, r *http.Request) {
-	if h.clientID == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotImplemented)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error":          "GitHub OAuth not configured",
-			"setup_required": true,
-		})
+	orgIDStr := r.URL.Query().Get("org")
+	if orgIDStr == "" {
+		http.Error(w, `{"error":"org parameter is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	orgID, err := uuid.Parse(orgIDStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid org parameter"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	clientID, _, err := h.getOAuthConfig(ctx, orgID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
 		return
 	}
 
@@ -229,9 +273,11 @@ func (h *GitHubCopilotHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Encode state + orgID into cookie
+	stateData := fmt.Sprintf("%s:%s", state, orgID.String())
 	http.SetCookie(w, &http.Cookie{
 		Name:     "github_oauth_state",
-		Value:    state,
+		Value:    base64.URLEncoding.EncodeToString([]byte(stateData)),
 		Path:     "/",
 		MaxAge:   600, // 10 minutes
 		HttpOnly: true,
@@ -239,16 +285,13 @@ func (h *GitHubCopilotHandler) Login(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	redirectURI := h.baseURL + "/api/auth/github/callback"
-	url := fmt.Sprintf(
-		"https://github.com/login/oauth/authorize?client_id=%s&scope=%s&state=%s&redirect_uri=%s",
-		h.clientID,
-		"read:user+copilot",
-		state,
-		redirectURI,
+	redirectURL := fmt.Sprintf(
+		"https://github.com/login/oauth/authorize?client_id=%s&scope=read:user+copilot&state=%s&redirect_uri=%s",
+		clientID, state,
+		url.QueryEscape(h.baseURL+"/api/auth/github/callback"),
 	)
 
-	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
 // Callback handles the GitHub OAuth callback.
@@ -258,16 +301,40 @@ func (h *GitHubCopilotHandler) Callback(w http.ResponseWriter, r *http.Request) 
 		frontendURL = "http://localhost:5173"
 	}
 
-	// Verify state
+	// Verify state cookie
 	stateCookie, err := r.Cookie("github_oauth_state")
 	if err != nil {
 		http.Error(w, `{"error":"missing state cookie"}`, http.StatusBadRequest)
 		return
 	}
 
+	// Decode state data: <randomState>:<orgID>
+	stateDataBytes, err := base64.URLEncoding.DecodeString(stateCookie.Value)
+	if err != nil {
+		http.Error(w, `{"error":"invalid state cookie"}`, http.StatusBadRequest)
+		return
+	}
+
+	stateData := string(stateDataBytes)
+	var expectedState, orgIDStr string
+	if idx := strings.Index(stateData, ":"); idx > 0 && idx < len(stateData)-1 {
+		expectedState = stateData[:idx]
+		orgIDStr = stateData[idx+1:]
+	}
+	if expectedState == "" || orgIDStr == "" {
+		http.Error(w, `{"error":"invalid state format"}`, http.StatusBadRequest)
+		return
+	}
+
 	state := r.URL.Query().Get("state")
-	if state != stateCookie.Value {
+	if state != expectedState {
 		http.Error(w, `{"error":"state mismatch"}`, http.StatusBadRequest)
+		return
+	}
+
+	orgID, err := uuid.Parse(orgIDStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid org in state"}`, http.StatusBadRequest)
 		return
 	}
 
@@ -338,8 +405,15 @@ func (h *GitHubCopilotHandler) Callback(w http.ResponseWriter, r *http.Request) 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
+	// Look up org-specific credentials
+	clientID, clientSecret, err := h.getOAuthConfig(ctx, orgID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+
 	// Exchange code for access token
-	ghToken, scopes, err := h.exchangeCode(ctx, code)
+	ghToken, scopes, err := h.exchangeCode(ctx, code, clientID, clientSecret)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":"failed to exchange code: %s"}`, err.Error()), http.StatusInternalServerError)
 		return
@@ -567,8 +641,8 @@ func (h *GitHubCopilotHandler) Chat(w http.ResponseWriter, r *http.Request) {
 }
 
 // exchangeCode exchanges an authorization code for a GitHub access token.
-func (h *GitHubCopilotHandler) exchangeCode(ctx context.Context, code string) (string, string, error) {
-	body := fmt.Sprintf("client_id=%s&client_secret=%s&code=%s", h.clientID, h.clientSecret, code)
+func (h *GitHubCopilotHandler) exchangeCode(ctx context.Context, code, clientID, clientSecret string) (string, string, error) {
+	body := fmt.Sprintf("client_id=%s&client_secret=%s&code=%s", clientID, clientSecret, code)
 	req, err := http.NewRequestWithContext(ctx, "POST", "https://github.com/login/oauth/access_token", strings.NewReader(body))
 	if err != nil {
 		return "", "", err
@@ -593,6 +667,131 @@ func (h *GitHubCopilotHandler) exchangeCode(ctx context.Context, code string) (s
 	}
 
 	return tokenResp.AccessToken, tokenResp.Scope, nil
+}
+
+// ConfigureGitHubApp creates or updates GitHub OAuth App configuration for an organization.
+func (h *GitHubCopilotHandler) ConfigureGitHubApp(w http.ResponseWriter, r *http.Request) {
+	orgID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, `{"error":"invalid organization id"}`, http.StatusBadRequest)
+		return
+	}
+
+	userID, ok := auth.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	// Check if user is admin of org
+	var role string
+	err = h.pool.QueryRow(ctx,
+		`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
+		userID, orgID,
+	).Scan(&role)
+	if err == pgx.ErrNoRows {
+		http.Error(w, `{"error":"not a member of this organization"}`, http.StatusForbidden)
+		return
+	}
+	if err != nil {
+		http.Error(w, `{"error":"failed to check membership"}`, http.StatusInternalServerError)
+		return
+	}
+	if role != "admin" {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+
+	var req GitHubAppConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.ClientID == "" || req.ClientSecret == "" {
+		http.Error(w, `{"error":"client_id and client_secret are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	var config GitHubAppConfigResponse
+	err = h.pool.QueryRow(ctx,
+		`INSERT INTO sso_configs (organization_id, provider, client_id, client_secret, enabled)
+		 VALUES ($1, 'github_copilot', $2, $3, $4)
+		 ON CONFLICT (organization_id, provider) DO UPDATE
+		 SET client_id = $2, client_secret = $3, enabled = $4, updated_at = NOW()
+		 RETURNING client_id, enabled, created_at, updated_at`,
+		orgID, req.ClientID, req.ClientSecret, enabled,
+	).Scan(&config.ClientID, &config.Enabled, &config.CreatedAt, &config.UpdatedAt)
+	if err != nil {
+		http.Error(w, `{"error":"failed to save GitHub App config"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(config)
+}
+
+// GetGitHubApp returns the GitHub OAuth App configuration for an organization.
+func (h *GitHubCopilotHandler) GetGitHubApp(w http.ResponseWriter, r *http.Request) {
+	orgID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, `{"error":"invalid organization id"}`, http.StatusBadRequest)
+		return
+	}
+
+	userID, ok := auth.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	// Check if user is admin of org
+	var role string
+	err = h.pool.QueryRow(ctx,
+		`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
+		userID, orgID,
+	).Scan(&role)
+	if err == pgx.ErrNoRows {
+		http.Error(w, `{"error":"not a member of this organization"}`, http.StatusForbidden)
+		return
+	}
+	if err != nil {
+		http.Error(w, `{"error":"failed to check membership"}`, http.StatusInternalServerError)
+		return
+	}
+	if role != "admin" {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+
+	var config GitHubAppConfigResponse
+	err = h.pool.QueryRow(ctx,
+		`SELECT client_id, enabled, created_at, updated_at FROM sso_configs
+		 WHERE organization_id = $1 AND provider = 'github_copilot'`,
+		orgID,
+	).Scan(&config.ClientID, &config.Enabled, &config.CreatedAt, &config.UpdatedAt)
+	if err == pgx.ErrNoRows {
+		http.Error(w, `{"error":"github copilot not configured"}`, http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(w, `{"error":"failed to get GitHub App config"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(config)
 }
 
 // fetchGitHubUser fetches the authenticated GitHub user.

--- a/frontend/src/api/sso.ts
+++ b/frontend/src/api/sso.ts
@@ -1,5 +1,7 @@
 import { trackEvent } from '../analytics'
 import type {
+  ConfigureGitHubAppRequest,
+  GitHubAppConfig,
   GoogleSSOConfig,
   MicrosoftSSOConfig,
   UpdateGoogleSSOConfigRequest,
@@ -109,6 +111,53 @@ export async function updateMicrosoftSSOConfig(
 
   const config = await response.json()
   trackEvent('settings_sso_microsoft_updated', {
+    org_id: orgId,
+    enabled: config.enabled,
+  })
+  return config
+}
+
+export async function getGitHubAppConfig(orgId: string): Promise<GitHubAppConfig> {
+  const response = await fetch(`${API_BASE}/api/orgs/${orgId}/github-app`, {
+    headers: getAuthHeaders(),
+  })
+
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error('Admin access required')
+    }
+    if (response.status === 404) {
+      throw new Error('GitHub Copilot not configured')
+    }
+    throw new Error(await getErrorMessage(response, 'Failed to fetch GitHub App config'))
+  }
+
+  return response.json()
+}
+
+export async function configureGitHubApp(
+  orgId: string,
+  data: ConfigureGitHubAppRequest,
+): Promise<GitHubAppConfig> {
+  const response = await fetch(`${API_BASE}/api/orgs/${orgId}/github-app`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    trackEvent('settings_github_app_update_failed', {
+      org_id: orgId,
+      status_code: response.status,
+    })
+    if (response.status === 403) {
+      throw new Error('Admin access required')
+    }
+    throw new Error(await getErrorMessage(response, 'Failed to save GitHub App config'))
+  }
+
+  const config = await response.json()
+  trackEvent('settings_github_app_updated', {
     org_id: orgId,
     enabled: config.enabled,
   })

--- a/frontend/src/components/CopilotPanel.vue
+++ b/frontend/src/components/CopilotPanel.vue
@@ -2,6 +2,7 @@
 import { Loader2, Send, Sparkles, Trash2, Unplug, X } from 'lucide-vue-next'
 import { nextTick, onMounted, ref, watch } from 'vue'
 import { type CopilotMessage, useCopilot } from '../composables/useCopilot'
+import { useOrganization } from '../composables/useOrganization'
 
 const props = defineProps<{
   datasourceType: string
@@ -24,6 +25,8 @@ const {
   disconnect,
   sendMessage,
 } = useCopilot()
+
+const { currentOrgId } = useOrganization()
 
 const messages = ref<CopilotMessage[]>([])
 const inputText = ref('')
@@ -135,7 +138,8 @@ async function handleDisconnect() {
       </div>
       <button
         class="inline-flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-slate-950 cursor-pointer border-none transition hover:bg-amber-600"
-        @click="connect"
+        :disabled="!currentOrgId"
+        @click="currentOrgId && connect(currentOrgId)"
       >
         Connect GitHub Copilot
       </button>

--- a/frontend/src/components/GitHubAppSettings.vue
+++ b/frontend/src/components/GitHubAppSettings.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { Github, Loader2 } from 'lucide-vue-next'
+import { computed, onMounted, ref } from 'vue'
+import { configureGitHubApp, getGitHubAppConfig } from '../api/sso'
+
+const props = defineProps<{
+  orgId: string
+  isAdmin: boolean
+}>()
+
+const callbackUrl = computed(() => `${window.location.origin}/api/auth/github/callback`)
+
+const loading = ref(true)
+const saving = ref(false)
+const error = ref<string | null>(null)
+const notice = ref<string | null>(null)
+
+const configured = ref(false)
+const enabled = ref(false)
+const clientId = ref('')
+const clientSecret = ref('')
+
+onMounted(async () => {
+  await loadConfig()
+})
+
+async function loadConfig() {
+  loading.value = true
+  error.value = null
+  try {
+    const config = await getGitHubAppConfig(props.orgId)
+    clientId.value = config.client_id
+    enabled.value = config.enabled
+    configured.value = true
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Failed to load GitHub App config'
+    if (message === 'GitHub Copilot not configured') {
+      clientId.value = ''
+      enabled.value = false
+      configured.value = false
+      return
+    }
+    error.value = message
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleSave() {
+  if (!props.isAdmin) return
+
+  const id = clientId.value.trim()
+  const secret = clientSecret.value.trim()
+
+  if (!id) {
+    error.value = 'Client ID is required'
+    return
+  }
+  if (!secret) {
+    error.value = 'Client Secret is required'
+    return
+  }
+
+  saving.value = true
+  error.value = null
+  notice.value = null
+
+  try {
+    const updated = await configureGitHubApp(props.orgId, {
+      client_id: id,
+      client_secret: secret,
+      enabled: enabled.value,
+    })
+    clientId.value = updated.client_id
+    enabled.value = updated.enabled
+    configured.value = true
+    clientSecret.value = ''
+    notice.value = 'GitHub Copilot credentials saved'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to save GitHub App config'
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <section class="rounded-xl border border-slate-200 bg-white p-6">
+    <div class="flex justify-between items-center mb-4">
+      <h2 class="flex items-center gap-2 m-0 text-base font-semibold text-slate-900">
+        <Github :size="20" />
+        GitHub Copilot Integration
+      </h2>
+      <span
+        v-if="!loading"
+        class="inline-block rounded-full px-2.5 py-0.5 text-xs border"
+        :class="configured
+          ? (enabled
+            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+            : 'border-amber-200 bg-amber-50 text-amber-700')
+          : 'border-slate-200 bg-slate-50 text-slate-500'"
+      >
+        {{ configured ? (enabled ? 'Configured' : 'Disabled') : 'Not configured' }}
+      </span>
+    </div>
+
+    <div v-if="loading" class="flex items-center gap-2 py-4">
+      <Loader2 :size="16" class="animate-spin text-slate-400" />
+      <span class="text-sm text-slate-500">Loading configuration...</span>
+    </div>
+
+    <template v-else-if="isAdmin">
+      <p class="text-sm text-slate-500 mb-4 mt-0">
+        Configure a GitHub OAuth App so members of this organization can connect their GitHub Copilot subscriptions for AI-assisted query writing.
+      </p>
+
+      <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+        <div class="mb-4">
+          <label class="block mb-1.5 text-sm font-medium text-slate-700">Client ID</label>
+          <input
+            v-model="clientId"
+            type="text"
+            :disabled="saving"
+            class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+          />
+        </div>
+        <div class="mb-4">
+          <label class="block mb-1.5 text-sm font-medium text-slate-700">Client Secret</label>
+          <input
+            v-model="clientSecret"
+            type="password"
+            :placeholder="configured ? '••••••••' : 'Enter client secret'"
+            :disabled="saving"
+            class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+          />
+        </div>
+        <div class="mb-4">
+          <label class="inline-flex items-center gap-2 text-sm font-medium text-slate-700 cursor-pointer">
+            <input
+              v-model="enabled"
+              type="checkbox"
+              :disabled="saving"
+              class="rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+            />
+            Enable GitHub Copilot
+          </label>
+        </div>
+
+        <div class="rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-xs text-slate-500 mb-4">
+          Create a GitHub OAuth App at
+          <strong>github.com/settings/developers</strong>.
+          Set the callback URL to:
+          <code class="rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono text-slate-700">{{ callbackUrl }}</code>.
+          Required scopes: <code class="rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono text-slate-700">read:user, copilot</code>.
+        </div>
+
+        <div v-if="error" class="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2.5 text-sm text-rose-600 mb-3">{{ error }}</div>
+        <div v-if="notice" class="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-700 mb-3">{{ notice }}</div>
+
+        <div class="flex justify-end">
+          <button
+            class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            :disabled="saving"
+            @click="handleSave"
+          >
+            {{ saving ? 'Saving...' : 'Save Credentials' }}
+          </button>
+        </div>
+      </div>
+    </template>
+
+    <template v-else>
+      <p class="text-sm text-slate-500 mt-0 mb-0">
+        GitHub Copilot is {{ configured ? (enabled ? 'configured' : 'configured but disabled') : 'not configured' }} for this organization. Contact an admin to update credentials.
+      </p>
+    </template>
+  </section>
+</template>

--- a/frontend/src/composables/useCopilot.ts
+++ b/frontend/src/composables/useCopilot.ts
@@ -44,8 +44,8 @@ export function useCopilot() {
     }
   }
 
-  function connect() {
-    window.location.href = `${API_BASE}/api/auth/github/login`
+  function connect(orgId: string) {
+    window.location.href = `${API_BASE}/api/auth/github/login?org=${orgId}`
   }
 
   async function disconnect() {

--- a/frontend/src/types/sso.ts
+++ b/frontend/src/types/sso.ts
@@ -25,3 +25,16 @@ export interface UpdateMicrosoftSSOConfigRequest {
   client_secret: string
   enabled?: boolean
 }
+
+export interface GitHubAppConfig {
+  client_id: string
+  enabled: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface ConfigureGitHubAppRequest {
+  client_id: string
+  client_secret: string
+  enabled?: boolean
+}

--- a/frontend/src/views/OrganizationSettings.vue
+++ b/frontend/src/views/OrganizationSettings.vue
@@ -29,6 +29,7 @@ import {
 import { useOrganization } from '../composables/useOrganization'
 import type { Member, MembershipRole, Organization } from '../types/organization'
 import type { UserGroup, UserGroupMembership } from '../types/rbac'
+import GitHubAppSettings from '../components/GitHubAppSettings.vue'
 import OrgBrandingSettings from './OrgBrandingSettings.vue'
 
 const route = useRoute()
@@ -135,17 +136,18 @@ const activeSsoLabel = computed(() => {
 
 const isAdmin = computed(() => org.value?.role === 'admin')
 
-type SettingsSection = 'general' | 'members' | 'groups' | 'branding'
+type SettingsSection = 'general' | 'members' | 'groups' | 'branding' | 'integrations'
 
 const settingsSections: Array<{ key: SettingsSection; label: string }> = [
   { key: 'general', label: 'General' },
   { key: 'members', label: 'Members' },
   { key: 'groups', label: 'Groups' },
   { key: 'branding', label: 'Branding' },
+  { key: 'integrations', label: 'Integrations' },
 ]
 
 function isSettingsSection(value: string | undefined): value is SettingsSection {
-  return value === 'general' || value === 'members' || value === 'groups' || value === 'branding'
+  return value === 'general' || value === 'members' || value === 'groups' || value === 'branding' || value === 'integrations'
 }
 
 const activeSection = computed<SettingsSection>(() => {
@@ -1110,6 +1112,9 @@ function goBack() {
 
       <!-- Branding Section -->
       <OrgBrandingSettings v-if="activeSection === 'branding'" :org-id="orgId" />
+
+      <!-- Integrations Section -->
+      <GitHubAppSettings v-if="activeSection === 'integrations'" :org-id="orgId" :is-admin="isAdmin" />
 
       <!-- SSO Section -->
       <section v-if="activeSection === 'general'" class="rounded-xl border border-slate-200 bg-white p-6">

--- a/frontend/src/views/UserSettingsView.vue
+++ b/frontend/src/views/UserSettingsView.vue
@@ -3,6 +3,7 @@ import { Check, Github, Loader2, Unplug } from 'lucide-vue-next'
 import { onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useCopilot } from '../composables/useCopilot'
+import { useOrganization } from '../composables/useOrganization'
 
 const route = useRoute()
 const {
@@ -13,6 +14,8 @@ const {
   connect,
   disconnect,
 } = useCopilot()
+
+const { currentOrgId } = useOrganization()
 
 const loading = ref(true)
 const showSuccessToast = ref(false)
@@ -88,8 +91,9 @@ async function handleDisconnect() {
             <div class="shrink-0">
               <button
                 v-if="!loading && !isConnected"
-                class="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white cursor-pointer border-none transition hover:bg-slate-800"
-                @click="connect"
+                class="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white cursor-pointer border-none transition hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                :disabled="!currentOrgId"
+                @click="currentOrgId && connect(currentOrgId)"
               >
                 <Github :size="14" />
                 Connect


### PR DESCRIPTION
## Summary

Closes #435 on Fizzy (Dash board)

### Changes

Each org now configures its own GitHub OAuth App (client_id + client_secret) in org settings, matching the pattern established by Google and Microsoft SSO. The global `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` env vars are no longer used for the Copilot OAuth flow.

### Implementation Details

**Backend**
- New DB migration (`009_github_copilot_per_org.sql`): adds `github_client_id` and `github_client_secret` columns to `sso_configs` table (org-scoped)
- `github_copilot.go` handler updated: reads org-scoped credentials instead of global env vars; stores/retrieves tokens per org
- OAuth initiation endpoint reads org's stored `github_client_id` to build the auth URL

**Frontend**
- New `GitHubAppSettings.vue` component: UI to enter/save org GitHub App credentials (client_id + client_secret)
- Integrated into `OrganizationSettings.vue` alongside existing Google/Microsoft SSO config sections
- `sso.ts` API: new endpoints for getting/updating GitHub App org settings
- `types/sso.ts`: added `GitHubAppConfig` type
- Minor updates to `CopilotPanel.vue` and `useCopilot.ts` to pass org context

### Files Changed
- `backend/cmd/api/main.go` — register new org credentials endpoint
- `backend/db/migrations/009_github_copilot_per_org.sql` — schema migration
- `backend/internal/handlers/github_copilot.go` — per-org credential logic
- `frontend/src/api/sso.ts` — GitHub App config API calls
- `frontend/src/components/CopilotPanel.vue` — org context
- `frontend/src/components/GitHubAppSettings.vue` — new settings component
- `frontend/src/composables/useCopilot.ts` — org context
- `frontend/src/types/sso.ts` — type definitions
- `frontend/src/views/OrganizationSettings.vue` — add GitHubAppSettings section
- `frontend/src/views/UserSettingsView.vue` — minor update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-organization GitHub Copilot configuration support with secure credential management.
  * New "Integrations" section in Organization Settings for managing GitHub App credentials.
  * Organization-aware OAuth authentication flow for GitHub Copilot.
  * Admin-gated controls to configure GitHub App Client ID and Client Secret with toggle to enable/disable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->