### PR TITLE
fix: resolve security vulnerabilities and add frontend test IDs

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/janhoon/dash/backend
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1525,9 +1525,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.1.tgz",
+      "integrity": "sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ==",
       "cpu": [
         "arm"
       ],
@@ -1539,9 +1539,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.1.tgz",
+      "integrity": "sha512-XOjPId0qwSDKHaIsdzHJtKCxX0+nH8MhBwvrNsT7tVyKmdTx1jJ4XzN5RZXCdTzMpufLb+B8llTC0D8uCrLhcw==",
       "cpu": [
         "arm64"
       ],
@@ -1553,9 +1553,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.1.tgz",
+      "integrity": "sha512-vQuRd28p0gQpPrS6kppd8IrWmFo42U8Pz1XLRjSZXq5zCqyMDYFABT7/sywL11mO1EL10Qhh7MVPEwkG8GiBeg==",
       "cpu": [
         "arm64"
       ],
@@ -1567,9 +1567,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.1.tgz",
+      "integrity": "sha512-x6VG6U29+Ivlnajrg1IHdzXeAwSoEHBFVO+CtC9Brugx6de712CUJobRUxsIA0KYrQvCmzNrMPFTT1A4CCqNTg==",
       "cpu": [
         "x64"
       ],
@@ -1581,9 +1581,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.1.tgz",
+      "integrity": "sha512-Sgi0Uo6t1YCHJMNO3Y8+bm+SvOanUGkoZKn/VJPwYUe2kp31X5KnXmzKd/NjW8iA3gFcfNZ64zh14uOGrIllCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1595,9 +1595,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.1.tgz",
+      "integrity": "sha512-AM4xnwEZwukdhk7laMWfzWu9JGSVnJd+Fowt6Fd7QW1nrf3h0Hp7Qx5881M4aqrUlKBCybOxz0jofvIIfl7C5g==",
       "cpu": [
         "x64"
       ],
@@ -1609,9 +1609,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.1.tgz",
+      "integrity": "sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==",
       "cpu": [
         "arm"
       ],
@@ -1623,9 +1623,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.1.tgz",
+      "integrity": "sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==",
       "cpu": [
         "arm"
       ],
@@ -1637,9 +1637,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.1.tgz",
+      "integrity": "sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==",
       "cpu": [
         "arm64"
       ],
@@ -1651,9 +1651,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.1.tgz",
+      "integrity": "sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==",
       "cpu": [
         "arm64"
       ],
@@ -1665,9 +1665,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.1.tgz",
+      "integrity": "sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==",
       "cpu": [
         "loong64"
       ],
@@ -1679,9 +1679,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.1.tgz",
+      "integrity": "sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==",
       "cpu": [
         "loong64"
       ],
@@ -1693,9 +1693,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.1.tgz",
+      "integrity": "sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==",
       "cpu": [
         "ppc64"
       ],
@@ -1707,9 +1707,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.1.tgz",
+      "integrity": "sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==",
       "cpu": [
         "ppc64"
       ],
@@ -1721,9 +1721,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.1.tgz",
+      "integrity": "sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==",
       "cpu": [
         "riscv64"
       ],
@@ -1735,9 +1735,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.1.tgz",
+      "integrity": "sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==",
       "cpu": [
         "riscv64"
       ],
@@ -1749,9 +1749,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.1.tgz",
+      "integrity": "sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==",
       "cpu": [
         "s390x"
       ],
@@ -1763,9 +1763,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==",
       "cpu": [
         "x64"
       ],
@@ -1777,9 +1777,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.1.tgz",
+      "integrity": "sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==",
       "cpu": [
         "x64"
       ],
@@ -1791,9 +1791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.1.tgz",
+      "integrity": "sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==",
       "cpu": [
         "x64"
       ],
@@ -1805,9 +1805,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.1.tgz",
+      "integrity": "sha512-ARoKfflk0SiiYm3r1fmF73K/yB+PThmOwfWCk1sr7x/k9dc3uGLWuEE9if+Pw21el8MSpp3TMnG5vLNsJ/MMGQ==",
       "cpu": [
         "arm64"
       ],
@@ -1819,9 +1819,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.1.tgz",
+      "integrity": "sha512-oOST61G6VM45Mz2vdzWMr1s2slI7y9LqxEV5fCoWi2MDONmMvgsJVHSXxce/I2xOSZPTZ47nDPOl1tkwKWSHcw==",
       "cpu": [
         "arm64"
       ],
@@ -1833,9 +1833,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.1.tgz",
+      "integrity": "sha512-x5WgLi5dWpRz7WclKBGEF15LcWTh0ewrHM6Cq4A+WUbkysUMZNeqt05bwPonOQ3ihPS/WMhAZV5zB1DfnI4Sxg==",
       "cpu": [
         "ia32"
       ],
@@ -1847,9 +1847,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-wS+zHAJRVP5zOL0e+a3V3E/NTEwM2HEvvNKoDy5Xcfs0o8lljxn+EAFPkUsxihBdmDq1JWzXmmB9cbssCPdxxw==",
       "cpu": [
         "x64"
       ],
@@ -1861,9 +1861,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.1.tgz",
+      "integrity": "sha512-rhHyrMeLpErT/C7BxcEsU4COHQUzHyrPYW5tOZUeUhziNtRuYxmDWvqQqzpuUt8xpOgmbKa1btGXfnA/ANVO+g==",
       "cpu": [
         "x64"
       ],
@@ -3233,15 +3233,15 @@
       }
     },
     "node_modules/editorconfig": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@one-ini/wasm": "0.1.1",
         "commander": "^10.0.0",
-        "minimatch": "9.0.1",
+        "minimatch": "^9.0.1",
         "semver": "^7.5.3"
       },
       "bin": {
@@ -3517,22 +3517,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/graceful-fs": {
@@ -4395,13 +4379,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4473,15 +4457,6 @@
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/monaco-editor/node_modules/marked": {
@@ -4888,9 +4863,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
+      "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4904,31 +4879,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.1",
+        "@rollup/rollup-android-arm64": "4.59.1",
+        "@rollup/rollup-darwin-arm64": "4.59.1",
+        "@rollup/rollup-darwin-x64": "4.59.1",
+        "@rollup/rollup-freebsd-arm64": "4.59.1",
+        "@rollup/rollup-freebsd-x64": "4.59.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.1",
+        "@rollup/rollup-linux-arm64-musl": "4.59.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.1",
+        "@rollup/rollup-linux-loong64-musl": "4.59.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-musl": "4.59.1",
+        "@rollup/rollup-openbsd-x64": "4.59.1",
+        "@rollup/rollup-openharmony-arm64": "4.59.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.1",
+        "@rollup/rollup-win32-x64-gnu": "4.59.1",
+        "@rollup/rollup-win32-x64-msvc": "4.59.1",
         "fsevents": "~2.3.2"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,5 +47,8 @@
     "vitest": "^4.0.18",
     "vue-tsc": "^3.2.5"
   },
+  "overrides": {
+    "dompurify": "^3.3.3"
+  },
   "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b"
 }

--- a/frontend/src/components/ClickHouseSQLEditor.vue
+++ b/frontend/src/components/ClickHouseSQLEditor.vue
@@ -62,6 +62,7 @@ function handleQueryInput(event: Event) {
       <select
         id="clickhouse-signal"
         :value="props.signal"
+        data-testid="clickhouse-signal-select"
         :disabled="props.disabled"
         class="w-full rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm text-text-primary cursor-pointer transition-colors duration-200 focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
         @change="handleSignalChange"
@@ -77,6 +78,7 @@ function handleQueryInput(event: Event) {
       <textarea
         id="clickhouse-query"
         :value="props.modelValue"
+        data-testid="clickhouse-query-input"
         :disabled="props.disabled"
         :placeholder="placeholder"
         rows="7"

--- a/frontend/src/components/CloudWatchQueryEditor.vue
+++ b/frontend/src/components/CloudWatchQueryEditor.vue
@@ -53,6 +53,7 @@ function handleQueryInput(event: Event) {
       <select
         id="cloudwatch-signal"
         :value="props.signal"
+        data-testid="cloudwatch-signal-select"
         :disabled="props.disabled"
         class="w-full rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm text-text-primary cursor-pointer transition-colors duration-200 focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
         @change="handleSignalChange"
@@ -67,6 +68,7 @@ function handleQueryInput(event: Event) {
       <textarea
         id="cloudwatch-query"
         :value="props.modelValue"
+        data-testid="cloudwatch-query-input"
         :disabled="props.disabled"
         :placeholder="placeholder"
         rows="7"

--- a/frontend/src/components/CookieConsentBanner.vue
+++ b/frontend/src/components/CookieConsentBanner.vue
@@ -40,18 +40,21 @@ function openPrivacySettings() {
     <div class="inline-flex items-center gap-2 flex-wrap justify-end max-md:justify-start">
       <button
         class="text-accent hover:text-accent underline text-sm px-4 py-2 rounded-sm transition"
+        data-testid="cookie-privacy-settings-btn"
         @click="openPrivacySettings"
       >
         Privacy settings
       </button>
       <button
         class="rounded-sm border border-border px-4 py-2 text-sm font-medium text-text-muted hover:text-text-primary transition"
+        data-testid="cookie-decline-btn"
         @click="declineAnalytics"
       >
         Decline
       </button>
       <button
         class="rounded-sm bg-accent px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-hover"
+        data-testid="cookie-accept-btn"
         @click="acceptAnalytics"
       >
         Allow analytics

--- a/frontend/src/components/CreateDashboardModal.vue
+++ b/frontend/src/components/CreateDashboardModal.vue
@@ -258,11 +258,11 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="emit('close')">
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" data-testid="create-dashboard-modal" @click.self="emit('close')">
     <div class="w-full max-w-lg rounded border border-border bg-surface-raised shadow-lg">
       <header class="flex items-center justify-between border-b border-border px-6 py-4">
         <h2 class="text-lg font-semibold text-text-primary">Create Dashboard</h2>
-        <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer" @click="emit('close')">
+        <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer" data-testid="create-dashboard-close-btn" @click="emit('close')">
           <X :size="20" />
         </button>
       </header>
@@ -273,6 +273,7 @@ async function handleSubmit() {
             type="button"
             class="rounded-sm px-4 py-2 text-sm font-medium transition cursor-pointer"
             :class="mode === 'create' ? 'bg-surface-raised text-text-primary shadow-sm' : 'text-text-secondary'"
+            data-testid="create-mode-create-btn"
             :disabled="loading"
             @click="setMode('create')"
           >
@@ -282,6 +283,7 @@ async function handleSubmit() {
             type="button"
             class="rounded-sm px-4 py-2 text-sm font-medium transition cursor-pointer"
             :class="mode === 'import' ? 'bg-surface-raised text-text-primary shadow-sm' : 'text-text-secondary'"
+            data-testid="create-mode-import-btn"
             :disabled="loading"
             @click="setMode('import')"
           >
@@ -291,6 +293,7 @@ async function handleSubmit() {
             type="button"
             class="rounded-sm px-4 py-2 text-sm font-medium transition cursor-pointer"
             :class="mode === 'grafana' ? 'bg-surface-raised text-text-primary shadow-sm' : 'text-text-secondary'"
+            data-testid="create-mode-grafana-btn"
             :disabled="loading"
             @click="setMode('grafana')"
           >
@@ -303,6 +306,7 @@ async function handleSubmit() {
             <label for="title" class="block mb-2 text-sm font-medium text-text-primary">Title <span class="text-red-500">*</span></label>
             <input
               id="title"
+              data-testid="create-dashboard-title-input"
               v-model="title"
               type="text"
               placeholder="My Dashboard"
@@ -316,6 +320,7 @@ async function handleSubmit() {
             <label for="description" class="block mb-2 text-sm font-medium text-text-primary">Description</label>
             <textarea
               id="description"
+              data-testid="create-dashboard-description-input"
               v-model="description"
               placeholder="Dashboard description (optional)"
               rows="3"
@@ -400,10 +405,10 @@ async function handleSubmit() {
         <div v-if="error" class="mb-5 rounded-sm border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{{ error }}</div>
 
         <div class="flex justify-end gap-3 border-t border-border pt-4">
-          <button type="button" class="rounded-sm border border-border-strong px-5 py-2.5 text-sm font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" @click="emit('close')" :disabled="loading">
+          <button type="button" data-testid="create-dashboard-cancel-btn" class="rounded-sm border border-border-strong px-5 py-2.5 text-sm font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" @click="emit('close')" :disabled="loading">
             Cancel
           </button>
-          <button type="submit" class="rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" :disabled="loading">
+          <button type="submit" data-testid="create-dashboard-submit-btn" class="rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" :disabled="loading">
             {{ submitLabel }}
           </button>
         </div>

--- a/frontend/src/components/CreateOrganizationModal.vue
+++ b/frontend/src/components/CreateOrganizationModal.vue
@@ -139,6 +139,7 @@ async function handleSubmit() {
     >
       <div
         ref="modalRef"
+        data-testid="create-org-modal"
         class="w-full max-w-md m-4 rounded border border-border bg-surface-raised shadow-lg animate-[slideUp_0.3s_ease-out] max-sm:max-w-none max-sm:m-0 max-sm:h-full max-sm:rounded-none"
         role="dialog"
         aria-modal="true"
@@ -148,13 +149,14 @@ async function handleSubmit() {
           <h2 id="create-org-modal-title" class="text-lg font-semibold text-text-primary">Create Organization</h2>
           <button
             class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer"
+            data-testid="create-org-close-btn"
             @click="closeModal"
           >
             <X :size="20" />
           </button>
         </header>
 
-        <form class="px-6 py-4 max-sm:pb-[max(1.5rem,env(safe-area-inset-bottom))]" @submit.prevent="handleSubmit">
+        <form class="px-6 py-4 max-sm:pb-[max(1.5rem,env(safe-area-inset-bottom))]" data-testid="create-org-form" @submit.prevent="handleSubmit">
           <div class="mb-5">
             <label for="name" class="block mb-2 text-sm font-medium text-text-primary">
               Organization Name <span class="text-red-500">*</span>
@@ -167,6 +169,7 @@ async function handleSubmit() {
               placeholder="My Organization"
               :disabled="loading"
               autocomplete="off"
+              data-testid="create-org-name-input"
               class="w-full rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm text-text-primary placeholder:text-text-muted transition focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
             />
           </div>
@@ -184,6 +187,7 @@ async function handleSubmit() {
                 placeholder="my-organization"
                 :disabled="loading"
                 autocomplete="off"
+                data-testid="create-org-slug-input"
                 class="w-full bg-transparent border-none pl-0 py-2 pr-3 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-0 disabled:text-text-muted disabled:cursor-not-allowed"
                 @input="handleSlugInput"
               />
@@ -193,6 +197,7 @@ async function handleSubmit() {
 
           <div
             v-if="error"
+            data-testid="create-org-error"
             class="mb-5 rounded-sm border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600"
           >
             {{ error }}
@@ -203,6 +208,7 @@ async function handleSubmit() {
               type="button"
               class="inline-flex items-center justify-center rounded-sm border border-border px-4 py-2 text-sm font-medium text-text-muted hover:text-text-primary transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               :disabled="loading"
+              data-testid="create-org-cancel-btn"
               @click="closeModal"
             >
               Cancel
@@ -211,6 +217,7 @@ async function handleSubmit() {
               type="submit"
               class="inline-flex items-center justify-center rounded-sm bg-accent px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-hover cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               :disabled="loading"
+              data-testid="create-org-submit-btn"
             >
               {{ loading ? 'Creating...' : 'Create Organization' }}
             </button>

--- a/frontend/src/components/DashboardList.vue
+++ b/frontend/src/components/DashboardList.vue
@@ -810,6 +810,7 @@ onMounted(() => {
         </button>
         <button
           class="inline-flex items-center gap-2 rounded-sm bg-accent px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-hover cursor-pointer"
+          data-testid="new-dashboard-btn"
           @click="openCreateModal"
         >
           <Plus :size="18" />
@@ -1342,7 +1343,7 @@ onMounted(() => {
     />
 
     <!-- Delete confirmation modal -->
-    <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" @click.self="cancelDelete">
+    <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" data-testid="delete-dashboard-modal" @click.self="cancelDelete">
       <div class="w-full max-w-sm rounded border border-border bg-surface-raised p-8 text-center shadow-lg">
         <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-sm bg-rose-50 text-rose-600">
           <Trash2 :size="24" />
@@ -1353,12 +1354,14 @@ onMounted(() => {
         <div class="mt-5 flex justify-center gap-3">
           <button
             class="inline-flex items-center gap-2 rounded-sm border border-border bg-surface-raised px-4 py-2 text-sm font-medium text-text-primary transition hover:border-border-strong hover:bg-surface-overlay cursor-pointer"
+            data-testid="delete-dashboard-cancel-btn"
             @click="cancelDelete"
           >
             Cancel
           </button>
           <button
             class="inline-flex items-center gap-2 rounded-sm bg-rose-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-rose-700 cursor-pointer"
+            data-testid="delete-dashboard-confirm-btn"
             @click="handleDelete"
           >
             Delete

--- a/frontend/src/components/DataSourceSettingsPanel.vue
+++ b/frontend/src/components/DataSourceSettingsPanel.vue
@@ -10,7 +10,7 @@
       <Database :size="40" class="text-text-muted" />
       <h3 class="m-0 text-base text-text-primary">No data sources configured</h3>
       <p class="m-0 text-text-secondary text-sm">Add a data source to start visualising your metrics, logs, and traces.</p>
-      <RouterLink :to="`/app/datasources/new?orgId=${orgId}`" class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-accent text-white border-none rounded-sm text-sm font-medium cursor-pointer no-underline transition hover:bg-accent-hover">
+      <RouterLink :to="`/app/datasources/new?orgId=${orgId}`" data-testid="ds-panel-add-empty-btn" class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-accent text-white border-none rounded-sm text-sm font-medium cursor-pointer no-underline transition hover:bg-accent-hover">
         Add data source
       </RouterLink>
     </div>
@@ -19,13 +19,13 @@
     <div v-else>
       <div class="flex items-center justify-between mb-3">
         <span class="text-sm text-text-secondary font-medium">{{ datasources.length }} data source{{ datasources.length !== 1 ? 's' : '' }}</span>
-        <RouterLink :to="`/app/datasources/new?orgId=${orgId}`" class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-accent text-white border-none rounded-sm text-sm font-medium cursor-pointer no-underline transition hover:bg-accent-hover">
+        <RouterLink :to="`/app/datasources/new?orgId=${orgId}`" data-testid="ds-panel-add-btn" class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-accent text-white border-none rounded-sm text-sm font-medium cursor-pointer no-underline transition hover:bg-accent-hover">
           Add data source
         </RouterLink>
       </div>
 
       <div class="flex flex-col gap-2">
-        <div v-for="ds in datasources" :key="ds.id" class="flex items-center justify-between gap-4 px-4 py-3 bg-surface-overlay border border-border rounded transition-colors hover:border-accent-border">
+        <div v-for="ds in datasources" :key="ds.id" :data-testid="`ds-panel-row-${ds.id}`" class="flex items-center justify-between gap-4 px-4 py-3 bg-surface-overlay border border-border rounded transition-colors hover:border-accent-border">
           <div class="flex items-center gap-3 min-w-0 flex-1">
             <div class="flex items-center gap-2">
               <img v-if="dataSourceTypeLogos[ds.type]" :src="dataSourceTypeLogos[ds.type]" :alt="ds.type" class="h-5 w-5 shrink-0 object-contain" />
@@ -35,13 +35,13 @@
             <span class="text-xs text-text-muted whitespace-nowrap overflow-hidden text-ellipsis">{{ ds.url }}</span>
           </div>
           <div class="flex items-center gap-1 shrink-0">
-            <button @click="testDatasource(ds.id)" class="inline-flex items-center justify-center w-[30px] h-[30px] p-0 bg-transparent border border-transparent rounded-sm text-text-secondary cursor-pointer transition-all no-underline hover:bg-surface-overlay hover:border-border-strong hover:text-text-primary" title="Test connection">
+            <button @click="testDatasource(ds.id)" :data-testid="`ds-panel-test-${ds.id}`" class="inline-flex items-center justify-center w-[30px] h-[30px] p-0 bg-transparent border border-transparent rounded-sm text-text-secondary cursor-pointer transition-all no-underline hover:bg-surface-overlay hover:border-border-strong hover:text-text-primary" title="Test connection">
               <Zap :size="14" />
             </button>
-            <RouterLink :to="`/app/datasources/${ds.id}/edit`" class="inline-flex items-center justify-center w-[30px] h-[30px] p-0 bg-transparent border border-transparent rounded-sm text-text-secondary cursor-pointer transition-all no-underline hover:bg-surface-overlay hover:border-border-strong hover:text-text-primary" title="Edit">
+            <RouterLink :to="`/app/datasources/${ds.id}/edit`" :data-testid="`ds-panel-edit-${ds.id}`" class="inline-flex items-center justify-center w-[30px] h-[30px] p-0 bg-transparent border border-transparent rounded-sm text-text-secondary cursor-pointer transition-all no-underline hover:bg-surface-overlay hover:border-border-strong hover:text-text-primary" title="Edit">
               <Edit2 :size="14" />
             </RouterLink>
-            <button @click="deleteDatasource(ds.id)" class="inline-flex items-center justify-center w-[30px] h-[30px] p-0 bg-transparent border border-transparent rounded-sm text-text-secondary cursor-pointer transition-all no-underline hover:bg-surface-overlay hover:border-border-strong hover:text-text-primary hover:!bg-rose-500/15 hover:!border-rose-500/30 hover:!text-rose-500" title="Delete">
+            <button @click="deleteDatasource(ds.id)" :data-testid="`ds-panel-delete-${ds.id}`" class="inline-flex items-center justify-center w-[30px] h-[30px] p-0 bg-transparent border border-transparent rounded-sm text-text-secondary cursor-pointer transition-all no-underline hover:bg-surface-overlay hover:border-border-strong hover:text-text-primary hover:!bg-rose-500/15 hover:!border-rose-500/30 hover:!text-rose-500" title="Delete">
               <Trash2 :size="14" />
             </button>
           </div>

--- a/frontend/src/components/EditDashboardModal.vue
+++ b/frontend/src/components/EditDashboardModal.vue
@@ -47,10 +47,10 @@ async function handleSubmit() {
 
 <template>
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="emit('close')">
-    <div class="w-full max-w-lg rounded border border-border bg-surface-raised shadow-lg">
+    <div class="w-full max-w-lg rounded border border-border bg-surface-raised shadow-lg" data-testid="edit-dashboard-modal">
       <header class="flex items-center justify-between border-b border-border px-6 py-4">
         <h2 class="text-lg font-semibold text-text-primary">Edit Dashboard</h2>
-        <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer" @click="emit('close')">
+        <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer" data-testid="edit-dashboard-close-btn" @click="emit('close')">
           <X :size="20" />
         </button>
       </header>
@@ -65,6 +65,7 @@ async function handleSubmit() {
             placeholder="My Dashboard"
             :disabled="loading"
             autocomplete="off"
+            data-testid="edit-dashboard-title-input"
             class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
           />
         </div>
@@ -77,6 +78,7 @@ async function handleSubmit() {
             placeholder="Dashboard description (optional)"
             rows="3"
             :disabled="loading"
+            data-testid="edit-dashboard-description-input"
             class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed resize-vertical min-h-[80px]"
           ></textarea>
         </div>
@@ -87,6 +89,7 @@ async function handleSubmit() {
             id="folder"
             v-model="folderId"
             :disabled="loading"
+            data-testid="edit-dashboard-folder-select"
             class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
           >
             <option value="">Unfiled (Root)</option>
@@ -103,10 +106,10 @@ async function handleSubmit() {
         <div v-if="error" class="mb-5 rounded-sm border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{{ error }}</div>
 
         <div class="flex justify-end gap-3 border-t border-border pt-4">
-          <button type="button" class="rounded-sm border border-border-strong px-5 py-2.5 text-sm font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" @click="emit('close')" :disabled="loading">
+          <button type="button" class="rounded-sm border border-border-strong px-5 py-2.5 text-sm font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" data-testid="edit-dashboard-cancel-btn" @click="emit('close')" :disabled="loading">
             Cancel
           </button>
-          <button type="submit" class="rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" :disabled="loading">
+          <button type="submit" class="rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer" data-testid="edit-dashboard-save-btn" :disabled="loading">
             {{ loading ? 'Saving...' : 'Save Changes' }}
           </button>
         </div>

--- a/frontend/src/components/ElasticsearchQueryEditor.vue
+++ b/frontend/src/components/ElasticsearchQueryEditor.vue
@@ -53,6 +53,7 @@ function handleQueryInput(event: Event) {
       <select
         id="elasticsearch-signal"
         :value="props.signal"
+        data-testid="elasticsearch-signal-select"
         :disabled="props.disabled"
         class="w-full rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm text-text-primary cursor-pointer transition-colors duration-200 focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
         @change="handleSignalChange"
@@ -67,6 +68,7 @@ function handleQueryInput(event: Event) {
       <textarea
         id="elasticsearch-query"
         :value="props.modelValue"
+        data-testid="elasticsearch-query-input"
         :disabled="props.disabled"
         :placeholder="placeholder"
         rows="7"

--- a/frontend/src/components/GitHubAppSettings.vue
+++ b/frontend/src/components/GitHubAppSettings.vue
@@ -121,6 +121,7 @@ async function handleSave() {
             v-model="clientId"
             type="text"
             :disabled="saving"
+            data-testid="github-app-client-id-input"
             class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary outline-none focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-50"
           />
         </div>
@@ -131,6 +132,7 @@ async function handleSave() {
             type="password"
             :placeholder="configured ? '••••••••' : 'Enter client secret'"
             :disabled="saving"
+            data-testid="github-app-client-secret-input"
             class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary outline-none focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-50"
           />
         </div>
@@ -140,6 +142,7 @@ async function handleSave() {
               v-model="enabled"
               type="checkbox"
               :disabled="saving"
+              data-testid="github-app-enabled-checkbox"
               class="rounded border-border-strong text-accent focus:ring-accent"
             />
             Enable GitHub Copilot
@@ -161,6 +164,7 @@ async function handleSave() {
           <button
             class="inline-flex items-center gap-1.5 rounded-sm bg-accent px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-hover cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             :disabled="saving"
+            data-testid="github-app-save-btn"
             @click="handleSave"
           >
             {{ saving ? 'Saving...' : 'Save Credentials' }}

--- a/frontend/src/components/LogQLQueryBuilder.vue
+++ b/frontend/src/components/LogQLQueryBuilder.vue
@@ -321,6 +321,7 @@ watch(activeQuery, (newValue) => {
         type="button"
         class="flex items-center gap-1.5 px-3 py-1.5 bg-transparent border-none rounded-sm text-xs font-medium text-text-secondary cursor-pointer transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:enabled:text-text-primary"
         :class="{ 'bg-surface-raised text-text-primary shadow-sm': mode === 'builder' }"
+        data-testid="logql-builder-mode-btn"
         :disabled="props.disabled || !builderAvailable"
         :title="!builderAvailable ? 'Query cannot be edited in builder mode' : ''"
         @click="mode = 'builder'"
@@ -332,6 +333,7 @@ watch(activeQuery, (newValue) => {
         type="button"
         class="flex items-center gap-1.5 px-3 py-1.5 bg-transparent border-none rounded-sm text-xs font-medium text-text-secondary cursor-pointer transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:enabled:text-text-primary"
         :class="{ 'bg-surface-raised text-text-primary shadow-sm': mode === 'code' }"
+        data-testid="logql-code-mode-btn"
         :disabled="props.disabled"
         @click="mode = 'code'"
       >
@@ -347,6 +349,7 @@ watch(activeQuery, (newValue) => {
           <button
             type="button"
             class="flex items-center gap-1.5 px-3 py-1.5 rounded-sm border border-border text-xs font-medium text-text-secondary cursor-pointer transition-all duration-200 hover:enabled:bg-surface-overlay hover:enabled:text-text-primary"
+            data-testid="logql-add-filter-btn"
             :disabled="props.disabled"
             @click="addLabelFilter"
           >
@@ -425,6 +428,7 @@ watch(activeQuery, (newValue) => {
         <div class="flex items-center gap-2">
           <select
             v-model="lineFilterOperator"
+            data-testid="logql-line-filter-operator-select"
             class="w-[120px] flex-none rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm font-mono text-text-secondary cursor-pointer focus:outline-none focus:border-accent"
             :disabled="props.disabled"
           >
@@ -434,6 +438,7 @@ watch(activeQuery, (newValue) => {
           </select>
           <input
             v-model="lineFilterValue"
+            data-testid="logql-line-filter-value-input"
             class="flex-1 min-w-0 rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm text-text-primary focus:outline-none focus:border-accent"
             type="text"
             :placeholder="lineFilterPlaceholder"

--- a/frontend/src/components/OrganizationDropdown.vue
+++ b/frontend/src/components/OrganizationDropdown.vue
@@ -51,6 +51,7 @@ function handleCreateOrg() {
   <div class="relative mx-2 my-2" ref="dropdownRef">
     <button
       @click="toggleDropdown"
+      data-testid="org-dropdown-btn"
       :class="[
         'flex items-center gap-2 rounded-sm border border-[#1a1a30] bg-[--color-surface-sidebar] px-2.5 py-1.5 text-sm text-[#c8cad4] transition hover:border-[#262644] hover:bg-[#14142a] w-full cursor-pointer',
         !expanded && 'mx-auto !w-9 justify-center !px-0'
@@ -69,7 +70,7 @@ function handleCreateOrg() {
     </button>
 
     <Teleport to="body">
-      <div v-if="dropdownOpen" class="absolute z-[60] w-64 rounded border border-border bg-surface-raised shadow-lg overflow-hidden animate-[fadeIn_0.15s_ease-out]" :style="{ position: 'fixed', left: (props.sidebarWidth ?? 220) + 'px', top: '64px', zIndex: 1000 }">
+      <div v-if="dropdownOpen" data-testid="org-dropdown-menu" class="absolute z-[60] w-64 rounded border border-border bg-surface-raised shadow-lg overflow-hidden animate-[fadeIn_0.15s_ease-out]" :style="{ position: 'fixed', left: (props.sidebarWidth ?? 220) + 'px', top: '64px', zIndex: 1000 }">
         <div class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-muted">Organizations</div>
 
         <div class="max-h-[200px] overflow-y-auto">
@@ -80,6 +81,7 @@ function handleCreateOrg() {
               'flex w-full items-center gap-3 px-4 py-2.5 text-sm text-text-primary transition hover:bg-surface-overlay cursor-pointer border-none bg-transparent',
               currentOrg?.id === org.id && 'bg-accent-muted text-accent'
             ]"
+            :data-testid="`org-dropdown-item-${org.id}`"
             @click="handleSelectOrg(org.id)"
           >
             <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-surface-overlay text-xs font-semibold text-text-secondary">
@@ -93,7 +95,7 @@ function handleCreateOrg() {
           </button>
         </div>
 
-        <button class="flex w-full items-center gap-2 border-t border-border px-4 py-3 text-sm font-medium text-accent transition hover:bg-accent-muted cursor-pointer bg-transparent" @click="handleCreateOrg">
+        <button class="flex w-full items-center gap-2 border-t border-border px-4 py-3 text-sm font-medium text-accent transition hover:bg-accent-muted cursor-pointer bg-transparent" data-testid="org-dropdown-create-btn" @click="handleCreateOrg">
           <Plus :size="16" />
           <span>Create Organization</span>
         </button>

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -514,6 +514,7 @@ function handleOpenTrace(traceId: string) {
       <div class="flex gap-1">
         <button
           class="flex items-center justify-center h-7 w-7 rounded-sm border-0 bg-transparent text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer"
+          data-testid="panel-edit-btn"
           @click="$emit('edit', panel)"
           title="Edit panel"
         >
@@ -521,6 +522,7 @@ function handleOpenTrace(traceId: string) {
         </button>
         <button
           class="flex items-center justify-center h-7 w-7 rounded-sm border-0 bg-transparent text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer"
+          data-testid="panel-delete-btn"
           @click="$emit('delete', panel)"
           title="Delete panel"
         >
@@ -534,6 +536,7 @@ function handleOpenTrace(traceId: string) {
         <p class="text-sm text-text-muted m-0">No query configured</p>
         <button
           class="px-4 py-2 bg-accent text-white border-0 rounded-sm text-sm font-medium cursor-pointer hover:-translate-y-px transition"
+          data-testid="panel-configure-btn"
           @click="$emit('edit', panel)"
         >
           Configure Panel

--- a/frontend/src/components/PanelEditModal.vue
+++ b/frontend/src/components/PanelEditModal.vue
@@ -324,10 +324,10 @@ async function handleSubmit() {
 
 <template>
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" @click.self="emit('close')">
-    <div class="w-full max-w-4xl rounded border border-border bg-surface-raised shadow-lg max-h-[90vh] overflow-y-auto">
+    <div class="w-full max-w-4xl rounded border border-border bg-surface-raised shadow-lg max-h-[90vh] overflow-y-auto" data-testid="panel-edit-modal">
       <header class="flex items-center justify-between border-b border-border px-6 py-4 sticky top-0 bg-surface-raised z-10">
         <h2 class="text-lg font-semibold text-text-primary">{{ isEditing ? 'Edit Panel' : 'Add Panel' }}</h2>
-        <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer" @click="emit('close')">
+        <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition cursor-pointer" data-testid="panel-edit-close-btn" @click="emit('close')">
           <X :size="20" />
         </button>
       </header>
@@ -343,13 +343,14 @@ async function handleSubmit() {
               placeholder="Panel title"
               :disabled="loading"
               autocomplete="off"
+              data-testid="panel-title-input"
               class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
             />
           </div>
 
           <div class="mb-5 min-w-[160px]">
             <label for="type" class="block mb-2 text-sm font-medium text-text-primary">Panel Type</label>
-            <select id="type" v-model="panelType" :disabled="loading" class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition cursor-pointer appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-10 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed">
+            <select id="type" v-model="panelType" :disabled="loading" data-testid="panel-type-select" class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition cursor-pointer appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-10 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed">
               <option value="line_chart">Line Chart</option>
               <option value="bar_chart">Bar Chart</option>
               <option value="pie">Pie Chart</option>
@@ -365,7 +366,7 @@ async function handleSubmit() {
 
         <div v-if="datasources.length > 0" class="mb-5">
           <label for="datasource" class="block mb-2 text-sm font-medium text-text-primary">Data Source</label>
-          <select id="datasource" v-model="selectedDatasourceId" :disabled="loading" class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition cursor-pointer appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-10 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed">
+          <select id="datasource" v-model="selectedDatasourceId" :disabled="loading" data-testid="panel-datasource-select" class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition cursor-pointer appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-10 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed">
             <option v-if="!isTracePanelType" value="">Default (Prometheus)</option>
             <option v-else value="">Select tracing datasource</option>
             <option v-for="ds in availableDatasources" :key="ds.id" :value="ds.id">
@@ -422,6 +423,7 @@ async function handleSubmit() {
               <input
                 id="trace-service-filter"
                 v-model="traceService"
+                data-testid="panel-trace-service-input"
                 type="text"
                 placeholder="api-service"
                 :disabled="loading"
@@ -433,6 +435,7 @@ async function handleSubmit() {
               <input
                 id="trace-limit"
                 v-model.number="traceLimit"
+                data-testid="panel-trace-limit-input"
                 type="number"
                 min="1"
                 max="200"
@@ -453,6 +456,7 @@ async function handleSubmit() {
               <input
                 id="gauge-min"
                 v-model.number="gaugeMin"
+                data-testid="panel-gauge-min-input"
                 type="number"
                 :disabled="loading"
                 class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
@@ -463,6 +467,7 @@ async function handleSubmit() {
               <input
                 id="gauge-max"
                 v-model.number="gaugeMax"
+                data-testid="panel-gauge-max-input"
                 type="number"
                 :disabled="loading"
                 class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
@@ -473,6 +478,7 @@ async function handleSubmit() {
               <input
                 id="gauge-unit"
                 v-model="gaugeUnit"
+                data-testid="panel-gauge-unit-input"
                 type="text"
                 placeholder="%"
                 :disabled="loading"
@@ -484,6 +490,7 @@ async function handleSubmit() {
               <input
                 id="gauge-decimals"
                 v-model.number="gaugeDecimals"
+                data-testid="panel-gauge-decimals-input"
                 type="number"
                 min="0"
                 max="10"
@@ -496,7 +503,7 @@ async function handleSubmit() {
           <div class="mt-4">
             <div class="flex justify-between items-center mb-2">
               <label class="text-sm font-medium text-text-primary">Thresholds</label>
-              <button type="button" class="inline-flex items-center gap-1 rounded-sm border border-border bg-surface-raised px-2.5 py-1.5 text-xs font-medium text-text-primary transition hover:bg-surface-overlay cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" @click="addThreshold" :disabled="loading">
+              <button type="button" data-testid="panel-gauge-add-threshold-btn" class="inline-flex items-center gap-1 rounded-sm border border-border bg-surface-raised px-2.5 py-1.5 text-xs font-medium text-text-primary transition hover:bg-surface-overlay cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" @click="addThreshold" :disabled="loading">
                 <Plus :size="14" />
                 Add
               </button>
@@ -540,7 +547,7 @@ async function handleSubmit() {
           <div class="grid grid-cols-3 gap-3">
             <div class="mb-3">
               <label for="pie-display" class="block mb-2 text-sm font-medium text-text-primary">Display Style</label>
-              <select id="pie-display" v-model="pieDisplayAs" :disabled="loading" class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition cursor-pointer appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-10 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed">
+              <select id="pie-display" v-model="pieDisplayAs" data-testid="panel-pie-display-select" :disabled="loading" class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition cursor-pointer appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-10 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed">
                 <option value="pie">Pie</option>
                 <option value="donut">Donut</option>
               </select>
@@ -551,6 +558,7 @@ async function handleSubmit() {
                 <input
                   id="pie-legend"
                   v-model="pieShowLegend"
+                  data-testid="panel-pie-legend-checkbox"
                   type="checkbox"
                   :disabled="loading"
                   class="h-4 w-4 rounded border-border-strong text-accent focus:ring-accent/20"
@@ -564,6 +572,7 @@ async function handleSubmit() {
                 <input
                   id="pie-labels"
                   v-model="pieShowLabels"
+                  data-testid="panel-pie-labels-checkbox"
                   type="checkbox"
                   :disabled="loading"
                   class="h-4 w-4 rounded border-border-strong text-accent focus:ring-accent/20"
@@ -584,6 +593,7 @@ async function handleSubmit() {
               <input
                 id="stat-unit"
                 v-model="statUnit"
+                data-testid="panel-stat-unit-input"
                 type="text"
                 placeholder="%"
                 :disabled="loading"
@@ -595,6 +605,7 @@ async function handleSubmit() {
               <input
                 id="stat-decimals"
                 v-model.number="statDecimals"
+                data-testid="panel-stat-decimals-input"
                 type="number"
                 min="0"
                 max="10"
@@ -610,6 +621,7 @@ async function handleSubmit() {
                 <input
                   type="checkbox"
                   v-model="statShowTrend"
+                  data-testid="panel-stat-trend-checkbox"
                   :disabled="loading"
                   class="h-4 w-4 rounded border-border-strong text-accent focus:ring-accent/20"
                 />
@@ -621,6 +633,7 @@ async function handleSubmit() {
                 <input
                   type="checkbox"
                   v-model="statShowSparkline"
+                  data-testid="panel-stat-sparkline-checkbox"
                   :disabled="loading"
                   class="h-4 w-4 rounded border-border-strong text-accent focus:ring-accent/20"
                 />
@@ -632,7 +645,7 @@ async function handleSubmit() {
           <div class="mt-4">
             <div class="flex justify-between items-center mb-2">
               <label class="text-sm font-medium text-text-primary">Thresholds (Optional)</label>
-              <button type="button" class="inline-flex items-center gap-1 rounded-sm border border-border bg-surface-raised px-2.5 py-1.5 text-xs font-medium text-text-primary transition hover:bg-surface-overlay cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" @click="addStatThreshold" :disabled="loading">
+              <button type="button" data-testid="panel-stat-add-threshold-btn" class="inline-flex items-center gap-1 rounded-sm border border-border bg-surface-raised px-2.5 py-1.5 text-xs font-medium text-text-primary transition hover:bg-surface-overlay cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" @click="addStatThreshold" :disabled="loading">
                 <Plus :size="14" />
                 Add
               </button>
@@ -672,10 +685,10 @@ async function handleSubmit() {
         <div v-if="error" class="rounded-sm border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600 mb-5">{{ error }}</div>
 
         <div class="flex justify-end gap-3 border-t border-border pt-4 mt-2">
-          <button type="button" class="rounded-sm border border-border-strong px-5 py-2.5 text-sm font-semibold text-text-primary transition hover:border-border-strong cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" @click="emit('close')" :disabled="loading">
+          <button type="button" data-testid="panel-edit-cancel-btn" class="rounded-sm border border-border-strong px-5 py-2.5 text-sm font-semibold text-text-primary transition hover:border-border-strong cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" @click="emit('close')" :disabled="loading">
             Cancel
           </button>
-          <button type="submit" class="rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" :disabled="loading">
+          <button type="submit" data-testid="panel-edit-save-btn" class="rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" :disabled="loading">
             {{ loading ? 'Saving...' : (isEditing ? 'Save Changes' : 'Add Panel') }}
           </button>
         </div>

--- a/frontend/src/components/QueryBuilder.vue
+++ b/frontend/src/components/QueryBuilder.vue
@@ -152,6 +152,7 @@ function getLabelValues(labelName: string): string[] {
         type="button"
         class="flex items-center gap-1.5 px-3 py-1.5 bg-transparent border-none rounded-sm text-xs font-medium text-text-secondary cursor-pointer transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:enabled:text-text-primary"
         :class="{ 'bg-surface-raised text-text-primary shadow-sm': mode === 'builder' }"
+        data-testid="query-builder-mode-btn"
         @click="mode = 'builder'"
         :disabled="disabled || !builderAvailable"
         :title="!builderAvailable ? 'Query cannot be edited in builder mode' : ''"
@@ -163,6 +164,7 @@ function getLabelValues(labelName: string): string[] {
         type="button"
         class="flex items-center gap-1.5 px-3 py-1.5 bg-transparent border-none rounded-sm text-xs font-medium text-text-secondary cursor-pointer transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:enabled:text-text-primary"
         :class="{ 'bg-surface-raised text-text-primary shadow-sm': mode === 'code' }"
+        data-testid="query-code-mode-btn"
         @click="mode = 'code'"
         :disabled="disabled"
       >
@@ -182,6 +184,7 @@ function getLabelValues(labelName: string): string[] {
             <input
               v-model="metricSearch"
               type="text"
+              data-testid="query-metric-search-input"
               class="w-full rounded-sm border border-border bg-surface-overlay px-3 py-2 pl-9 text-sm text-text-primary transition-colors duration-200 focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
               placeholder="Search metrics..."
               :disabled="disabled || loadingMetrics"
@@ -213,6 +216,7 @@ function getLabelValues(labelName: string): string[] {
           <button
             type="button"
             class="flex items-center gap-1.5 px-3 py-1.5 rounded-sm border border-border text-xs font-medium text-text-secondary cursor-pointer transition-all duration-200 hover:enabled:bg-surface-overlay hover:enabled:text-text-primary"
+            data-testid="query-add-filter-btn"
             @click="addLabelFilter"
             :disabled="disabled"
           >
@@ -298,6 +302,7 @@ function getLabelValues(labelName: string): string[] {
         <div class="flex gap-4 items-center">
           <select
             v-model="aggregation"
+            data-testid="query-aggregation-select"
             class="flex-1 max-w-[200px] rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm text-text-primary cursor-pointer focus:outline-none focus:border-accent"
             :disabled="disabled"
           >
@@ -312,6 +317,7 @@ function getLabelValues(labelName: string): string[] {
             <input
               v-model="rangeInterval"
               type="text"
+              data-testid="query-range-input"
               class="w-20 rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm font-mono text-text-primary focus:outline-none focus:border-accent"
               placeholder="5m"
               :disabled="disabled"
@@ -325,6 +331,7 @@ function getLabelValues(labelName: string): string[] {
               v-model.number="kValue"
               type="number"
               min="1"
+              data-testid="query-k-input"
               class="w-[60px] rounded-sm border border-border bg-surface-overlay px-3 py-2 text-sm text-text-primary focus:outline-none focus:border-accent"
               :disabled="disabled"
             />

--- a/frontend/src/components/QueryEditor.vue
+++ b/frontend/src/components/QueryEditor.vue
@@ -99,6 +99,7 @@ const previewData = computed(() => {
         placeholder="up"
         rows="3"
         :disabled="disabled || loading"
+        data-testid="promql-query-input"
         class="w-full rounded-sm border border-border bg-surface-raised px-4 py-3 font-mono text-sm text-text-primary resize-y min-h-[80px] transition-colors duration-200 placeholder:text-text-muted focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 disabled:bg-surface-overlay disabled:text-text-muted disabled:cursor-not-allowed"
         @keydown.ctrl.enter="runQuery"
       ></textarea>
@@ -107,6 +108,7 @@ const previewData = computed(() => {
           type="button"
           class="inline-flex items-center gap-1.5 px-4 py-2 bg-accent border border-accent rounded-sm text-white text-sm font-medium cursor-pointer transition-all duration-200 hover:enabled:bg-accent-hover hover:enabled:border-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
           :disabled="disabled || loading || !query.trim()"
+          data-testid="promql-run-btn"
           @click="runQuery"
         >
           <Play :size="14" />

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -150,6 +150,7 @@ defineExpose({ isPinned, sidebarWidth })
 <template>
   <!-- Single sidebar that transitions width -->
   <aside
+    data-testid="sidebar"
     class="fixed left-0 top-0 bottom-0 z-50 overflow-hidden border-r border-[#12122a] transition-[width] duration-200 ease-out"
     :style="{ width: sidebarWidth + 'px' }"
     style="background: linear-gradient(180deg, #0a0a18 0%, #060610 100%)"
@@ -182,6 +183,7 @@ defineExpose({ isPinned, sidebarWidth })
           ]"
           :style="isPinned ? '' : 'background: transparent'"
           :title="isPinned ? 'Unpin sidebar' : 'Pin sidebar'"
+          data-testid="sidebar-pin-btn"
           @click="togglePin"
         >
           <PinOff v-if="isPinned" :size="14" />
@@ -209,6 +211,7 @@ defineExpose({ isPinned, sidebarWidth })
                   : 'text-[#555a6e] hover:text-[#c8cad4] hover:bg-[#14142a]'
               ]"
               :style="isActive(item) ? 'background: radial-gradient(circle at 24px center, rgba(52,211,153,0.10) 0%, transparent 70%)' : ''"
+              :data-testid="`nav-${item.id}`"
               @click="handleNavItemClick(item)"
             >
               <component :is="item.icon" :size="20" class="shrink-0" />
@@ -219,6 +222,7 @@ defineExpose({ isPinned, sidebarWidth })
               <span
                 v-if="item.children && isOpen"
                 class="ml-auto inline-flex items-center justify-center w-5 h-5 text-[#555a6e] rounded hover:text-[#c8cad4]"
+                :data-testid="`nav-${item.id}-toggle`"
                 @click.stop="toggleNavGroup(item.id)"
               >
                 <ChevronDown
@@ -248,6 +252,7 @@ defineExpose({ isPinned, sidebarWidth })
                     ? 'text-accent font-medium'
                     : 'text-[#555a6e] hover:text-[#c8cad4] hover:bg-[#14142a]'
                 ]"
+                :data-testid="`nav-${item.id}-${child.label.toLowerCase()}`"
                 @click="navigate(child.path)"
               >
                 <span class="text-xs">{{ child.label }}</span>
@@ -269,6 +274,7 @@ defineExpose({ isPinned, sidebarWidth })
                 ? 'text-accent before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-0.5 before:rounded-r before:bg-accent'
                 : 'text-[#555a6e] hover:text-[#c8cad4] hover:bg-[#14142a]'
             ]"
+            data-testid="nav-settings"
             @click="navigate(settingsPath)"
           >
             <Settings :size="20" class="shrink-0" />
@@ -289,6 +295,7 @@ defineExpose({ isPinned, sidebarWidth })
                 ? 'text-accent before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-0.5 before:rounded-r before:bg-accent'
                 : 'text-[#555a6e] hover:text-[#c8cad4] hover:bg-[#14142a]'
             ]"
+            data-testid="nav-privacy"
             @click="navigate(privacySettingsPath)"
           >
             <Shield :size="20" class="shrink-0" />
@@ -304,6 +311,7 @@ defineExpose({ isPinned, sidebarWidth })
 
           <button
             class="group relative flex h-9 items-center gap-3 px-[14px] rounded-sm text-[#555a6e] hover:text-[#c8cad4] hover:bg-[#14142a] transition-colors duration-150 cursor-pointer border-none"
+            data-testid="nav-theme"
             @click="cycle()"
             :title="`Theme: ${mode}`"
           >
@@ -322,6 +330,7 @@ defineExpose({ isPinned, sidebarWidth })
 
           <button
             class="group relative flex h-9 items-center gap-3 px-[14px] rounded-sm text-[#555a6e] hover:text-rose-500 hover:bg-rose-500/10 transition-colors duration-150 cursor-pointer border-none mb-2"
+            data-testid="nav-logout"
             @click="handleLogout"
           >
             <LogOut :size="20" class="shrink-0" />

--- a/frontend/src/components/TimeRangePicker.vue
+++ b/frontend/src/components/TimeRangePicker.vue
@@ -142,6 +142,7 @@ onUnmounted(() => {
       <!-- Time select row -->
       <div class="flex items-center gap-2" :class="props.stacked ? 'w-full' : ''">
         <button
+          data-testid="time-range-picker-btn"
           class="flex items-center gap-2 rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary transition cursor-pointer hover:border-border-strong hover:bg-surface-overlay"
           :class="[
             isOpen ? 'border-accent ring-1 ring-accent/20' : '',
@@ -161,6 +162,7 @@ onUnmounted(() => {
         :class="props.stacked ? 'w-full flex-wrap' : ''"
       >
         <button
+          data-testid="time-range-refresh-btn"
           class="flex items-center justify-center rounded-sm border border-border bg-surface-raised px-2 py-1.5 text-text-muted transition cursor-pointer hover:bg-surface-overlay hover:text-text-primary"
           :class="isRefreshing ? 'text-accent' : ''"
           @click="handleRefresh"
@@ -172,6 +174,7 @@ onUnmounted(() => {
         <div>
           <select
             :value="refreshIntervalValue"
+            data-testid="time-range-interval-select"
             @change="selectRefreshInterval(($event.target as HTMLSelectElement).value)"
             title="Auto-refresh interval"
             class="rounded-sm border border-border bg-surface-raised px-2 py-1.5 pr-7 text-xs font-medium text-text-secondary cursor-pointer transition appearance-none hover:border-border-strong focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/20 bg-[url('data:image/svg+xml,%3Csvg_xmlns=%27http://www.w3.org/2000/svg%27_width=%2712%27_height=%2712%27_viewBox=%270_0_24_24%27_fill=%27none%27_stroke=%27%2394a3b8%27_stroke-width=%272%27_stroke-linecap=%27round%27_stroke-linejoin=%27round%27%3E%3Cpath_d=%27m6_9_6_6_6-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.5rem_center]"
@@ -237,6 +240,7 @@ onUnmounted(() => {
           <label for="custom-from" class="block mb-1.5 text-xs font-medium text-text-muted">From</label>
           <input
             id="custom-from"
+            data-testid="time-range-custom-from-input"
             type="datetime-local"
             v-model="customFrom"
             class="w-full rounded-sm border border-border bg-surface-raised px-2 py-1 text-xs text-text-primary focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/20"
@@ -247,6 +251,7 @@ onUnmounted(() => {
           <label for="custom-to" class="block mb-1.5 text-xs font-medium text-text-muted">To</label>
           <input
             id="custom-to"
+            data-testid="time-range-custom-to-input"
             type="datetime-local"
             v-model="customTo"
             class="w-full rounded-sm border border-border bg-surface-raised px-2 py-1 text-xs text-text-primary focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/20"
@@ -262,12 +267,14 @@ onUnmounted(() => {
 
         <div class="flex justify-end gap-2">
           <button
+            data-testid="time-range-cancel-btn"
             class="rounded-sm px-4 py-2 text-sm font-medium border border-border bg-transparent text-text-secondary cursor-pointer transition hover:bg-surface-overlay"
             @click="cancelCustomRange"
           >
             Cancel
           </button>
           <button
+            data-testid="time-range-apply-btn"
             class="rounded-sm px-4 py-2 text-sm font-medium border border-accent bg-accent text-white cursor-pointer transition hover:bg-accent-hover hover:border-accent-hover"
             @click="applyCustomRange"
           >

--- a/frontend/src/views/AlertsView.vue
+++ b/frontend/src/views/AlertsView.vue
@@ -452,6 +452,7 @@ onUnmounted(() => {
       <div class="flex items-center gap-2">
         <select
           v-model="selectedDatasourceId"
+          data-testid="alerts-datasource-select"
           class="px-3 py-2 pr-8 bg-surface-overlay border border-border rounded-sm text-text-primary text-sm appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.65rem_center] focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
           :disabled="alertingDatasources.length === 0"
         >
@@ -468,6 +469,7 @@ onUnmounted(() => {
         </select>
         <button
           class="inline-flex items-center justify-center gap-1.5 px-2.5 py-2 bg-surface-overlay border border-border rounded-sm text-sm font-medium text-text-secondary cursor-pointer transition hover:bg-surface-overlay disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid="alerts-refresh-btn"
           :disabled="!selectedDatasourceId || loading"
           @click="loadData"
           title="Refresh"
@@ -478,6 +480,7 @@ onUnmounted(() => {
         <button
           class="inline-flex items-center justify-center gap-1.5 px-2.5 py-2 rounded-sm text-sm font-medium cursor-pointer transition disabled:opacity-50 disabled:cursor-not-allowed"
           :class="autoRefresh ? 'bg-accent-muted border border-accent-border text-accent' : 'bg-surface-overlay border border-border text-text-primary hover:bg-surface-overlay'"
+          data-testid="alerts-auto-refresh-btn"
           :disabled="!selectedDatasourceId"
           @click="toggleAutoRefresh"
           title="Auto-refresh every 30s"
@@ -521,6 +524,7 @@ onUnmounted(() => {
         <button
           class="px-4 py-2.5 text-sm font-medium transition cursor-pointer border-b-2 bg-transparent"
           :class="activeTab === 'alerts' ? 'text-accent border-accent' : 'text-text-muted border-transparent hover:text-text-primary'"
+          data-testid="alerts-tab-alerts"
           @click="activeTab = 'alerts'"
         >
           Active Alerts
@@ -529,6 +533,7 @@ onUnmounted(() => {
         <button
           class="px-4 py-2.5 text-sm font-medium transition cursor-pointer border-b-2 bg-transparent"
           :class="activeTab === 'groups' ? 'text-accent border-accent' : 'text-text-muted border-transparent hover:text-text-primary'"
+          data-testid="alerts-tab-groups"
           @click="activeTab = 'groups'"
         >
           Rule Groups
@@ -666,6 +671,7 @@ onUnmounted(() => {
         <button
           class="px-4 py-2.5 text-sm font-medium transition cursor-pointer border-b-2 bg-transparent"
           :class="activeTab === 'am-alerts' ? 'text-accent border-accent' : 'text-text-muted border-transparent hover:text-text-primary'"
+          data-testid="alerts-tab-am-alerts"
           @click="activeTab = 'am-alerts'"
         >
           Active Alerts
@@ -674,6 +680,7 @@ onUnmounted(() => {
         <button
           class="px-4 py-2.5 text-sm font-medium transition cursor-pointer border-b-2 bg-transparent"
           :class="activeTab === 'am-silences' ? 'text-accent border-accent' : 'text-text-muted border-transparent hover:text-text-primary'"
+          data-testid="alerts-tab-am-silences"
           @click="activeTab = 'am-silences'"
         >
           Silences
@@ -682,6 +689,7 @@ onUnmounted(() => {
         <button
           class="px-4 py-2.5 text-sm font-medium transition cursor-pointer border-b-2 bg-transparent"
           :class="activeTab === 'am-receivers' ? 'text-accent border-accent' : 'text-text-muted border-transparent hover:text-text-primary'"
+          data-testid="alerts-tab-am-receivers"
           @click="activeTab = 'am-receivers'"
         >
           Receivers
@@ -696,16 +704,19 @@ onUnmounted(() => {
           <button
             class="px-2.5 py-1 border rounded-sm text-xs cursor-pointer transition"
             :class="amFilterActive ? 'bg-accent-muted border-accent-border text-accent' : 'bg-surface-overlay border-border text-text-muted hover:bg-surface-overlay'"
+            data-testid="alerts-filter-active-btn"
             @click="amFilterActive = !amFilterActive"
           >Active</button>
           <button
             class="px-2.5 py-1 border rounded-sm text-xs cursor-pointer transition"
             :class="amFilterSilenced ? 'bg-accent-muted border-accent-border text-accent' : 'bg-surface-overlay border-border text-text-muted hover:bg-surface-overlay'"
+            data-testid="alerts-filter-silenced-btn"
             @click="amFilterSilenced = !amFilterSilenced"
           >Silenced</button>
           <button
             class="px-2.5 py-1 border rounded-sm text-xs cursor-pointer transition"
             :class="amFilterInhibited ? 'bg-accent-muted border-accent-border text-accent' : 'bg-surface-overlay border-border text-text-muted hover:bg-surface-overlay'"
+            data-testid="alerts-filter-inhibited-btn"
             @click="amFilterInhibited = !amFilterInhibited"
           >Inhibited</button>
         </div>
@@ -753,6 +764,7 @@ onUnmounted(() => {
         <div class="flex items-center justify-between mb-4">
           <h3 class="text-sm font-semibold text-text-primary m-0">Silences</h3>
           <button
+            data-testid="alerts-new-silence-btn"
             class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-accent text-white text-sm font-medium rounded-sm hover:bg-accent-hover transition cursor-pointer"
             @click="openSilenceModal"
           >
@@ -906,6 +918,7 @@ onUnmounted(() => {
                 <label for="silence-start" class="text-sm font-medium text-text-secondary">Start</label>
                 <input
                   id="silence-start"
+                  data-testid="silence-start-input"
                   v-model="silenceStart"
                   type="datetime-local"
                   class="px-3 py-2 bg-surface-overlay border border-border rounded-sm text-sm text-text-primary focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
@@ -915,6 +928,7 @@ onUnmounted(() => {
                 <label for="silence-end" class="text-sm font-medium text-text-secondary">End</label>
                 <input
                   id="silence-end"
+                  data-testid="silence-end-input"
                   v-model="silenceEnd"
                   type="datetime-local"
                   class="px-3 py-2 bg-surface-overlay border border-border rounded-sm text-sm text-text-primary focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
@@ -927,6 +941,7 @@ onUnmounted(() => {
               <label for="silence-created-by" class="text-sm font-medium text-text-secondary">Created By</label>
               <input
                 id="silence-created-by"
+                data-testid="silence-created-by-input"
                 v-model="silenceCreatedBy"
                 type="text"
                 placeholder="your-name@example.com"
@@ -939,6 +954,7 @@ onUnmounted(() => {
               <label for="silence-comment" class="text-sm font-medium text-text-secondary">Comment <span class="text-rose-500">*</span></label>
               <textarea
                 id="silence-comment"
+                data-testid="silence-comment-input"
                 v-model="silenceComment"
                 rows="3"
                 placeholder="Reason for silencing..."
@@ -956,6 +972,7 @@ onUnmounted(() => {
           <div class="flex justify-end gap-2.5 px-5 py-4 border-t border-border">
             <button
               class="inline-flex items-center gap-1.5 px-3 py-2 bg-surface-overlay border border-border rounded-sm text-sm font-medium text-text-secondary cursor-pointer transition hover:bg-surface-overlay disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="silence-cancel-btn"
               @click="closeSilenceModal"
               :disabled="silenceSaving"
             >
@@ -963,6 +980,7 @@ onUnmounted(() => {
             </button>
             <button
               class="inline-flex items-center gap-1.5 px-4 py-2 bg-accent border border-accent rounded-sm text-sm font-medium text-white cursor-pointer transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="silence-create-btn"
               @click="handleCreateSilence"
               :disabled="silenceSaving"
             >

--- a/frontend/src/views/DashboardDetailView.vue
+++ b/frontend/src/views/DashboardDetailView.vue
@@ -368,6 +368,7 @@ onUnmounted(() => {
       <div class="flex items-center gap-4">
         <button
           class="flex h-[38px] w-[38px] items-center justify-center rounded-sm border border-border bg-surface-raised text-text-muted transition hover:bg-surface-overlay hover:text-text-primary"
+          data-testid="dashboard-back-btn"
           @click="goBack"
           title="Back to Dashboards"
         >
@@ -395,6 +396,7 @@ onUnmounted(() => {
         </button>
         <button
           class="inline-flex items-center gap-2 rounded-sm bg-accent px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+          data-testid="dashboard-add-panel-btn"
           @click="openAddPanel"
           :disabled="loading"
         >
@@ -484,6 +486,7 @@ onUnmounted(() => {
     <div
       v-if="showDeleteConfirm"
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in"
+      data-testid="delete-panel-modal"
       @click.self="cancelDelete"
     >
       <div class="w-full max-w-[400px] rounded border border-border bg-surface-raised p-8 text-center shadow-lg animate-slide-up">
@@ -496,10 +499,12 @@ onUnmounted(() => {
         <div class="mt-6 flex justify-center gap-3">
           <button
             class="inline-flex items-center gap-2 rounded-sm border border-border px-3 py-1.5 text-sm font-semibold text-text-secondary transition hover:bg-surface-overlay hover:text-text-primary"
+            data-testid="delete-panel-cancel-btn"
             @click="cancelDelete"
           >Cancel</button>
           <button
             class="inline-flex items-center gap-2 rounded-sm bg-rose-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-rose-700"
+            data-testid="delete-panel-confirm-btn"
             @click="handleDeletePanel"
           >Delete</button>
         </div>

--- a/frontend/src/views/DashboardSettingsView.vue
+++ b/frontend/src/views/DashboardSettingsView.vue
@@ -553,6 +553,7 @@ onMounted(async () => {
     <!-- Page header -->
     <button
       class="flex items-center gap-1 text-sm text-text-muted hover:text-text-primary transition mb-4"
+      data-testid="dashboard-settings-back-btn"
       @click="goBack"
       title="Back to Dashboard"
     >
@@ -602,6 +603,7 @@ onMounted(async () => {
               <label for="dashboard-name" class="text-sm font-medium text-text-secondary">Name</label>
               <input
                 id="dashboard-name"
+                data-testid="dashboard-name-input"
                 v-model="title"
                 type="text"
                 class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
@@ -614,6 +616,7 @@ onMounted(async () => {
               <label for="dashboard-description" class="text-sm font-medium text-text-secondary">Description</label>
               <textarea
                 id="dashboard-description"
+                data-testid="dashboard-description-input"
                 v-model="description"
                 rows="3"
                 class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition min-h-[100px] resize-y disabled:opacity-60 disabled:cursor-not-allowed"
@@ -626,6 +629,7 @@ onMounted(async () => {
               <label for="dashboard-time-range" class="text-sm font-medium text-text-secondary">Default time range</label>
               <select
                 id="dashboard-time-range"
+                data-testid="dashboard-time-range-select"
                 v-model="timeRangePreset"
                 class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
                 :disabled="!canEdit || isSaving"
@@ -640,6 +644,7 @@ onMounted(async () => {
               <label for="dashboard-refresh" class="text-sm font-medium text-text-secondary">Refresh interval</label>
               <select
                 id="dashboard-refresh"
+                data-testid="dashboard-refresh-select"
                 v-model="refreshInterval"
                 class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
                 :disabled="!canEdit || isSaving"
@@ -667,6 +672,7 @@ onMounted(async () => {
             <button
               type="button"
               class="inline-flex items-center gap-1.5 rounded-sm border border-border-strong px-5 py-2.5 text-sm font-semibold text-text-primary transition hover:border-border-strong"
+              data-testid="dashboard-export-yaml-btn"
               :disabled="isExporting"
               @click="exportSettings"
             >

--- a/frontend/src/views/DataSourceCreateView.vue
+++ b/frontend/src/views/DataSourceCreateView.vue
@@ -592,7 +592,7 @@ watch(
       {{ loadError }}
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSave">
+    <form v-else class="flex flex-col gap-4" data-testid="ds-create-form" @submit.prevent="handleSave">
       <section class="rounded border border-border bg-surface-raised p-6">
         <h2 class="text-sm font-semibold text-text-primary mb-3 mt-0">Basics</h2>
         <div class="grid grid-cols-2 gap-3 max-md:grid-cols-1">
@@ -600,6 +600,7 @@ watch(
             <label for="ds-name" class="block text-sm font-medium text-text-primary mb-1.5">Name <span class="text-rose-500">*</span></label>
             <input
               id="ds-name"
+              data-testid="ds-name-input"
               v-model="formName"
               type="text"
               placeholder="My Prometheus"
@@ -613,6 +614,7 @@ watch(
             <label for="ds-type" class="block text-sm font-medium text-text-primary mb-1.5">Type</label>
             <select
               id="ds-type"
+              data-testid="ds-type-select"
               v-model="formType"
               :disabled="saveLoading"
               class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-9"
@@ -636,6 +638,7 @@ watch(
           <label for="ds-url" class="block text-sm font-medium text-text-primary mb-1.5">URL <span class="text-rose-500">*</span></label>
           <input
             id="ds-url"
+            data-testid="ds-url-input"
             v-model="formUrl"
             type="text"
             placeholder="http://localhost:9090"
@@ -653,6 +656,7 @@ watch(
             <label for="ds-cloudwatch-region" class="block text-sm font-medium text-text-primary mb-1.5">AWS Region <span class="text-rose-500">*</span></label>
             <input
               id="ds-cloudwatch-region"
+              data-testid="ds-cloudwatch-region-input"
               v-model="formCloudWatchRegion"
               type="text"
               placeholder="us-east-1"
@@ -735,6 +739,7 @@ watch(
           <label for="ds-database" class="block text-sm font-medium text-text-primary mb-1.5">Database (optional)</label>
           <input
             id="ds-database"
+            data-testid="ds-database-input"
             v-model="formDatabase"
             type="text"
             placeholder="default"
@@ -751,6 +756,7 @@ watch(
           <label for="ds-elasticsearch-index" class="block text-sm font-medium text-text-primary mb-1.5">Default Index Pattern (optional)</label>
           <input
             id="ds-elasticsearch-index"
+            data-testid="ds-elasticsearch-index-input"
             v-model="formElasticsearchIndex"
             type="text"
             placeholder="logs-*"
@@ -838,6 +844,7 @@ watch(
           <label for="ds-auth-type" class="block text-sm font-medium text-text-primary mb-1.5">Authentication</label>
           <select
             id="ds-auth-type"
+            data-testid="ds-auth-type-select"
             v-model="formAuthType"
             :disabled="saveLoading"
             class="w-full rounded-sm border border-border bg-surface-raised px-3 py-2.5 text-sm text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-9"
@@ -855,6 +862,7 @@ watch(
               <label for="ds-basic-username" class="block text-sm font-medium text-text-primary mb-1.5">Username <span class="text-rose-500">*</span></label>
               <input
                 id="ds-basic-username"
+                data-testid="ds-basic-username-input"
                 v-model="formBasicUsername"
                 type="text"
                 :disabled="saveLoading"
@@ -866,6 +874,7 @@ watch(
               <label for="ds-basic-password" class="block text-sm font-medium text-text-primary mb-1.5">Password</label>
               <input
                 id="ds-basic-password"
+                data-testid="ds-basic-password-input"
                 v-model="formBasicPassword"
                 type="password"
                 :disabled="saveLoading"
@@ -881,6 +890,7 @@ watch(
             <label for="ds-bearer-token" class="block text-sm font-medium text-text-primary mb-1.5">Bearer token <span class="text-rose-500">*</span></label>
             <input
               id="ds-bearer-token"
+              data-testid="ds-bearer-token-input"
               v-model="formBearerToken"
               type="password"
               :disabled="saveLoading"
@@ -896,6 +906,7 @@ watch(
               <label for="ds-api-header" class="block text-sm font-medium text-text-primary mb-1.5">Header name</label>
               <input
                 id="ds-api-header"
+                data-testid="ds-api-header-input"
                 v-model="formApiKeyHeader"
                 type="text"
                 :disabled="saveLoading"
@@ -907,6 +918,7 @@ watch(
               <label for="ds-api-value" class="block text-sm font-medium text-text-primary mb-1.5">API key <span class="text-rose-500">*</span></label>
               <input
                 id="ds-api-value"
+                data-testid="ds-api-value-input"
                 v-model="formApiKeyValue"
                 type="password"
                 :disabled="saveLoading"
@@ -927,6 +939,7 @@ watch(
           <button
             type="button"
             class="inline-flex items-center justify-center gap-2 rounded-sm border border-border-strong px-4 py-2 text-sm font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="ds-test-btn"
             :disabled="testLoading || saveLoading"
             @click="handleTestConnection"
           >
@@ -951,7 +964,7 @@ watch(
 
       <section class="rounded border border-border bg-surface-raised px-6 py-4">
         <label class="inline-flex items-center gap-2 cursor-pointer text-sm text-text-primary">
-          <input type="checkbox" v-model="formIsDefault" :disabled="saveLoading" class="h-4 w-4" />
+          <input type="checkbox" v-model="formIsDefault" data-testid="ds-default-checkbox" :disabled="saveLoading" class="h-4 w-4" />
           Set as default data source
         </label>
       </section>
@@ -962,6 +975,7 @@ watch(
         <button
           type="button"
           class="inline-flex items-center justify-center gap-2 rounded-sm border border-border-strong px-4 py-2 text-sm font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed max-md:w-full"
+          data-testid="ds-cancel-btn"
           :disabled="saveLoading"
           @click="router.push('/datasources')"
         >
@@ -969,6 +983,7 @@ watch(
         </button>
         <button
           type="submit"
+          data-testid="ds-save-btn"
           class="inline-flex items-center justify-center gap-2 rounded-sm bg-accent px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed max-md:w-full"
           :disabled="saveLoading"
         >

--- a/frontend/src/views/DataSourceSettings.vue
+++ b/frontend/src/views/DataSourceSettings.vue
@@ -139,6 +139,7 @@ watch(
       <div class="flex items-center gap-2.5">
         <button
           class="inline-flex items-center justify-center gap-2 rounded-sm border border-border-strong px-4 py-2 text-sm font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed min-w-[96px]"
+          data-testid="ds-test-all-btn"
           :disabled="datasources.length === 0 || testAllLoading"
           @click="testAllDatasources"
         >
@@ -148,6 +149,7 @@ watch(
         </button>
         <button
           class="inline-flex items-center justify-center gap-2 rounded-sm bg-accent px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid="ds-add-btn"
           :disabled="!canCreate"
           @click="openCreatePage"
         >
@@ -183,6 +185,7 @@ watch(
         v-for="ds in datasources"
         :key="ds.id"
         class="rounded border border-border bg-surface-raised transition hover:border-accent-border hover:shadow-md"
+        :data-testid="`ds-card-${ds.id}`"
       >
         <div class="flex justify-between items-start p-4 pb-0 gap-3">
           <div class="flex items-start flex-wrap gap-2.5 min-w-0">
@@ -203,10 +206,10 @@ watch(
             </span>
           </div>
           <div class="flex gap-1">
-            <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition border-none bg-transparent cursor-pointer" @click="openEditPage(ds.id)" title="Edit">
+            <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-surface-overlay hover:text-text-secondary transition border-none bg-transparent cursor-pointer" :data-testid="`ds-edit-${ds.id}`" @click="openEditPage(ds.id)" title="Edit">
               <Pencil :size="16" />
             </button>
-            <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-rose-500/10 hover:text-rose-500 transition border-none bg-transparent cursor-pointer" @click="handleDelete(ds)" title="Delete">
+            <button class="flex items-center justify-center h-8 w-8 rounded-sm text-text-muted hover:bg-rose-500/10 hover:text-rose-500 transition border-none bg-transparent cursor-pointer" :data-testid="`ds-delete-${ds.id}`" @click="handleDelete(ds)" title="Delete">
               <Trash2 :size="16" />
             </button>
           </div>
@@ -239,6 +242,7 @@ watch(
 
             <button
               class="inline-flex items-center justify-center gap-1.5 rounded-sm border border-border-strong px-2.5 py-1 text-xs font-semibold text-text-primary transition hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
+              :data-testid="`ds-test-${ds.id}`"
               :disabled="getHealthStatus(ds.id) === 'checking'"
               @click="testDatasource(ds)"
               title="Run connection test"

--- a/frontend/src/views/Explore.vue
+++ b/frontend/src/views/Explore.vue
@@ -529,6 +529,7 @@ watch(selectedDatasourceId, () => {
               <button
                 type="button"
                 class="flex w-full items-center gap-3 rounded border border-border bg-surface-raised px-4 py-3 text-left cursor-pointer transition hover:border-border-strong hover:bg-surface-overlay disabled:opacity-60 disabled:cursor-not-allowed"
+                data-testid="explore-datasource-btn"
                 :disabled="loading || !hasMetricsDatasources"
                 @click="toggleDatasourceMenu"
                 :title="activeDatasource ? `Active datasource: ${activeDatasource.name}` : 'No metrics datasource configured'"
@@ -625,6 +626,7 @@ watch(selectedDatasourceId, () => {
           <!-- History button -->
           <div v-if="queryHistory.length > 0" class="relative">
             <button
+              data-testid="explore-history-btn"
               class="flex items-center gap-1 text-sm text-text-muted hover:text-text-primary cursor-pointer"
               :class="{ 'text-text-primary': showHistory }"
               @click="showHistory = !showHistory"
@@ -656,6 +658,7 @@ watch(selectedDatasourceId, () => {
 
         <div class="flex items-center gap-4">
           <button
+            data-testid="explore-run-query-btn"
             class="inline-flex items-center gap-2 rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
             :disabled="loading || !query.trim() || !selectedDatasourceId || !hasMetricsDatasources"
             @click="runQuery"

--- a/frontend/src/views/ExploreLogs.vue
+++ b/frontend/src/views/ExploreLogs.vue
@@ -892,6 +892,7 @@ watch(
               <button
                 type="button"
                 class="flex w-full items-center gap-3 rounded border border-border bg-surface-raised px-4 py-3 text-left cursor-pointer transition hover:border-border-strong hover:bg-surface-overlay disabled:opacity-60 disabled:cursor-not-allowed"
+                data-testid="explore-logs-datasource-btn"
                 :disabled="loading || !hasLogsDatasources"
                 @click="toggleDatasourceMenu"
                 :title="activeDatasource ? `Active datasource: ${activeDatasource.name}` : 'No logs datasource configured'"
@@ -998,6 +999,7 @@ watch(
           <!-- History button -->
           <div v-if="queryHistory.length > 0" class="relative">
             <button
+              data-testid="explore-logs-history-btn"
               class="flex items-center gap-1 text-sm text-text-muted hover:text-text-primary cursor-pointer"
               :class="{ 'text-text-primary': showHistory }"
               @click="showHistory = !showHistory"
@@ -1029,6 +1031,7 @@ watch(
 
         <div class="flex items-center gap-4 flex-wrap">
           <button
+            data-testid="explore-logs-run-query-btn"
             class="inline-flex items-center gap-2 rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
             :disabled="loading || !query.trim() || !selectedDatasourceId || !hasLogsDatasources"
             @click="runQuery"
@@ -1042,6 +1045,7 @@ watch(
             :class="isLive
               ? 'border-accent-border bg-accent-muted text-accent hover:bg-accent-muted'
               : 'border-border bg-surface-raised text-text-primary hover:bg-surface-overlay hover:border-border-strong'"
+            data-testid="explore-logs-live-btn"
             :disabled="loading || !supportsLiveStreaming || (!isLive && (!query.trim() || !selectedDatasourceId || !hasLogsDatasources))"
             @click="toggleLive"
             :title="supportsLiveStreaming ? '' : 'Live streaming is only available for Loki and Victoria Logs datasources'"

--- a/frontend/src/views/ExploreTraces.vue
+++ b/frontend/src/views/ExploreTraces.vue
@@ -780,6 +780,7 @@ onUnmounted(() => {
               <button
                 type="button"
                 class="flex w-full items-center gap-3 rounded border border-border bg-surface-raised px-4 py-3 text-left cursor-pointer transition hover:border-border-strong hover:bg-surface-overlay disabled:opacity-60 disabled:cursor-not-allowed"
+                data-testid="explore-traces-datasource-btn"
                 :disabled="!hasTracingDatasources"
                 @click="toggleDatasourceMenu"
               >
@@ -854,6 +855,7 @@ onUnmounted(() => {
               <span class="text-xs font-medium text-text-muted">Service</span>
               <select
                 v-model="selectedService"
+                data-testid="explore-traces-service-select"
                 :disabled="loadingServices || services.length === 0"
                 class="rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -866,6 +868,7 @@ onUnmounted(() => {
               <span class="text-xs font-medium text-text-muted">Limit</span>
               <select
                 v-model.number="limit"
+                data-testid="explore-traces-limit-select"
                 class="rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary"
               >
                 <option :value="10">10</option>
@@ -891,6 +894,7 @@ onUnmounted(() => {
           <input
             id="trace-search-query"
             v-model="query"
+            data-testid="explore-traces-search-input"
             type="text"
             class="rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary placeholder:text-text-muted"
             placeholder="service.name=api error=true"
@@ -900,6 +904,7 @@ onUnmounted(() => {
         <!-- Search button -->
         <div class="flex items-center gap-4">
           <button
+            data-testid="explore-traces-search-btn"
             class="inline-flex items-center gap-2 rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
             :disabled="loadingSearch || !selectedDatasourceId || (isClickHouseDatasource && !query.trim())"
             @click="runSearch"
@@ -917,11 +922,13 @@ onUnmounted(() => {
             <input
               id="trace-id-input"
               v-model="traceIdInput"
+              data-testid="explore-traces-id-input"
               type="text"
               placeholder="Paste trace id"
               class="flex-1 rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary placeholder:text-text-muted"
             />
             <button
+              data-testid="explore-traces-open-btn"
               class="inline-flex items-center gap-2 rounded-sm border border-border bg-surface-overlay px-4 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-overlay disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
               :disabled="loadingTrace || !selectedDatasourceId || !traceIdInput.trim()"
               @click="lookupTraceById"

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -60,8 +60,8 @@ function switchMode() {
         </p>
       </div>
 
-      <form class="flex flex-col gap-5" @submit.prevent="handleSubmit">
-        <div v-if="error" class="flex items-center gap-2 rounded-sm bg-rose-500/10 border border-rose-500/20 px-4 py-3 text-sm text-rose-400">
+      <form class="flex flex-col gap-5" @submit.prevent="handleSubmit" data-testid="login-form">
+        <div v-if="error" class="flex items-center gap-2 rounded-sm bg-rose-500/10 border border-rose-500/20 px-4 py-3 text-sm text-rose-400" data-testid="login-error">
           <AlertCircle :size="16" class="shrink-0" />
           <span>{{ error }}</span>
         </div>
@@ -76,6 +76,7 @@ function switchMode() {
               type="text"
               placeholder="Your name (optional)"
               :disabled="loading"
+              data-testid="name-input"
               class="w-full rounded-sm border border-border bg-surface-input pl-11 pr-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </div>
@@ -92,6 +93,7 @@ function switchMode() {
               placeholder="you@example.com"
               required
               :disabled="loading"
+              data-testid="email-input"
               class="w-full rounded-sm border border-border bg-surface-input pl-11 pr-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </div>
@@ -108,6 +110,7 @@ function switchMode() {
               placeholder="Enter your password"
               required
               :disabled="loading"
+              data-testid="password-input"
               class="w-full rounded-sm border border-border bg-surface-input pl-11 pr-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 focus:outline-none transition disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </div>
@@ -121,6 +124,7 @@ function switchMode() {
           class="flex w-full items-center justify-center gap-2 rounded-sm py-2.5 text-sm font-semibold text-white transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
           style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); box-shadow: 0 1px 3px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.1)"
           :disabled="loading"
+          data-testid="login-submit-btn"
         >
           <template v-if="loading">
             <span class="animate-spin h-4 w-4 rounded-full border-2 border-white/30 border-t-white"></span>
@@ -137,7 +141,7 @@ function switchMode() {
       <div class="mt-6 text-center">
         <p class="text-sm text-text-muted">
           {{ mode === 'login' ? "Don't have an account?" : 'Already have an account?' }}
-          <button type="button" class="ml-1 text-sm text-accent hover:underline cursor-pointer bg-transparent border-none p-0 font-medium" @click="switchMode">
+          <button type="button" class="ml-1 text-sm text-accent hover:underline cursor-pointer bg-transparent border-none p-0 font-medium" @click="switchMode" data-testid="auth-mode-switch-btn">
             {{ mode === 'login' ? 'Create one' : 'Sign in' }}
           </button>
         </p>

--- a/frontend/src/views/OrgBrandingSettings.vue
+++ b/frontend/src/views/OrgBrandingSettings.vue
@@ -125,6 +125,7 @@ async function handleSave() {
       <p class="m-0 mb-3 text-sm text-text-muted">Custom title replaces "Ace" in the sidebar header.</p>
       <input
         v-model="appTitle"
+        data-testid="branding-title-input"
         type="text"
         maxlength="100"
         placeholder="Ace"
@@ -140,12 +141,14 @@ async function handleSave() {
       <div class="flex items-center gap-3">
         <input
           v-model="primaryColor"
+          data-testid="branding-color-picker"
           type="color"
           :disabled="!isAdmin"
           class="h-10 w-12 cursor-pointer rounded border border-border bg-surface-raised p-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
         />
         <input
           v-model="primaryColor"
+          data-testid="branding-color-input"
           type="text"
           maxlength="7"
           placeholder="#10b981"
@@ -183,6 +186,7 @@ async function handleSave() {
         <img :src="logoDataURI" alt="Logo preview" class="h-14 w-14 rounded-sm border border-border object-contain bg-surface-overlay p-1" />
         <button
           v-if="isAdmin"
+          data-testid="branding-remove-logo-btn"
           class="inline-flex items-center gap-1.5 rounded-sm border border-rose-500/25 bg-surface-raised px-3 py-1.5 text-sm font-medium text-rose-500 transition hover:bg-rose-500/10 cursor-pointer"
           @click="removeLogo"
         >Remove logo</button>
@@ -190,6 +194,7 @@ async function handleSave() {
 
       <input
         type="file"
+        data-testid="branding-logo-upload"
         accept="image/png,image/jpeg,image/svg+xml,image/gif,image/webp"
         :disabled="!isAdmin"
         class="block w-full max-w-sm text-sm text-text-muted file:mr-3 file:rounded-sm file:border-0 file:bg-accent-muted file:px-4 file:py-2 file:text-sm file:font-semibold file:text-accent file:cursor-pointer hover:file:bg-accent-muted disabled:opacity-50"
@@ -241,6 +246,7 @@ async function handleSave() {
     <div class="flex items-center gap-3">
       <button
         v-if="isAdmin"
+        data-testid="branding-save-btn"
         class="inline-flex items-center gap-1.5 rounded-sm bg-accent px-4 py-2 text-sm font-semibold text-white transition hover:bg-accent-hover cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         :disabled="saving"
         @click="handleSave"

--- a/frontend/src/views/OrganizationSettings.vue
+++ b/frontend/src/views/OrganizationSettings.vue
@@ -765,6 +765,7 @@ function goBack() {
     <header class="flex items-center gap-4 mb-5 p-4 border border-border rounded bg-surface-raised">
       <button
         class="flex items-center justify-center w-10 h-10 bg-surface-overlay border border-border rounded text-text-secondary cursor-pointer transition-all duration-200 hover:bg-surface-overlay hover:text-text-primary"
+        data-testid="org-settings-back-btn"
         @click="goBack"
       >
         <ArrowLeft :size="20" />
@@ -803,6 +804,7 @@ function goBack() {
           <button
             v-if="isAdmin && !editMode"
             class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-overlay text-text-primary border border-border rounded-sm text-[0.8125rem] font-medium cursor-pointer transition-all duration-200 hover:bg-surface-overlay hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="org-edit-btn"
             @click="startEdit"
           >
             <Edit2 :size="16" />
@@ -816,6 +818,7 @@ function goBack() {
             <input
               v-model="editName"
               type="text"
+              data-testid="org-name-input"
               class="w-full px-3 py-2.5 bg-surface-overlay border border-border rounded-sm text-sm text-text-primary outline-none transition-colors focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-50"
               :disabled="editLoading"
             />
@@ -824,6 +827,7 @@ function goBack() {
             <label class="block mb-1.5 text-sm font-medium text-text-primary">URL Slug</label>
             <input
               v-model="editSlug"
+              data-testid="org-slug-input"
               type="text"
               class="w-full px-3 py-2.5 bg-surface-overlay border border-border rounded-sm text-sm text-text-primary outline-none transition-colors focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-50"
               :disabled="editLoading"
@@ -833,11 +837,13 @@ function goBack() {
           <div class="flex justify-end gap-3 mt-4">
             <button
               class="inline-flex items-center gap-1.5 px-4 py-2.5 bg-surface-overlay text-text-primary border border-border rounded-sm text-sm font-medium cursor-pointer transition-all duration-200 hover:bg-surface-overlay hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="org-edit-cancel-btn"
               @click="cancelEdit"
               :disabled="editLoading"
             >Cancel</button>
             <button
               class="inline-flex items-center gap-1.5 px-4 py-2.5 bg-accent text-white border-none rounded-sm text-sm font-semibold cursor-pointer transition-all duration-200 hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="org-edit-save-btn"
               @click="saveEdit"
               :disabled="editLoading"
             >
@@ -879,6 +885,7 @@ function goBack() {
           <button
             v-if="isAdmin"
             class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-accent text-white border-none rounded-sm text-[0.8125rem] font-semibold cursor-pointer transition-all duration-200 hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="org-invite-btn"
             @click="showInviteForm = !showInviteForm"
           >
             <UserPlus :size="16" />
@@ -893,11 +900,13 @@ function goBack() {
               v-model="inviteEmail"
               type="email"
               placeholder="Email address"
+              data-testid="org-invite-email-input"
               class="flex-1 px-3 py-2.5 bg-surface-overlay border border-border rounded-sm text-sm text-text-primary outline-none transition-colors focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-50"
               :disabled="inviteLoading"
             />
             <select
               v-model="inviteRole"
+              data-testid="org-invite-role-select"
               class="w-full md:w-[120px] px-3 py-2.5 bg-surface-overlay border border-border rounded-sm text-sm text-text-primary cursor-pointer outline-none transition-colors focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-50"
               :disabled="inviteLoading"
             >
@@ -907,6 +916,7 @@ function goBack() {
             </select>
             <button
               class="inline-flex items-center gap-1.5 px-4 py-2.5 bg-accent text-white border-none rounded-sm text-sm font-semibold cursor-pointer transition-all duration-200 hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="org-invite-submit-btn"
               @click="handleInvite"
               :disabled="inviteLoading"
             >
@@ -919,7 +929,7 @@ function goBack() {
 
         <!-- Members List -->
         <div class="flex flex-col gap-2">
-          <div v-for="member in members" :key="member.id" class="flex items-center gap-3 p-3 bg-surface-overlay rounded border border-border">
+          <div v-for="member in members" :key="member.id" :data-testid="`member-row-${member.id}`" class="flex items-center gap-3 p-3 bg-surface-overlay rounded border border-border">
             <div class="w-9 h-9 flex items-center justify-center bg-accent rounded-sm text-sm font-semibold text-white shrink-0">
               {{ (member.name || member.email).charAt(0).toUpperCase() }}
             </div>
@@ -931,6 +941,7 @@ function goBack() {
               <select
                 v-if="isAdmin"
                 :value="member.role"
+                :data-testid="`member-role-${member.id}`"
                 @change="handleRoleChange(member, ($event.target as HTMLSelectElement).value as MembershipRole)"
                 class="w-auto px-2 py-1.5 text-xs bg-surface-overlay border border-border rounded-sm text-text-primary cursor-pointer outline-none transition-colors focus:border-accent focus:ring-1 focus:ring-accent"
               >
@@ -950,6 +961,7 @@ function goBack() {
               <button
                 v-if="isAdmin"
                 class="flex items-center justify-center w-8 h-8 bg-transparent border-none rounded-sm text-text-secondary cursor-pointer transition-all duration-200 hover:bg-rose-500/15 hover:text-rose-500"
+                :data-testid="`member-remove-${member.id}`"
                 @click="handleRemoveMember(member)"
                 title="Remove member"
               >
@@ -1285,6 +1297,7 @@ function goBack() {
             </div>
             <button
               class="inline-flex items-center gap-1.5 px-4 py-2.5 bg-rose-500 text-white border-none rounded-sm text-sm font-semibold cursor-pointer transition-all duration-200 hover:bg-rose-600 disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="org-delete-btn"
               @click="showDeleteConfirm = true"
             >Delete Organization</button>
           </div>
@@ -1294,7 +1307,7 @@ function goBack() {
     </div>
 
     <!-- Delete Confirmation Modal -->
-    <div v-if="showDeleteConfirm" class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[1000]" @click.self="showDeleteConfirm = false">
+    <div v-if="showDeleteConfirm" class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[1000]" data-testid="org-delete-modal" @click.self="showDeleteConfirm = false">
       <div class="bg-surface-raised border border-border rounded p-6 max-w-[400px]">
         <h3 class="m-0 mb-3 text-lg font-semibold text-text-primary">Delete Organization?</h3>
         <p class="m-0 mb-6 text-sm text-text-secondary">
@@ -1304,6 +1317,7 @@ function goBack() {
         <div class="flex justify-end gap-3">
           <button
             class="inline-flex items-center gap-1.5 px-4 py-2.5 bg-surface-overlay text-text-primary border border-border rounded-sm text-sm font-medium cursor-pointer transition-all duration-200 hover:bg-surface-overlay hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="org-delete-cancel-btn"
             @click="showDeleteConfirm = false"
             :disabled="deleteLoading"
           >
@@ -1311,6 +1325,7 @@ function goBack() {
           </button>
           <button
             class="inline-flex items-center gap-1.5 px-4 py-2.5 bg-rose-500 text-white border-none rounded-sm text-sm font-semibold cursor-pointer transition-all duration-200 hover:bg-rose-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="org-delete-confirm-btn"
             @click="handleDelete"
             :disabled="deleteLoading"
           >

--- a/frontend/src/views/PrivacySettingsView.vue
+++ b/frontend/src/views/PrivacySettingsView.vue
@@ -50,6 +50,7 @@ function toggleSessionRecording(event: Event) {
           <span class="text-xs text-text-secondary mt-1">Anonymous usage events for page visits, dashboard actions, and settings interactions.</span>
         </div>
         <button
+          data-testid="analytics-consent-switch"
           class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition"
           :class="analyticsEnabled ? 'bg-accent' : 'bg-surface-overlay'"
           :disabled="dntEnabled"
@@ -71,6 +72,7 @@ function toggleSessionRecording(event: Event) {
           <span class="text-xs text-text-secondary mt-1">Optional replay sessions to debug UI flows. Requires analytics to be enabled.</span>
         </div>
         <button
+          data-testid="session-recording-switch"
           class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition"
           :class="sessionRecordingEnabled && analyticsEnabled ? 'bg-accent' : 'bg-surface-overlay'"
           :disabled="!analyticsEnabled"
@@ -111,6 +113,7 @@ function toggleSessionRecording(event: Event) {
     <!-- Save / back button -->
     <div class="flex items-center gap-3 mt-2">
       <button
+        data-testid="privacy-done-btn"
         class="rounded-sm bg-accent px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent-hover"
         @click="goBack"
       >

--- a/frontend/src/views/UserSettingsView.vue
+++ b/frontend/src/views/UserSettingsView.vue
@@ -91,6 +91,7 @@ async function handleDisconnect() {
             <div class="shrink-0">
               <button
                 v-if="!loading && !isConnected"
+                data-testid="copilot-connect-btn"
                 class="inline-flex items-center gap-2 rounded-sm bg-slate-900 px-4 py-2 text-sm font-semibold text-white cursor-pointer border-none transition hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed"
                 :disabled="!currentOrgId"
                 @click="currentOrgId && connect(currentOrgId)"
@@ -101,6 +102,7 @@ async function handleDisconnect() {
 
               <button
                 v-else-if="!loading && isConnected"
+                data-testid="copilot-disconnect-btn"
                 class="inline-flex items-center gap-1.5 rounded-sm border border-border bg-surface-raised px-3 py-1.5 text-xs font-medium text-text-secondary cursor-pointer transition hover:bg-rose-500/10 hover:border-rose-500/25 hover:text-rose-500"
                 @click="handleDisconnect"
               >

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.25.1"
+go = "1.25.8"
 helm = "latest"
 k3d = "latest"
 kubectl = "latest"


### PR DESCRIPTION
## Summary
- **Security fixes:** Bump Go from 1.25.0 to 1.25.8, rollup from 4.57.1 to 4.59.1, minimatch from 9.0.1 to 9.0.9, and add dompurify ^3.3.3 override to resolve known vulnerabilities
- **QA infrastructure:** Add `data-testid` attributes to all interactive elements across 31 Vue components and views for automated testing

## Test Coverage
No new application code paths — changes are dependency bumps and HTML attribute additions.

## Pre-Landing Review
No issues found.

## Test plan
- [x] All frontend Vitest tests pass (500 tests, 44 files)
- [x] All backend Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)