### PR TITLE
feat: chart types expansion — Tier 2 (5 observability panel types)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@types/d3-force": "^3.0.10",
+        "d3-force": "^3.0.0",
         "dompurify": "^3.3.3",
         "echarts": "^6.0.0",
         "lucide-vue-next": "^0.577.0",
@@ -2645,6 +2647,12 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3459,6 +3467,47 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@types/d3-force": "^3.0.10",
+    "d3-force": "^3.0.0",
     "dompurify": "^3.3.3",
     "echarts": "^6.0.0",
     "lucide-vue-next": "^0.577.0",

--- a/frontend/src/components/panels/FlameGraphPanel.spec.ts
+++ b/frontend/src/components/panels/FlameGraphPanel.spec.ts
@@ -1,0 +1,346 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { chartPalette, chartTooltipStyle } from '../../utils/chartTheme'
+import { clearRegistry } from '../../utils/panelRegistry'
+import type { FlameNode } from './FlameGraphPanel.vue'
+
+// ---------------------------------------------------------------------------
+// FlameGraphPanel component tests
+// ---------------------------------------------------------------------------
+
+describe('FlameGraphPanel', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let FlameGraphPanel: any
+
+  beforeEach(async () => {
+    const mod = await import('./FlameGraphPanel.vue')
+    FlameGraphPanel = mod.default
+  })
+
+  const leafRoot: FlameNode = { name: 'main', value: 100 }
+
+  const treeRoot: FlameNode = {
+    name: 'root',
+    value: 10,
+    children: [
+      {
+        name: 'child-a',
+        value: 20,
+        children: [{ name: 'grandchild', value: 30 }],
+      },
+      { name: 'child-b', value: 40 },
+    ],
+  }
+
+  // Helper: compute total value of a node (self + all descendants)
+  function totalValue(node: FlameNode): number {
+    const childTotal = (node.children ?? []).reduce((sum, c) => sum + totalValue(c), 0)
+    return node.value + childTotal
+  }
+
+  // Test 1: Renders SVG element
+  it('renders an SVG element', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    expect(wrapper.find('svg').exists()).toBe(true)
+  })
+
+  // Test 2: Root node rendered as a rect at the bottom
+  it('root node rendered as a rect at the bottom (highest y)', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const rects = wrapper.findAll('rect')
+    expect(rects.length).toBeGreaterThanOrEqual(1)
+
+    // Root should have the highest y-position (bottom of the flame graph)
+    // and full width
+    const rootRect = rects.find((r) => {
+      const x = Number(r.attributes('x'))
+      const width = Number(r.attributes('width'))
+      // Root spans the full width (x=0, widest rect)
+      return x === 0 && width > 0
+    })
+    expect(rootRect).toBeDefined()
+
+    // Root rect should be at the bottom — highest y value among all rects
+    const allYs = rects.map((r) => Number(r.attributes('y')))
+    const maxY = Math.max(...allYs)
+    expect(Number(rootRect!.attributes('y'))).toBe(maxY)
+  })
+
+  // Test 3: Child nodes rendered above parent
+  it('child nodes rendered above parent (lower y value)', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const rects = wrapper.findAll('rect')
+
+    // Collect y values — multiple depth levels should exist
+    const ys = new Set(rects.map((r) => Number(r.attributes('y'))))
+    // At least 3 depths: root, children, grandchild
+    expect(ys.size).toBeGreaterThanOrEqual(3)
+
+    const sortedYs = Array.from(ys).sort((a, b) => a - b)
+    // Children are above parent (smaller y = higher visually)
+    // Root is at bottom (largest y), grandchild at top (smallest y)
+    expect(sortedYs[sortedYs.length - 1]).toBeGreaterThan(sortedYs[0])
+  })
+
+  // Test 4: Rect widths proportional to total time
+  it('rect widths proportional to total time', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const svg = wrapper.find('svg')
+    const svgWidth = Number(svg.attributes('width'))
+    const rects = wrapper.findAll('rect')
+
+    // Root rect should span full width
+    const rootTotal = totalValue(treeRoot)
+    const rootRect = rects.find(
+      (r) =>
+        Number(r.attributes('y')) === Math.max(...rects.map((r2) => Number(r2.attributes('y')))),
+    )
+    expect(rootRect).toBeDefined()
+    expect(Number(rootRect!.attributes('width'))).toBeCloseTo(svgWidth, 0)
+
+    // child-a total = 20 + 30 = 50, child-b total = 40
+    // child-a width / child-b width should be ~50/40 = 1.25
+    // Both are at the same depth (one level above root)
+    const rootY = Number(rootRect!.attributes('y'))
+    const childRects = rects.filter((r) => {
+      const y = Number(r.attributes('y'))
+      return y < rootY && y > Math.min(...rects.map((r2) => Number(r2.attributes('y'))))
+    })
+
+    if (childRects.length === 2) {
+      const widths = childRects.map((r) => Number(r.attributes('width'))).sort((a, b) => b - a)
+      // Larger width is child-a (total 50), smaller is child-b (total 40)
+      const ratio = widths[0] / widths[1]
+      expect(ratio).toBeCloseTo(50 / 40, 1)
+    }
+  })
+
+  // Test 5: Colors derived from chartPalette via name hash
+  it('colors derived from chartPalette via name hash', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const rects = wrapper.findAll('rect')
+
+    // All rect fills should be derived from chartPalette (hex color with opacity)
+    for (const rect of rects) {
+      const fill = rect.attributes('fill') ?? ''
+      // Fill should contain one of the chartPalette colors (possibly lowercased)
+      const matchesPalette = chartPalette.some((color) =>
+        fill.toLowerCase().includes(color.toLowerCase()),
+      )
+      expect(matchesPalette).toBe(true)
+    }
+  })
+
+  // Test 6: Same function name always gets same color
+  it('same function name always gets same color', () => {
+    // Mount two separate trees with the same name but different values
+    const wrapper1 = mount(FlameGraphPanel, {
+      props: { root: { name: 'test-fn', value: 100 } },
+    })
+    const wrapper2 = mount(FlameGraphPanel, {
+      props: { root: { name: 'test-fn', value: 200 } },
+    })
+    const fill1 = wrapper1.find('rect').attributes('fill')
+    const fill2 = wrapper2.find('rect').attributes('fill')
+    expect(fill1).toBe(fill2)
+
+    // Different name should produce a different color
+    const wrapper3 = mount(FlameGraphPanel, {
+      props: { root: { name: 'other-fn', value: 100 } },
+    })
+    const fill3 = wrapper3.find('rect').attributes('fill')
+    expect(fill3).not.toBe(fill1)
+  })
+
+  // Test 7: Text labels shown for wide rects
+  it('text labels shown for wide rects', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const texts = wrapper.findAll('text')
+    // Root and wider children should have text labels
+    expect(texts.length).toBeGreaterThanOrEqual(1)
+    // At least one text should contain a function name from the tree
+    const allText = texts.map((t) => t.text())
+    const hasKnownName = allText.some(
+      (t) =>
+        t.includes('root') ||
+        t.includes('child-a') ||
+        t.includes('child-b') ||
+        t.includes('grandchild'),
+    )
+    expect(hasKnownName).toBe(true)
+  })
+
+  // Test 8: Text labels hidden for narrow rects (< 40px)
+  it('text labels hidden for narrow rects (< 40px wide)', () => {
+    // Create a tree where one child is extremely small relative to root
+    const root: FlameNode = {
+      name: 'main',
+      value: 0,
+      children: [
+        { name: 'big-fn', value: 990 },
+        { name: 'tiny-fn', value: 1 }, // ~0.1% of total → very narrow
+      ],
+    }
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root },
+    })
+    const texts = wrapper.findAll('text')
+    const textContents = texts.map((t) => t.text())
+    // 'tiny-fn' should NOT have a visible text label
+    expect(textContents.some((t) => t.includes('tiny-fn'))).toBe(false)
+  })
+
+  // Test 9: Handles empty/leaf root node (no children)
+  it('handles leaf root node (no children)', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: leafRoot },
+    })
+    expect(wrapper.find('svg').exists()).toBe(true)
+    const rects = wrapper.findAll('rect')
+    expect(rects).toHaveLength(1)
+  })
+
+  // Test 10: Tooltip data computed correctly
+  it('tooltip data attributes present on rects (name, value, percentage)', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const rects = wrapper.findAll('rect')
+    // Each rect should have data attributes for tooltip
+    for (const rect of rects) {
+      expect(rect.attributes('data-name')).toBeTruthy()
+      expect(rect.attributes('data-total-value')).toBeTruthy()
+      expect(rect.attributes('data-self-value')).toBeTruthy()
+      expect(rect.attributes('data-percentage')).toBeTruthy()
+    }
+  })
+
+  // Test 11: Container is scrollable
+  it('container is scrollable (overflow auto)', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const container = wrapper.find('[data-testid="flame-graph-container"]')
+    expect(container.exists()).toBe(true)
+    const style = container.attributes('style') ?? ''
+    expect(style).toContain('overflow')
+  })
+
+  // Test 12: Default unit is "ms"
+  it('default unit is "ms"', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: leafRoot },
+    })
+    // Check the data-unit attribute on the SVG or container
+    const container = wrapper.find('[data-testid="flame-graph-container"]')
+    expect(container.attributes('data-unit')).toBe('ms')
+  })
+
+  // Test 13: Custom unit is passed through
+  it('custom unit is applied', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: leafRoot, unit: 'samples' },
+    })
+    const container = wrapper.find('[data-testid="flame-graph-container"]')
+    expect(container.attributes('data-unit')).toBe('samples')
+  })
+
+  // Test 14: Tooltip element uses chartTooltipStyle colors
+  it('tooltip element uses chartTooltipStyle background', () => {
+    const wrapper = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const tooltip = wrapper.find('[data-testid="flame-graph-tooltip"]')
+    expect(tooltip.exists()).toBe(true)
+    const style = tooltip.attributes('style') ?? ''
+    expect(style).toContain(chartTooltipStyle.backgroundColor)
+  })
+
+  // Test 15: SVG height scales with tree depth
+  it('SVG height scales with tree depth', () => {
+    const shallow = mount(FlameGraphPanel, {
+      props: { root: leafRoot },
+    })
+    const deep = mount(FlameGraphPanel, {
+      props: { root: treeRoot },
+    })
+    const shallowHeight = Number(shallow.find('svg').attributes('height'))
+    const deepHeight = Number(deep.find('svg').attributes('height'))
+    expect(deepHeight).toBeGreaterThan(shallowHeight)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Registration tests
+// ---------------------------------------------------------------------------
+
+describe('flame_graph panel registration', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let reg: any
+
+  beforeEach(async () => {
+    clearRegistry()
+    const { registerPanel } = await import('../../utils/panelRegistry')
+    const { Flame } = await import('lucide-vue-next')
+    registerPanel({
+      type: 'flame_graph',
+      component: () => import('./FlameGraphPanel.vue'),
+      dataAdapter: () => {
+        return {
+          root: { name: 'root', value: 0, children: [] },
+          unit: 'ms',
+        }
+      },
+      defaultQuery: {},
+      category: 'observability',
+      label: 'Flame Graph',
+      icon: Flame,
+    })
+    const { lookupPanel } = await import('../../utils/panelRegistry')
+    reg = lookupPanel('flame_graph')
+  })
+
+  afterEach(() => {
+    clearRegistry()
+  })
+
+  it('registers with type "flame_graph"', () => {
+    expect(reg).not.toBeNull()
+    expect(reg?.type).toBe('flame_graph')
+  })
+
+  it('registers with category "observability"', () => {
+    expect(reg?.category).toBe('observability')
+  })
+
+  it('registers with label "Flame Graph"', () => {
+    expect(reg?.label).toBe('Flame Graph')
+  })
+
+  it('dataAdapter returns stub root node', () => {
+    const result = reg!.dataAdapter({ series: [] })
+    expect(result.root).toBeDefined()
+    expect(result.root.name).toBe('root')
+    expect(result.unit).toBe('ms')
+  })
+
+  it('defaultQuery is an empty object', () => {
+    expect(reg?.defaultQuery).toEqual({})
+  })
+
+  it('icon is defined', () => {
+    expect(reg?.icon).toBeDefined()
+  })
+})

--- a/frontend/src/components/panels/FlameGraphPanel.spec.ts
+++ b/frontend/src/components/panels/FlameGraphPanel.spec.ts
@@ -98,7 +98,6 @@ describe('FlameGraphPanel', () => {
     const rects = wrapper.findAll('rect')
 
     // Root rect should span full width
-    const rootTotal = totalValue(treeRoot)
     const rootRect = rects.find(
       (r) =>
         Number(r.attributes('y')) === Math.max(...rects.map((r2) => Number(r2.attributes('y')))),

--- a/frontend/src/components/panels/FlameGraphPanel.vue
+++ b/frontend/src/components/panels/FlameGraphPanel.vue
@@ -1,0 +1,246 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { chartPalette, chartTooltipStyle } from '../../utils/chartTheme'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FlameNode {
+  name: string
+  value: number
+  children?: FlameNode[]
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+const props = withDefaults(
+  defineProps<{
+    root: FlameNode
+    unit?: string
+  }>(),
+  { unit: 'ms' },
+)
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ROW_HEIGHT = 20
+const SVG_WIDTH = 960
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Simple string hash to deterministically map a name to a palette index. */
+function hashName(name: string): number {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash)
+}
+
+/** Returns total value of a node (self + all descendants). */
+function computeTotal(node: FlameNode): number {
+  const childTotal = (node.children ?? []).reduce((sum, c) => sum + computeTotal(c), 0)
+  return node.value + childTotal
+}
+
+/** Returns the max depth of the tree (0-indexed). */
+function computeMaxDepth(node: FlameNode, depth = 0): number {
+  if (!node.children || node.children.length === 0) return depth
+  return Math.max(...node.children.map((c) => computeMaxDepth(c, depth + 1)))
+}
+
+// ---------------------------------------------------------------------------
+// Flattened rect representation
+// ---------------------------------------------------------------------------
+
+interface FlatRect {
+  name: string
+  x: number
+  y: number
+  width: number
+  depth: number
+  selfValue: number
+  totalValue: number
+}
+
+function flattenTree(
+  node: FlameNode,
+  rootTotal: number,
+  maxDepth: number,
+  xOffset: number,
+  depth: number,
+): FlatRect[] {
+  const nodeTotalValue = computeTotal(node)
+  const width = (nodeTotalValue / rootTotal) * SVG_WIDTH
+  // Bottom-up: root at maxDepth, children at maxDepth - 1, etc.
+  const y = (maxDepth - depth) * ROW_HEIGHT
+
+  const rect: FlatRect = {
+    name: node.name,
+    x: xOffset,
+    y,
+    width,
+    depth,
+    selfValue: node.value,
+    totalValue: nodeTotalValue,
+  }
+
+  const result: FlatRect[] = [rect]
+
+  let childX = xOffset
+  for (const child of node.children ?? []) {
+    const childRects = flattenTree(child, rootTotal, maxDepth, childX, depth + 1)
+    result.push(...childRects)
+    childX += (computeTotal(child) / rootTotal) * SVG_WIDTH
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Computed
+// ---------------------------------------------------------------------------
+
+const rootTotal = computed(() => computeTotal(props.root))
+const maxDepth = computed(() => computeMaxDepth(props.root))
+const svgHeight = computed(() => (maxDepth.value + 1) * ROW_HEIGHT)
+
+const rects = computed(() => {
+  const total = rootTotal.value
+  if (total === 0) return []
+  return flattenTree(props.root, total, maxDepth.value, 0, 0)
+})
+
+function rectFill(name: string): string {
+  const idx = hashName(name) % chartPalette.length
+  return `${chartPalette[idx]}d9` // hex opacity ~0.85
+}
+
+function rectStroke(name: string): string {
+  const idx = hashName(name) % chartPalette.length
+  return chartPalette[idx]
+}
+
+function rectPercentage(rect: FlatRect): string {
+  const pct = rootTotal.value > 0 ? ((rect.totalValue / rootTotal.value) * 100).toFixed(1) : '0.0'
+  return pct
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip
+// ---------------------------------------------------------------------------
+
+const tooltipVisible = ref(false)
+const tooltipX = ref(0)
+const tooltipY = ref(0)
+const tooltipRect = ref<FlatRect | null>(null)
+
+function onRectEnter(event: MouseEvent, rect: FlatRect) {
+  tooltipRect.value = rect
+  tooltipX.value = event.offsetX + 12
+  tooltipY.value = event.offsetY - 10
+  tooltipVisible.value = true
+}
+
+function onRectMove(event: MouseEvent) {
+  tooltipX.value = event.offsetX + 12
+  tooltipY.value = event.offsetY - 10
+}
+
+function onRectLeave() {
+  tooltipVisible.value = false
+  tooltipRect.value = null
+}
+</script>
+
+<template>
+  <div
+    data-testid="flame-graph-container"
+    :data-unit="props.unit"
+    :style="{
+      overflow: 'auto',
+      height: '100%',
+      width: '100%',
+      position: 'relative',
+      backgroundColor: 'transparent',
+    }"
+  >
+    <svg
+      :width="SVG_WIDTH"
+      :height="svgHeight"
+      :style="{ display: 'block', fontFamily: '\'DM Sans\', sans-serif' }"
+    >
+      <rect
+        v-for="(rect, i) in rects"
+        :key="i"
+        :x="rect.x"
+        :y="rect.y"
+        :width="rect.width"
+        :height="ROW_HEIGHT"
+        :fill="rectFill(rect.name)"
+        :stroke="rectStroke(rect.name)"
+        stroke-width="0.5"
+        :data-name="rect.name"
+        :data-total-value="String(rect.totalValue)"
+        :data-self-value="String(rect.selfValue)"
+        :data-percentage="rectPercentage(rect)"
+        style="cursor: pointer"
+        @mouseenter="onRectEnter($event, rect)"
+        @mousemove="onRectMove"
+        @mouseleave="onRectLeave"
+      />
+      <text
+        v-for="(rect, i) in rects"
+        :key="'t' + i"
+        v-show="rect.width >= 40"
+        :x="rect.x + 4"
+        :y="rect.y + 14"
+        :style="{
+          fontSize: '11px',
+          fontFamily: '\'DM Sans\', sans-serif',
+          fill: 'var(--color-on-surface)',
+          pointerEvents: 'none',
+          userSelect: 'none',
+        }"
+      >
+        <template v-if="rect.width >= 40">{{ rect.name.length > rect.width / 7 ? rect.name.slice(0, Math.floor(rect.width / 7) - 1) + '…' : rect.name }}</template>
+      </text>
+    </svg>
+
+    <!-- Tooltip -->
+    <div
+      data-testid="flame-graph-tooltip"
+      :style="{
+        position: 'absolute',
+        left: tooltipX + 'px',
+        top: tooltipY + 'px',
+        pointerEvents: 'none',
+        display: tooltipVisible ? 'block' : 'none',
+        backgroundColor: chartTooltipStyle.backgroundColor,
+        borderColor: chartTooltipStyle.borderColor,
+        border: '1px solid ' + chartTooltipStyle.borderColor,
+        color: chartTooltipStyle.textStyle.color,
+        fontFamily: chartTooltipStyle.textStyle.fontFamily,
+        fontSize: chartTooltipStyle.textStyle.fontSize + 'px',
+        padding: '6px 10px',
+        borderRadius: '4px',
+        zIndex: '100',
+        whiteSpace: 'nowrap',
+      }"
+    >
+      <template v-if="tooltipRect">
+        <div :style="{ fontWeight: '600', marginBottom: '2px' }">{{ tooltipRect.name }}</div>
+        <div>Self: {{ tooltipRect.selfValue }} {{ props.unit }}</div>
+        <div>Total: {{ tooltipRect.totalValue }} {{ props.unit }}</div>
+        <div>{{ rectPercentage(tooltipRect) }}% of root</div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/panels/NodeGraphPanel.spec.ts
+++ b/frontend/src/components/panels/NodeGraphPanel.spec.ts
@@ -1,0 +1,295 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chartPalette, getSeriesColor } from '../../utils/chartTheme'
+import { clearRegistry } from '../../utils/panelRegistry'
+import type { GraphEdge, GraphNode } from './NodeGraphPanel.vue'
+
+// ---------------------------------------------------------------------------
+// Mock d3-force — the simulation doesn't run in happy-dom, so we assign
+// deterministic positions to nodes.
+// ---------------------------------------------------------------------------
+
+vi.mock('d3-force', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: mock helper
+  const forceSimulation = (nodes: any[]) => {
+    // Assign deterministic positions based on index
+    for (let i = 0; i < nodes.length; i++) {
+      nodes[i].x = 100 + i * 80
+      nodes[i].y = 100 + i * 60
+    }
+
+    const sim = {
+      force: () => sim,
+      stop: () => sim,
+      tick: () => sim,
+      nodes: () => nodes,
+    }
+    return sim
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: mock helper
+  const forceLink = (_links?: any[]) => {
+    const f = () => f
+    f.id = () => f
+    f.links = () => []
+    return f
+  }
+
+  const forceManyBody = () => {
+    const f = () => f
+    f.strength = () => f
+    return f
+  }
+
+  const forceCenter = () => {
+    const f = () => f
+    return f
+  }
+
+  return { forceSimulation, forceLink, forceManyBody, forceCenter }
+})
+
+// ---------------------------------------------------------------------------
+// NodeGraphPanel component tests
+// ---------------------------------------------------------------------------
+
+describe('NodeGraphPanel', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let NodeGraphPanel: any
+
+  beforeEach(async () => {
+    const mod = await import('./NodeGraphPanel.vue')
+    NodeGraphPanel = mod.default
+  })
+
+  const sampleNodes: GraphNode[] = [
+    { id: 'svc-a', label: 'Service A', metric: 120 },
+    { id: 'svc-b', label: 'Service B', metric: 80 },
+    { id: 'svc-c', label: 'Service C', metric: 45 },
+  ]
+
+  const sampleEdges: GraphEdge[] = [
+    { source: 'svc-a', target: 'svc-b', label: '120 req/s', value: 120 },
+    { source: 'svc-b', target: 'svc-c', label: '45 req/s', value: 45 },
+  ]
+
+  // Test 1: Renders SVG element
+  it('renders an SVG element', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    expect(wrapper.find('svg').exists()).toBe(true)
+  })
+
+  // Test 2: Renders correct number of circle elements for nodes
+  it('renders correct number of circle elements for nodes', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    const circles = wrapper.findAll('circle')
+    expect(circles).toHaveLength(sampleNodes.length)
+  })
+
+  // Test 3: Renders correct number of line elements for edges
+  it('renders correct number of line elements for edges', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    const lines = wrapper.findAll('line')
+    expect(lines).toHaveLength(sampleEdges.length)
+  })
+
+  // Test 4: Node labels rendered below circles
+  it('node labels rendered below circles', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    const texts = wrapper.findAll('text[data-type="node-label"]')
+    expect(texts).toHaveLength(sampleNodes.length)
+
+    // Each label should contain the node label text
+    const textContents = texts.map((t) => t.text())
+    for (const node of sampleNodes) {
+      expect(textContents).toContain(node.label)
+    }
+  })
+
+  // Test 5: Node colors use getSeriesColor/chartPalette
+  it('node colors use getSeriesColor/chartPalette', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    const circles = wrapper.findAll('circle')
+
+    for (let i = 0; i < circles.length; i++) {
+      const fill = circles[i].attributes('fill') ?? ''
+      const expectedColor = getSeriesColor(i).toLowerCase()
+      // Fill should contain the expected palette color (possibly with opacity suffix)
+      expect(fill.toLowerCase()).toContain(expectedColor.toLowerCase())
+    }
+  })
+
+  // Test 6: Edge connects correct source and target (via data attributes)
+  it('edge connects correct source and target via data attributes', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    const lines = wrapper.findAll('line')
+
+    for (let i = 0; i < sampleEdges.length; i++) {
+      expect(lines[i].attributes('data-source')).toBe(sampleEdges[i].source)
+      expect(lines[i].attributes('data-target')).toBe(sampleEdges[i].target)
+    }
+  })
+
+  // Test 7: Handles empty nodes/edges (no SVG children)
+  it('handles empty nodes/edges gracefully', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: [], edges: [] },
+    })
+    await flushPromises()
+    expect(wrapper.find('svg').exists()).toBe(true)
+    expect(wrapper.findAll('circle')).toHaveLength(0)
+    expect(wrapper.findAll('line')).toHaveLength(0)
+  })
+
+  // Test 8: Handles single node (no edges)
+  it('handles single node with no edges', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: {
+        nodes: [{ id: 'only', label: 'Only Node' }],
+        edges: [],
+      },
+    })
+    await flushPromises()
+    expect(wrapper.findAll('circle')).toHaveLength(1)
+    expect(wrapper.findAll('line')).toHaveLength(0)
+    const label = wrapper.find('text[data-type="node-label"]')
+    expect(label.text()).toBe('Only Node')
+  })
+
+  // Test 9: Edge thickness varies based on value
+  it('edge thickness varies based on value', async () => {
+    const edgesWithVariedValues: GraphEdge[] = [
+      { source: 'svc-a', target: 'svc-b', value: 10 },
+      { source: 'svc-b', target: 'svc-c', value: 100 },
+    ]
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: edgesWithVariedValues },
+    })
+    await flushPromises()
+    const lines = wrapper.findAll('line')
+    const strokeWidth0 = Number.parseFloat(lines[0].attributes('stroke-width') ?? '1')
+    const strokeWidth1 = Number.parseFloat(lines[1].attributes('stroke-width') ?? '1')
+    // The edge with value 100 should be thicker than the one with value 10
+    expect(strokeWidth1).toBeGreaterThan(strokeWidth0)
+  })
+
+  // Test 10: Edge labels rendered at midpoint
+  it('edge labels rendered at midpoint', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    const edgeLabels = wrapper.findAll('text[data-type="edge-label"]')
+    // Only edges with label prop should have label text
+    const labelsWithText = sampleEdges.filter((e) => e.label)
+    expect(edgeLabels).toHaveLength(labelsWithText.length)
+
+    const textContents = edgeLabels.map((t) => t.text())
+    for (const edge of labelsWithText) {
+      expect(textContents).toContain(edge.label)
+    }
+  })
+
+  // Test 11: Node circles have radius 20
+  it('node circles have radius 20', async () => {
+    const wrapper = mount(NodeGraphPanel, {
+      props: { nodes: sampleNodes, edges: sampleEdges },
+    })
+    await flushPromises()
+    const circles = wrapper.findAll('circle')
+    for (const circle of circles) {
+      expect(circle.attributes('r')).toBe('20')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Export tests
+// ---------------------------------------------------------------------------
+
+describe('NodeGraphPanel exports', () => {
+  it('exports GraphNode and GraphEdge interfaces (type-level)', async () => {
+    // Verify that we can import the types and use them
+    const node: GraphNode = { id: 'test', label: 'Test' }
+    const edge: GraphEdge = { source: 'a', target: 'b' }
+    expect(node.id).toBe('test')
+    expect(edge.source).toBe('a')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Registration tests
+// ---------------------------------------------------------------------------
+
+describe('node_graph panel registration', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let reg: any
+
+  beforeEach(async () => {
+    clearRegistry()
+    const { registerPanel } = await import('../../utils/panelRegistry')
+    const { Network } = await import('lucide-vue-next')
+    registerPanel({
+      type: 'node_graph',
+      component: () => import('./NodeGraphPanel.vue'),
+      dataAdapter: () => {
+        return { nodes: [], edges: [] }
+      },
+      defaultQuery: {},
+      category: 'observability',
+      label: 'Node Graph',
+      icon: Network,
+    })
+    const { lookupPanel } = await import('../../utils/panelRegistry')
+    reg = lookupPanel('node_graph')
+  })
+
+  afterEach(() => {
+    clearRegistry()
+  })
+
+  it('registers with type "node_graph"', () => {
+    expect(reg).not.toBeNull()
+    expect(reg?.type).toBe('node_graph')
+  })
+
+  it('registers with category "observability"', () => {
+    expect(reg?.category).toBe('observability')
+  })
+
+  it('registers with label "Node Graph"', () => {
+    expect(reg?.label).toBe('Node Graph')
+  })
+
+  it('dataAdapter returns empty graph stub', () => {
+    const result = reg!.dataAdapter({ series: [] })
+    expect(result.nodes).toEqual([])
+    expect(result.edges).toEqual([])
+  })
+
+  it('defaultQuery is an empty object', () => {
+    expect(reg?.defaultQuery).toEqual({})
+  })
+
+  it('icon is defined', () => {
+    expect(reg?.icon).toBeDefined()
+  })
+})

--- a/frontend/src/components/panels/NodeGraphPanel.spec.ts
+++ b/frontend/src/components/panels/NodeGraphPanel.spec.ts
@@ -1,6 +1,6 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { chartPalette, getSeriesColor } from '../../utils/chartTheme'
+import { getSeriesColor } from '../../utils/chartTheme'
 import { clearRegistry } from '../../utils/panelRegistry'
 import type { GraphEdge, GraphNode } from './NodeGraphPanel.vue'
 

--- a/frontend/src/components/panels/NodeGraphPanel.vue
+++ b/frontend/src/components/panels/NodeGraphPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SimulationNodeDatum } from 'd3-force'
 import { forceCenter, forceLink, forceManyBody, forceSimulation } from 'd3-force'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { getSeriesColor } from '../../utils/chartTheme'
 
 // ---------------------------------------------------------------------------
@@ -102,8 +102,12 @@ function clamp(val: number, min: number, max: number): number {
 // Simulation
 // ---------------------------------------------------------------------------
 
-onMounted(() => {
-  if (props.nodes.length === 0) return
+function runSimulation() {
+  if (props.nodes.length === 0) {
+    simulatedNodes.value = []
+    simulatedEdges.value = []
+    return
+  }
 
   // Create mutable copies for d3
   const simNodes: SimNode[] = props.nodes.map((n) => ({
@@ -141,13 +145,17 @@ onMounted(() => {
 
   simulatedNodes.value = simNodes
   simulatedEdges.value = simEdges
-})
+}
+
+// Run on mount and re-run when props change
+onMounted(runSimulation)
+watch([() => props.nodes, () => props.edges], runSimulation, { deep: true })
 
 // ---------------------------------------------------------------------------
-// Edge color
+// Edge color — use outline-variant at higher opacity for visibility
 // ---------------------------------------------------------------------------
 
-const edgeColor = 'rgba(71,72,74,0.4)'
+const edgeColor = 'var(--color-outline-variant)'
 </script>
 
 <template>

--- a/frontend/src/components/panels/NodeGraphPanel.vue
+++ b/frontend/src/components/panels/NodeGraphPanel.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+import type { SimulationNodeDatum } from 'd3-force'
+import { forceCenter, forceLink, forceManyBody, forceSimulation } from 'd3-force'
+import { computed, onMounted, ref } from 'vue'
+import { getSeriesColor } from '../../utils/chartTheme'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GraphNode {
+  id: string
+  label: string
+  metric?: number
+}
+
+export interface GraphEdge {
+  source: string
+  target: string
+  label?: string
+  value?: number
+}
+
+// ---------------------------------------------------------------------------
+// Internal simulation types
+// ---------------------------------------------------------------------------
+
+interface SimNode extends SimulationNodeDatum {
+  id: string
+  label: string
+  metric?: number
+}
+
+interface SimEdge {
+  source: string
+  target: string
+  label?: string
+  value?: number
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+const props = defineProps<{
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}>()
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const NODE_RADIUS = 20
+const SVG_WIDTH = 600
+const SVG_HEIGHT = 400
+const MAX_ITERATIONS = 300
+const EDGE_MIN_WIDTH = 1
+const EDGE_MAX_WIDTH = 4
+
+// ---------------------------------------------------------------------------
+// Reactive state
+// ---------------------------------------------------------------------------
+
+const simulatedNodes = ref<SimNode[]>([])
+const simulatedEdges = ref<SimEdge[]>([])
+
+// ---------------------------------------------------------------------------
+// Computed
+// ---------------------------------------------------------------------------
+
+/** Normalize edge value to a stroke width between EDGE_MIN_WIDTH and EDGE_MAX_WIDTH. */
+const edgeMaxValue = computed(() => {
+  const values = props.edges.filter((e) => e.value != null).map((e) => e.value!)
+  return values.length > 0 ? Math.max(...values) : 1
+})
+
+const edgeMinValue = computed(() => {
+  const values = props.edges.filter((e) => e.value != null).map((e) => e.value!)
+  return values.length > 0 ? Math.min(...values) : 0
+})
+
+function edgeStrokeWidth(value?: number): number {
+  if (value == null) return EDGE_MIN_WIDTH
+  const range = edgeMaxValue.value - edgeMinValue.value
+  if (range === 0) return (EDGE_MIN_WIDTH + EDGE_MAX_WIDTH) / 2
+  const t = (value - edgeMinValue.value) / range
+  return EDGE_MIN_WIDTH + t * (EDGE_MAX_WIDTH - EDGE_MIN_WIDTH)
+}
+
+/** Look up a simulated node by id. */
+function findNode(id: string): SimNode | undefined {
+  return simulatedNodes.value.find((n) => n.id === id)
+}
+
+/** Clamp a value within [min, max]. */
+function clamp(val: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, val))
+}
+
+// ---------------------------------------------------------------------------
+// Simulation
+// ---------------------------------------------------------------------------
+
+onMounted(() => {
+  if (props.nodes.length === 0) return
+
+  // Create mutable copies for d3
+  const simNodes: SimNode[] = props.nodes.map((n) => ({
+    id: n.id,
+    label: n.label,
+    metric: n.metric,
+  }))
+
+  const simEdges: SimEdge[] = props.edges.map((e) => ({
+    source: e.source,
+    target: e.target,
+    label: e.label,
+    value: e.value,
+  }))
+
+  // Build force simulation
+  // biome-ignore lint/suspicious/noExplicitAny: d3-force generic constraints require relaxed typing for link id accessor
+  const linkForce = forceLink<SimNode, SimEdge>(simEdges as any).id((d: any) => d.id)
+  const simulation = forceSimulation<SimNode>(simNodes)
+    .force('link', linkForce)
+    .force('charge', forceManyBody().strength(-200))
+    .force('center', forceCenter(SVG_WIDTH / 2, SVG_HEIGHT / 2))
+    .stop()
+
+  // Run simulation synchronously for MAX_ITERATIONS
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    simulation.tick()
+  }
+
+  // Clamp positions to viewport
+  for (const node of simNodes) {
+    node.x = clamp(node.x ?? SVG_WIDTH / 2, NODE_RADIUS, SVG_WIDTH - NODE_RADIUS)
+    node.y = clamp(node.y ?? SVG_HEIGHT / 2, NODE_RADIUS, SVG_HEIGHT - NODE_RADIUS)
+  }
+
+  simulatedNodes.value = simNodes
+  simulatedEdges.value = simEdges
+})
+
+// ---------------------------------------------------------------------------
+// Edge color
+// ---------------------------------------------------------------------------
+
+const edgeColor = 'rgba(71,72,74,0.4)'
+</script>
+
+<template>
+  <div
+    data-testid="node-graph-container"
+    :style="{
+      width: '100%',
+      height: '100%',
+      overflow: 'hidden',
+      backgroundColor: 'transparent',
+    }"
+  >
+    <svg
+      :width="SVG_WIDTH"
+      :height="SVG_HEIGHT"
+      :style="{ display: 'block', fontFamily: '\'DM Sans\', sans-serif' }"
+    >
+      <!-- Edges (lines) -->
+      <line
+        v-for="(edge, i) in simulatedEdges"
+        :key="'edge-' + i"
+        :x1="findNode(edge.source)?.x ?? 0"
+        :y1="findNode(edge.source)?.y ?? 0"
+        :x2="findNode(edge.target)?.x ?? 0"
+        :y2="findNode(edge.target)?.y ?? 0"
+        :stroke="edgeColor"
+        :stroke-width="edgeStrokeWidth(edge.value)"
+        :data-source="edge.source"
+        :data-target="edge.target"
+      />
+
+      <!-- Edge labels -->
+      <text
+        v-for="(edge, i) in simulatedEdges"
+        v-show="edge.label"
+        :key="'edge-label-' + i"
+        data-type="edge-label"
+        :x="((findNode(edge.source)?.x ?? 0) + (findNode(edge.target)?.x ?? 0)) / 2"
+        :y="((findNode(edge.source)?.y ?? 0) + (findNode(edge.target)?.y ?? 0)) / 2"
+        text-anchor="middle"
+        :style="{
+          fontSize: '10px',
+          fontFamily: '\'DM Sans\', sans-serif',
+          fill: 'var(--color-on-surface-variant)',
+          pointerEvents: 'none',
+          userSelect: 'none',
+        }"
+      >
+        {{ edge.label }}
+      </text>
+
+      <!-- Nodes (circles) -->
+      <circle
+        v-for="(node, i) in simulatedNodes"
+        :key="'node-' + node.id"
+        :cx="node.x"
+        :cy="node.y"
+        :r="NODE_RADIUS"
+        :fill="getSeriesColor(i) + 'e6'"
+        :stroke="getSeriesColor(i)"
+        stroke-width="1.5"
+        :data-node-id="node.id"
+      />
+
+      <!-- Node labels -->
+      <text
+        v-for="(node, i) in simulatedNodes"
+        :key="'label-' + node.id"
+        data-type="node-label"
+        :x="node.x"
+        :y="(node.y ?? 0) + NODE_RADIUS + 14"
+        text-anchor="middle"
+        :style="{
+          fontSize: '11px',
+          fontFamily: '\'DM Sans\', sans-serif',
+          fill: 'var(--color-on-surface-variant)',
+          pointerEvents: 'none',
+          userSelect: 'none',
+        }"
+      >
+        {{ node.label }}
+      </text>
+    </svg>
+  </div>
+</template>

--- a/frontend/src/components/panels/StateTimelinePanel.spec.ts
+++ b/frontend/src/components/panels/StateTimelinePanel.spec.ts
@@ -1,0 +1,450 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chartAxisStyle, chartPalette, chartTooltipStyle, thresholdColors } from '../../utils/chartTheme'
+import { clearRegistry } from '../../utils/panelRegistry'
+
+// Mock ECharts components
+vi.mock('vue-echarts', () => ({
+  default: {
+    name: 'VChart',
+    props: ['option', 'autoresize'],
+    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)"></div>',
+    methods: {
+      resize: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+}))
+
+vi.mock('echarts/renderers', () => ({
+  CanvasRenderer: {},
+}))
+
+vi.mock('echarts/charts', () => ({
+  CustomChart: {},
+}))
+
+vi.mock('echarts/components', () => ({
+  GridComponent: {},
+  TooltipComponent: {},
+  LegendComponent: {},
+}))
+
+// ---------------------------------------------------------------------------
+// StateTimelinePanel component tests
+// ---------------------------------------------------------------------------
+
+describe('StateTimelinePanel', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let StateTimelinePanel: any
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const mod = await import('./StateTimelinePanel.vue')
+    StateTimelinePanel = mod.default
+  })
+
+  const mockSegments = [
+    { entity: 'api-server', state: 'up', start: 1000, end: 2000 },
+    { entity: 'api-server', state: 'down', start: 2000, end: 3000 },
+    { entity: 'db-primary', state: 'degraded', start: 1000, end: 1500 },
+    { entity: 'db-primary', state: 'up', start: 1500, end: 3000 },
+  ]
+
+  it('renders with valid state segments', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    expect(wrapper.find('.h-full.w-full').exists()).toBe(true)
+    expect(wrapper.find('.echarts-mock').exists()).toBe(true)
+  })
+
+  it('series type is custom', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series).toHaveLength(1)
+    expect(option.series[0].type).toBe('custom')
+  })
+
+  it('up state uses thresholdColors.good', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [{ entity: 'api-server', state: 'up', start: 1000, end: 2000 }],
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const seg = option.series[0].data.find(
+      (d: { state: string }) => d.state === 'up',
+    )
+    expect(seg).toBeDefined()
+    expect(seg.color).toBe(thresholdColors.good)
+  })
+
+  it('down state uses thresholdColors.critical', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [{ entity: 'api-server', state: 'down', start: 1000, end: 2000 }],
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const seg = option.series[0].data.find(
+      (d: { state: string }) => d.state === 'down',
+    )
+    expect(seg).toBeDefined()
+    expect(seg.color).toBe(thresholdColors.critical)
+  })
+
+  it('degraded state uses thresholdColors.warning', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [{ entity: 'db-primary', state: 'degraded', start: 1000, end: 2000 }],
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const seg = option.series[0].data.find(
+      (d: { state: string }) => d.state === 'degraded',
+    )
+    expect(seg).toBeDefined()
+    expect(seg.color).toBe(thresholdColors.warning)
+  })
+
+  it('unknown state uses chartPalette[7] (Alloy Silver)', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [{ entity: 'svc', state: 'maintenance', start: 1000, end: 2000 }],
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const seg = option.series[0].data.find(
+      (d: { state: string }) => d.state === 'maintenance',
+    )
+    expect(seg).toBeDefined()
+    expect(seg.color).toBe(chartPalette[7])
+  })
+
+  it('custom stateColors override default mapping', () => {
+    const customColors = { up: '#123456', down: '#654321' }
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [
+          { entity: 'svc', state: 'up', start: 1000, end: 2000 },
+          { entity: 'svc', state: 'down', start: 2000, end: 3000 },
+        ],
+        stateColors: customColors,
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const upSeg = option.series[0].data.find((d: { state: string }) => d.state === 'up')
+    const downSeg = option.series[0].data.find((d: { state: string }) => d.state === 'down')
+    expect(upSeg.color).toBe('#123456')
+    expect(downSeg.color).toBe('#654321')
+  })
+
+  it('yAxis has entity names as categories', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.yAxis.type).toBe('category')
+    expect(option.yAxis.data).toContain('api-server')
+    expect(option.yAxis.data).toContain('db-primary')
+  })
+
+  it('applies chartAxisStyle to axes', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.xAxis.axisLine.lineStyle.color).toBe(chartAxisStyle.axisLine.lineStyle.color)
+    expect(option.xAxis.axisTick.show).toBe(chartAxisStyle.axisTick.show)
+    expect(option.xAxis.axisLabel.color).toBe(chartAxisStyle.axisLabel.color)
+    expect(option.xAxis.axisLabel.fontFamily).toBe(chartAxisStyle.axisLabel.fontFamily)
+    expect(option.yAxis.axisLabel.color).toBe(chartAxisStyle.axisLabel.color)
+    expect(option.yAxis.axisLabel.fontFamily).toBe(chartAxisStyle.axisLabel.fontFamily)
+  })
+
+  it('applies chartTooltipStyle to tooltip', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.tooltip.backgroundColor).toBe(chartTooltipStyle.backgroundColor)
+    expect(option.tooltip.borderColor).toBe(chartTooltipStyle.borderColor)
+    expect(option.tooltip.textStyle.color).toBe(chartTooltipStyle.textStyle.color)
+  })
+
+  it('handles empty segments gracefully', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: [] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data).toHaveLength(0)
+    expect(option.yAxis.data).toHaveLength(0)
+  })
+
+  it('has transparent background', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.backgroundColor).toBe('transparent')
+  })
+
+  it('grid has padding properties', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.grid).toBeDefined()
+    expect(option.grid.left).toBeDefined()
+    expect(option.grid.right).toBeDefined()
+    expect(option.grid.top).toBeDefined()
+    expect(option.grid.bottom).toBeDefined()
+  })
+
+  it('xAxis type is time', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments: mockSegments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.xAxis.type).toBe('time')
+  })
+
+  it('series data includes entity, state, start, end, and color for each segment', () => {
+    const segments = [{ entity: 'api-server', state: 'up', start: 1000, end: 2000 }]
+    const wrapper = mount(StateTimelinePanel, {
+      props: { segments },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data).toHaveLength(1)
+    const d = option.series[0].data[0]
+    expect(d.entity).toBe('api-server')
+    expect(d.state).toBe('up')
+    expect(d.start).toBe(1000)
+    expect(d.end).toBe(2000)
+    expect(d.color).toBeDefined()
+  })
+
+  it('also handles healthy and ok aliases as thresholdColors.good', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [
+          { entity: 'svc', state: 'healthy', start: 1000, end: 1500 },
+          { entity: 'svc', state: 'ok', start: 1500, end: 2000 },
+        ],
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    for (const seg of option.series[0].data) {
+      expect(seg.color).toBe(thresholdColors.good)
+    }
+  })
+
+  it('also handles error and critical aliases as thresholdColors.critical', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [
+          { entity: 'svc', state: 'error', start: 1000, end: 1500 },
+          { entity: 'svc', state: 'critical', start: 1500, end: 2000 },
+        ],
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    for (const seg of option.series[0].data) {
+      expect(seg.color).toBe(thresholdColors.critical)
+    }
+  })
+
+  it('also handles warning alias as thresholdColors.warning', () => {
+    const wrapper = mount(StateTimelinePanel, {
+      props: {
+        segments: [{ entity: 'svc', state: 'warning', start: 1000, end: 2000 }],
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data[0].color).toBe(thresholdColors.warning)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Data adapter tests
+// ---------------------------------------------------------------------------
+
+describe('state_timeline dataAdapter', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let adapter: (raw: any) => any
+
+  beforeEach(async () => {
+    clearRegistry()
+    const { registerPanel: reg } = await import('../../utils/panelRegistry')
+    const { GanttChart } = await import('lucide-vue-next')
+    reg({
+      type: 'state_timeline',
+      component: () => import('./StateTimelinePanel.vue'),
+      dataAdapter: (raw) => {
+        const segments: Array<{ entity: string; state: string; start: number; end: number }> = []
+        for (const series of raw.series) {
+          const points = series.data as Array<{ timestamp: number; value: number }>
+          if (points.length === 0) continue
+          let currentState = points[0].value > 0 ? 'up' : 'down'
+          let segStart = points[0].timestamp
+          for (let i = 1; i < points.length; i++) {
+            const newState = points[i].value > 0 ? 'up' : 'down'
+            if (newState !== currentState) {
+              segments.push({ entity: series.name, state: currentState, start: segStart, end: points[i].timestamp })
+              currentState = newState
+              segStart = points[i].timestamp
+            }
+          }
+          segments.push({ entity: series.name, state: currentState, start: segStart, end: points[points.length - 1].timestamp })
+        }
+        return { segments }
+      },
+      defaultQuery: {},
+      category: 'observability',
+      label: 'State Timeline',
+      icon: GanttChart,
+    })
+
+    const { lookupPanel } = await import('../../utils/panelRegistry')
+    adapter = lookupPanel('state_timeline')!.dataAdapter
+  })
+
+  afterEach(() => {
+    clearRegistry()
+  })
+
+  it('dataAdapter transforms value series into state segments', () => {
+    const raw = {
+      series: [
+        {
+          name: 'api-server',
+          data: [
+            { timestamp: 1000, value: 1 },
+            { timestamp: 2000, value: 1 },
+            { timestamp: 3000, value: 0 },
+            { timestamp: 4000, value: 0 },
+          ],
+        },
+      ],
+    }
+
+    const result = adapter(raw) as { segments: Array<{ entity: string; state: string; start: number; end: number }> }
+
+    // Should produce: up from 1000-3000, down from 3000-4000
+    expect(result.segments).toHaveLength(2)
+    expect(result.segments[0]).toEqual({ entity: 'api-server', state: 'up', start: 1000, end: 3000 })
+    expect(result.segments[1]).toEqual({ entity: 'api-server', state: 'down', start: 3000, end: 4000 })
+  })
+
+  it('dataAdapter handles single-point series (one segment)', () => {
+    const raw = {
+      series: [
+        {
+          name: 'db',
+          data: [{ timestamp: 1000, value: 1 }],
+        },
+      ],
+    }
+
+    const result = adapter(raw) as { segments: Array<{ entity: string; state: string; start: number; end: number }> }
+
+    expect(result.segments).toHaveLength(1)
+    expect(result.segments[0]).toEqual({ entity: 'db', state: 'up', start: 1000, end: 1000 })
+  })
+
+  it('dataAdapter handles empty series', () => {
+    const raw = { series: [] }
+    const result = adapter(raw) as { segments: unknown[] }
+
+    expect(result.segments).toHaveLength(0)
+  })
+
+  it('dataAdapter handles series with no data points', () => {
+    const raw = {
+      series: [{ name: 'empty-svc', data: [] }],
+    }
+
+    const result = adapter(raw) as { segments: unknown[] }
+
+    expect(result.segments).toHaveLength(0)
+  })
+
+  it('dataAdapter handles multiple series', () => {
+    const raw = {
+      series: [
+        {
+          name: 'svc-a',
+          data: [
+            { timestamp: 1000, value: 1 },
+            { timestamp: 2000, value: 1 },
+          ],
+        },
+        {
+          name: 'svc-b',
+          data: [
+            { timestamp: 1000, value: 0 },
+            { timestamp: 2000, value: 0 },
+          ],
+        },
+      ],
+    }
+
+    const result = adapter(raw) as { segments: Array<{ entity: string; state: string }> }
+
+    expect(result.segments).toHaveLength(2)
+    expect(result.segments[0].entity).toBe('svc-a')
+    expect(result.segments[0].state).toBe('up')
+    expect(result.segments[1].entity).toBe('svc-b')
+    expect(result.segments[1].state).toBe('down')
+  })
+
+  it('registers with type "state_timeline" and category "observability"', async () => {
+    const { lookupPanel } = await import('../../utils/panelRegistry')
+    const registration = lookupPanel('state_timeline')
+
+    expect(registration).not.toBeNull()
+    expect(registration?.type).toBe('state_timeline')
+    expect(registration?.category).toBe('observability')
+    expect(registration?.label).toBe('State Timeline')
+  })
+})

--- a/frontend/src/components/panels/StateTimelinePanel.vue
+++ b/frontend/src/components/panels/StateTimelinePanel.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+// Import ECharts custom chart components
+import { CustomChart } from 'echarts/charts'
+import { GridComponent, LegendComponent, TooltipComponent } from 'echarts/components'
+import { use } from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import VChart from 'vue-echarts'
+import {
+  chartAxisStyle,
+  chartPalette,
+  chartTooltipStyle,
+  thresholdColors,
+} from '../../utils/chartTheme'
+
+// Register ECharts components
+use([CanvasRenderer, CustomChart, GridComponent, TooltipComponent, LegendComponent])
+
+export interface StateSegment {
+  entity: string // e.g. "api-server", "db-primary"
+  state: string // e.g. "up", "down", "degraded"
+  start: number // Unix timestamp (seconds)
+  end: number // Unix timestamp (seconds)
+}
+
+const props = defineProps<{
+  segments: StateSegment[]
+  stateColors?: Record<string, string> // override state→color mapping
+}>()
+
+/** Resolve a state name to its display color. */
+function resolveColor(state: string): string {
+  // Check custom override first
+  if (props.stateColors?.[state]) {
+    return props.stateColors[state]
+  }
+  const s = state.toLowerCase()
+  if (s === 'up' || s === 'healthy' || s === 'ok') {
+    return thresholdColors.good
+  }
+  if (s === 'down' || s === 'error' || s === 'critical') {
+    return thresholdColors.critical
+  }
+  if (s === 'degraded' || s === 'warning') {
+    return thresholdColors.warning
+  }
+  return chartPalette[7] // Alloy Silver for unknown states
+}
+
+const chartRef = ref<typeof VChart | null>(null)
+
+/** Unique entity names — used as category axis labels. */
+const entities = computed(() => {
+  const seen = new Set<string>()
+  for (const seg of props.segments) {
+    seen.add(seg.entity)
+  }
+  return Array.from(seen)
+})
+
+/** Enriched segment data with resolved colors. */
+const seriesData = computed(() =>
+  props.segments.map((seg) => ({
+    ...seg,
+    color: resolveColor(seg.state),
+    value: [entities.value.indexOf(seg.entity), seg.start, seg.end],
+  })),
+)
+
+const chartOption = computed(() => ({
+  backgroundColor: 'transparent',
+  grid: {
+    left: '3%',
+    right: '4%',
+    top: '8%',
+    bottom: '8%',
+    containLabel: true,
+  },
+  tooltip: {
+    trigger: 'item' as const,
+    backgroundColor: chartTooltipStyle.backgroundColor,
+    borderColor: chartTooltipStyle.borderColor,
+    borderWidth: 1,
+    textStyle: {
+      color: chartTooltipStyle.textStyle.color,
+      fontFamily: chartTooltipStyle.textStyle.fontFamily,
+      fontSize: chartTooltipStyle.textStyle.fontSize,
+    },
+    formatter: (params: { data: { entity: string; state: string; start: number; end: number } }) => {
+      const { entity, state, start, end } = params.data
+      const durationSec = end - start
+      return `${entity}<br/>State: <b>${state}</b><br/>Duration: ${durationSec}s`
+    },
+  },
+  xAxis: {
+    type: 'time' as const,
+    axisLine: {
+      lineStyle: {
+        color: chartAxisStyle.axisLine.lineStyle.color,
+      },
+    },
+    axisTick: {
+      show: chartAxisStyle.axisTick.show,
+    },
+    axisLabel: {
+      color: chartAxisStyle.axisLabel.color,
+      fontFamily: chartAxisStyle.axisLabel.fontFamily,
+      fontSize: chartAxisStyle.axisLabel.fontSize,
+    },
+    splitLine: {
+      lineStyle: {
+        color: chartAxisStyle.splitLine.lineStyle.color,
+      },
+    },
+  },
+  yAxis: {
+    type: 'category' as const,
+    data: entities.value,
+    axisLine: {
+      lineStyle: {
+        color: chartAxisStyle.axisLine.lineStyle.color,
+      },
+    },
+    axisTick: {
+      show: chartAxisStyle.axisTick.show,
+    },
+    axisLabel: {
+      color: chartAxisStyle.axisLabel.color,
+      fontFamily: chartAxisStyle.axisLabel.fontFamily,
+      fontSize: chartAxisStyle.axisLabel.fontSize,
+    },
+  },
+  series: [
+    {
+      type: 'custom' as const,
+      renderItem: (
+        _params: unknown,
+        api: {
+          value: (idx: number) => number
+          coord: (arr: number[]) => number[]
+          size: (arr: number[]) => number[]
+          style: () => object
+        },
+      ) => {
+        const entityIndex = api.value(0)
+        const start = api.value(1)
+        const end = api.value(2)
+        const startCoord = api.coord([start, entityIndex])
+        const endCoord = api.coord([end, entityIndex])
+        const height = (api.size([0, 1])[1] ?? 20) * 0.6
+        return {
+          type: 'rect',
+          shape: {
+            x: startCoord[0],
+            y: startCoord[1] - height / 2,
+            width: endCoord[0] - startCoord[0],
+            height,
+          },
+          style: {
+            fill: seriesData.value.find(
+              (d) => d.value[0] === entityIndex && d.value[1] === start && d.value[2] === end,
+            )?.color ?? chartPalette[7],
+          },
+        }
+      },
+      encode: {
+        x: [1, 2],
+        y: 0,
+      },
+      data: seriesData.value,
+    },
+  ],
+}))
+
+// Handle resize
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  const container = chartRef.value?.$el?.parentElement
+  if (container) {
+    resizeObserver = new ResizeObserver(() => {
+      chartRef.value?.resize()
+    })
+    resizeObserver.observe(container)
+  }
+})
+
+onUnmounted(() => {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+})
+</script>
+
+<template>
+  <div class="h-full w-full">
+    <VChart
+      ref="chartRef"
+      :option="chartOption"
+      :autoresize="true"
+      class="h-full w-full"
+    />
+  </div>
+</template>

--- a/frontend/src/components/panels/StateTimelinePanel.vue
+++ b/frontend/src/components/panels/StateTimelinePanel.vue
@@ -134,7 +134,7 @@ const chartOption = computed(() => ({
     {
       type: 'custom' as const,
       renderItem: (
-        _params: unknown,
+        _params: { dataIndex: number },
         api: {
           value: (idx: number) => number
           coord: (arr: number[]) => number[]
@@ -157,9 +157,7 @@ const chartOption = computed(() => ({
             height,
           },
           style: {
-            fill: seriesData.value.find(
-              (d) => d.value[0] === entityIndex && d.value[1] === start && d.value[2] === end,
-            )?.color ?? chartPalette[7],
+            fill: seriesData.value[_params.dataIndex]?.color ?? chartPalette[7],
           },
         }
       },

--- a/frontend/src/components/panels/StatusHistoryPanel.spec.ts
+++ b/frontend/src/components/panels/StatusHistoryPanel.spec.ts
@@ -1,0 +1,398 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chartAxisStyle, chartPalette, chartTooltipStyle, thresholdColors } from '../../utils/chartTheme'
+import { clearRegistry } from '../../utils/panelRegistry'
+
+// Mock ECharts components
+vi.mock('vue-echarts', () => ({
+  default: {
+    name: 'VChart',
+    props: ['option', 'autoresize'],
+    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)"></div>',
+    methods: {
+      resize: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+}))
+
+vi.mock('echarts/renderers', () => ({
+  CanvasRenderer: {},
+}))
+
+vi.mock('echarts/charts', () => ({
+  HeatmapChart: {},
+}))
+
+vi.mock('echarts/components', () => ({
+  GridComponent: {},
+  TooltipComponent: {},
+  VisualMapComponent: {},
+}))
+
+// ---------------------------------------------------------------------------
+// StatusHistoryPanel component tests
+// ---------------------------------------------------------------------------
+
+describe('StatusHistoryPanel', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let StatusHistoryPanel: any
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const mod = await import('./StatusHistoryPanel.vue')
+    StatusHistoryPanel = mod.default
+  })
+
+  const mockCells = [
+    { entity: 'api-1', bucket: '10:00', state: 'up' },
+    { entity: 'api-1', bucket: '10:05', state: 'degraded' },
+    { entity: 'api-1', bucket: '10:10', state: 'down' },
+    { entity: 'api-2', bucket: '10:00', state: 'up' },
+    { entity: 'api-2', bucket: '10:05', state: 'up' },
+    { entity: 'db-primary', bucket: '10:00', state: 'up' },
+  ]
+
+  it('renders with valid status cells', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    expect(wrapper.find('.h-full.w-full').exists()).toBe(true)
+    expect(wrapper.find('.echarts-mock').exists()).toBe(true)
+  })
+
+  it('series type is heatmap', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series).toHaveLength(1)
+    expect(option.series[0].type).toBe('heatmap')
+  })
+
+  it('up state maps to thresholdColors.good', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: [{ entity: 'api-1', bucket: '10:00', state: 'up' }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const pieces = option.visualMap.pieces
+    const upPiece = pieces.find((p: { value: number }) => p.value === 0)
+    expect(upPiece).toBeDefined()
+    expect(upPiece.color).toBe(thresholdColors.good)
+  })
+
+  it('down state maps to thresholdColors.critical', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: [{ entity: 'api-1', bucket: '10:00', state: 'down' }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const pieces = option.visualMap.pieces
+    const downPiece = pieces.find((p: { value: number }) => p.value === 2)
+    expect(downPiece).toBeDefined()
+    expect(downPiece.color).toBe(thresholdColors.critical)
+  })
+
+  it('degraded state maps to thresholdColors.warning', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: [{ entity: 'api-1', bucket: '10:00', state: 'degraded' }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const pieces = option.visualMap.pieces
+    const degradedPiece = pieces.find((p: { value: number }) => p.value === 1)
+    expect(degradedPiece).toBeDefined()
+    expect(degradedPiece.color).toBe(thresholdColors.warning)
+  })
+
+  it('unknown state maps to chartPalette[7] (Alloy Silver)', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: [{ entity: 'svc', bucket: '10:00', state: 'maintenance' }] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const pieces = option.visualMap.pieces
+    const unknownPiece = pieces.find((p: { value: number }) => p.value === 3)
+    expect(unknownPiece).toBeDefined()
+    expect(unknownPiece.color).toBe(chartPalette[7])
+  })
+
+  it('custom stateColors prop overrides defaults', () => {
+    const customColors = { up: '#aabbcc', down: '#112233' }
+    const wrapper = mount(StatusHistoryPanel, {
+      props: {
+        cells: mockCells,
+        stateColors: customColors,
+      },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const pieces = option.visualMap.pieces
+    const upPiece = pieces.find((p: { value: number }) => p.value === 0)
+    const downPiece = pieces.find((p: { value: number }) => p.value === 2)
+    expect(upPiece.color).toBe('#aabbcc')
+    expect(downPiece.color).toBe('#112233')
+  })
+
+  it('xAxis has bucket labels as categories', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.xAxis.type).toBe('category')
+    expect(option.xAxis.data).toContain('10:00')
+    expect(option.xAxis.data).toContain('10:05')
+    expect(option.xAxis.data).toContain('10:10')
+  })
+
+  it('yAxis has entity names as categories', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.yAxis.type).toBe('category')
+    expect(option.yAxis.data).toContain('api-1')
+    expect(option.yAxis.data).toContain('api-2')
+    expect(option.yAxis.data).toContain('db-primary')
+  })
+
+  it('applies chartAxisStyle to axes', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.xAxis.axisLine.lineStyle.color).toBe(chartAxisStyle.axisLine.lineStyle.color)
+    expect(option.xAxis.axisTick.show).toBe(chartAxisStyle.axisTick.show)
+    expect(option.xAxis.axisLabel.color).toBe(chartAxisStyle.axisLabel.color)
+    expect(option.xAxis.axisLabel.fontFamily).toBe(chartAxisStyle.axisLabel.fontFamily)
+    expect(option.yAxis.axisLine.lineStyle.color).toBe(chartAxisStyle.axisLine.lineStyle.color)
+    expect(option.yAxis.axisLabel.color).toBe(chartAxisStyle.axisLabel.color)
+    expect(option.yAxis.axisLabel.fontFamily).toBe(chartAxisStyle.axisLabel.fontFamily)
+  })
+
+  it('applies chartTooltipStyle to tooltip', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.tooltip.backgroundColor).toBe(chartTooltipStyle.backgroundColor)
+    expect(option.tooltip.borderColor).toBe(chartTooltipStyle.borderColor)
+    expect(option.tooltip.textStyle.color).toBe(chartTooltipStyle.textStyle.color)
+  })
+
+  it('handles empty cells gracefully', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: [] },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.series[0].data).toHaveLength(0)
+    expect(option.xAxis.data).toHaveLength(0)
+    expect(option.yAxis.data).toHaveLength(0)
+  })
+
+  it('visualMap is piecewise (not continuous)', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.visualMap.type).toBe('piecewise')
+  })
+
+  it('series data is array of [bucketIndex, entityIndex, stateNumericValue]', () => {
+    const cells = [
+      { entity: 'api-1', bucket: '10:00', state: 'up' },
+      { entity: 'api-2', bucket: '10:05', state: 'down' },
+    ]
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    const data = option.series[0].data
+    expect(data).toHaveLength(2)
+    // Each item should be [bucketIndex, entityIndex, numericStateValue]
+    for (const item of data) {
+      expect(Array.isArray(item)).toBe(true)
+      expect(item).toHaveLength(3)
+    }
+  })
+
+  it('has transparent background', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.backgroundColor).toBe('transparent')
+  })
+
+  it('grid has padding properties', () => {
+    const wrapper = mount(StatusHistoryPanel, {
+      props: { cells: mockCells },
+    })
+    const chart = wrapper.find('.echarts-mock')
+    const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+    expect(option.grid).toBeDefined()
+    expect(option.grid.left).toBeDefined()
+    expect(option.grid.right).toBeDefined()
+    expect(option.grid.top).toBeDefined()
+    expect(option.grid.bottom).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Data adapter tests
+// ---------------------------------------------------------------------------
+
+describe('status_history dataAdapter', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let adapter: (raw: any) => any
+
+  beforeEach(async () => {
+    clearRegistry()
+    const { registerPanel: reg } = await import('../../utils/panelRegistry')
+    const { LayoutGrid } = await import('lucide-vue-next')
+    reg({
+      type: 'status_history',
+      component: () => import('./StatusHistoryPanel.vue'),
+      dataAdapter: (raw) => {
+        const cells: Array<{ entity: string; bucket: string; state: string }> = []
+        for (const series of raw.series) {
+          const points = series.data as Array<{ timestamp: number; value: number }>
+          for (const point of points) {
+            const date = new Date(point.timestamp * 1000)
+            const bucket = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
+            const state = point.value > 0.5 ? 'up' : point.value > 0 ? 'degraded' : 'down'
+            cells.push({ entity: series.name, bucket, state })
+          }
+        }
+        return { cells }
+      },
+      defaultQuery: {},
+      category: 'observability',
+      label: 'Status History',
+      icon: LayoutGrid,
+    })
+
+    const { lookupPanel } = await import('../../utils/panelRegistry')
+    adapter = lookupPanel('status_history')!.dataAdapter
+  })
+
+  afterEach(() => {
+    clearRegistry()
+  })
+
+  it('dataAdapter transforms value series into cells', () => {
+    const raw = {
+      series: [
+        {
+          name: 'api-server',
+          data: [
+            { timestamp: 1700000000, value: 1 },    // up
+            { timestamp: 1700000300, value: 0.3 },  // degraded
+            { timestamp: 1700000600, value: 0 },    // down
+          ],
+        },
+      ],
+    }
+
+    const result = adapter(raw) as { cells: Array<{ entity: string; bucket: string; state: string }> }
+
+    expect(result.cells).toHaveLength(3)
+    expect(result.cells[0].entity).toBe('api-server')
+    expect(result.cells[0].state).toBe('up')
+    expect(result.cells[1].state).toBe('degraded')
+    expect(result.cells[2].state).toBe('down')
+  })
+
+  it('dataAdapter produces bucket strings in HH:MM format', () => {
+    const raw = {
+      series: [
+        {
+          name: 'svc',
+          data: [{ timestamp: 1700000000, value: 1 }],
+        },
+      ],
+    }
+
+    const result = adapter(raw) as { cells: Array<{ bucket: string }> }
+
+    expect(result.cells[0].bucket).toMatch(/^\d{2}:\d{2}$/)
+  })
+
+  it('dataAdapter handles empty series', () => {
+    const raw = { series: [] }
+    const result = adapter(raw) as { cells: unknown[] }
+
+    expect(result.cells).toHaveLength(0)
+  })
+
+  it('dataAdapter handles series with no data points', () => {
+    const raw = {
+      series: [{ name: 'empty-svc', data: [] }],
+    }
+
+    const result = adapter(raw) as { cells: unknown[] }
+
+    expect(result.cells).toHaveLength(0)
+  })
+
+  it('dataAdapter handles multiple series', () => {
+    const raw = {
+      series: [
+        {
+          name: 'svc-a',
+          data: [{ timestamp: 1700000000, value: 1 }],
+        },
+        {
+          name: 'svc-b',
+          data: [{ timestamp: 1700000000, value: 0 }],
+        },
+      ],
+    }
+
+    const result = adapter(raw) as { cells: Array<{ entity: string; state: string }> }
+
+    expect(result.cells).toHaveLength(2)
+    expect(result.cells[0].entity).toBe('svc-a')
+    expect(result.cells[0].state).toBe('up')
+    expect(result.cells[1].entity).toBe('svc-b')
+    expect(result.cells[1].state).toBe('down')
+  })
+
+  it('registers with type "status_history" and category "observability"', async () => {
+    const { lookupPanel } = await import('../../utils/panelRegistry')
+    const registration = lookupPanel('status_history')
+
+    expect(registration).not.toBeNull()
+    expect(registration?.type).toBe('status_history')
+    expect(registration?.category).toBe('observability')
+    expect(registration?.label).toBe('Status History')
+  })
+})

--- a/frontend/src/components/panels/StatusHistoryPanel.vue
+++ b/frontend/src/components/panels/StatusHistoryPanel.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+// Import ECharts heatmap components
+import { HeatmapChart } from 'echarts/charts'
+import { GridComponent, TooltipComponent, VisualMapComponent } from 'echarts/components'
+import { use } from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import VChart from 'vue-echarts'
+import {
+  chartAxisStyle,
+  chartPalette,
+  chartTooltipStyle,
+  thresholdColors,
+} from '../../utils/chartTheme'
+
+// Register ECharts components
+use([CanvasRenderer, HeatmapChart, GridComponent, TooltipComponent, VisualMapComponent])
+
+export interface StatusCell {
+  entity: string  // y-axis label (e.g., "api-1", "api-2", "db-primary")
+  bucket: string  // x-axis label (e.g., "10:00", "10:05", "10:10")
+  state: string   // "up", "down", "degraded", etc.
+}
+
+/** Numeric mapping: up=0, degraded=1, down=2, unknown=3 */
+const STATE_TO_NUM: Record<string, number> = {
+  up: 0,
+  healthy: 0,
+  ok: 0,
+  degraded: 1,
+  warning: 1,
+  down: 2,
+  error: 2,
+  critical: 2,
+}
+
+const props = defineProps<{
+  cells: StatusCell[]
+  stateColors?: Record<string, string>  // override state→color mapping
+}>()
+
+/** Resolve the color for a state, checking custom overrides first. */
+function resolveStateColor(state: string): string {
+  if (props.stateColors?.[state]) {
+    return props.stateColors[state]
+  }
+  const s = state.toLowerCase()
+  if (s === 'up' || s === 'healthy' || s === 'ok') return thresholdColors.good
+  if (s === 'down' || s === 'error' || s === 'critical') return thresholdColors.critical
+  if (s === 'degraded' || s === 'warning') return thresholdColors.warning
+  return chartPalette[7]
+}
+
+/** Map a state string to its numeric value for visualMap. */
+function stateToNum(state: string): number {
+  const s = state.toLowerCase()
+  return STATE_TO_NUM[s] ?? 3
+}
+
+const chartRef = ref<typeof VChart | null>(null)
+
+/** Unique bucket labels, preserving insertion order. */
+const buckets = computed(() => {
+  const seen = new Set<string>()
+  for (const cell of props.cells) {
+    seen.add(cell.bucket)
+  }
+  return Array.from(seen)
+})
+
+/** Unique entity names, preserving insertion order. */
+const entities = computed(() => {
+  const seen = new Set<string>()
+  for (const cell of props.cells) {
+    seen.add(cell.entity)
+  }
+  return Array.from(seen)
+})
+
+/** Series data: [bucketIndex, entityIndex, stateNumericValue] */
+const seriesData = computed(() =>
+  props.cells.map((cell) => [
+    buckets.value.indexOf(cell.bucket),
+    entities.value.indexOf(cell.entity),
+    stateToNum(cell.state),
+  ]),
+)
+
+/** Build the piecewise visualMap pieces using resolved colors. */
+const visualMapPieces = computed(() => [
+  { value: 0, label: 'Up', color: resolveStateColor('up') },
+  { value: 1, label: 'Degraded', color: resolveStateColor('degraded') },
+  { value: 2, label: 'Down', color: resolveStateColor('down') },
+  { value: 3, label: 'Unknown', color: chartPalette[7] },
+])
+
+/** Build state name lookup for tooltip (numeric → state label). */
+const numToStateName = computed(() => {
+  const map = new Map<number, string>()
+  for (const cell of props.cells) {
+    const num = stateToNum(cell.state)
+    if (!map.has(num)) {
+      map.set(num, cell.state)
+    }
+  }
+  return map
+})
+
+const chartOption = computed(() => ({
+  backgroundColor: 'transparent',
+  grid: {
+    left: '3%',
+    right: '8%',
+    top: '8%',
+    bottom: '12%',
+    containLabel: true,
+  },
+  tooltip: {
+    trigger: 'item' as const,
+    backgroundColor: chartTooltipStyle.backgroundColor,
+    borderColor: chartTooltipStyle.borderColor,
+    borderWidth: 1,
+    textStyle: {
+      color: chartTooltipStyle.textStyle.color,
+      fontFamily: chartTooltipStyle.textStyle.fontFamily,
+      fontSize: chartTooltipStyle.textStyle.fontSize,
+    },
+    formatter: (params: { data: [number, number, number] }) => {
+      const [bucketIdx, entityIdx, stateNum] = params.data
+      const entity = entities.value[entityIdx] ?? '?'
+      const bucket = buckets.value[bucketIdx] ?? '?'
+      const stateName = numToStateName.value.get(stateNum) ?? 'unknown'
+      return `${entity}<br/>Time: <b>${bucket}</b><br/>State: <b>${stateName}</b>`
+    },
+  },
+  visualMap: {
+    type: 'piecewise' as const,
+    pieces: visualMapPieces.value,
+    orient: 'horizontal' as const,
+    left: 'center',
+    bottom: 0,
+    show: true,
+    textStyle: {
+      color: chartAxisStyle.axisLabel.color,
+      fontFamily: chartAxisStyle.axisLabel.fontFamily,
+      fontSize: chartAxisStyle.axisLabel.fontSize,
+    },
+  },
+  xAxis: {
+    type: 'category' as const,
+    data: buckets.value,
+    axisLine: {
+      lineStyle: {
+        color: chartAxisStyle.axisLine.lineStyle.color,
+      },
+    },
+    axisTick: {
+      show: chartAxisStyle.axisTick.show,
+    },
+    axisLabel: {
+      color: chartAxisStyle.axisLabel.color,
+      fontFamily: chartAxisStyle.axisLabel.fontFamily,
+      fontSize: chartAxisStyle.axisLabel.fontSize,
+    },
+    splitLine: {
+      lineStyle: {
+        color: chartAxisStyle.splitLine.lineStyle.color,
+      },
+    },
+  },
+  yAxis: {
+    type: 'category' as const,
+    data: entities.value,
+    axisLine: {
+      lineStyle: {
+        color: chartAxisStyle.axisLine.lineStyle.color,
+      },
+    },
+    axisTick: {
+      show: chartAxisStyle.axisTick.show,
+    },
+    axisLabel: {
+      color: chartAxisStyle.axisLabel.color,
+      fontFamily: chartAxisStyle.axisLabel.fontFamily,
+      fontSize: chartAxisStyle.axisLabel.fontSize,
+    },
+    splitLine: {
+      lineStyle: {
+        color: chartAxisStyle.splitLine.lineStyle.color,
+      },
+    },
+  },
+  series: [
+    {
+      type: 'heatmap' as const,
+      data: seriesData.value,
+      emphasis: {
+        itemStyle: {
+          shadowBlur: 10,
+          shadowColor: 'rgba(0, 0, 0, 0.5)',
+        },
+      },
+    },
+  ],
+}))
+
+// Handle resize
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  const container = chartRef.value?.$el?.parentElement
+  if (container) {
+    resizeObserver = new ResizeObserver(() => {
+      chartRef.value?.resize()
+    })
+    resizeObserver.observe(container)
+  }
+})
+
+onUnmounted(() => {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+})
+</script>
+
+<template>
+  <div class="h-full w-full">
+    <VChart
+      ref="chartRef"
+      :option="chartOption"
+      :autoresize="true"
+      class="h-full w-full"
+    />
+  </div>
+</template>

--- a/frontend/src/components/panels/TraceDetailPanel.spec.ts
+++ b/frontend/src/components/panels/TraceDetailPanel.spec.ts
@@ -1,0 +1,402 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getSeriesColor, thresholdColors } from '../../utils/chartTheme'
+import { clearRegistry } from '../../utils/panelRegistry'
+import type { TraceSpanItem } from './TraceDetailPanel.vue'
+
+// ---------------------------------------------------------------------------
+// TraceDetailPanel component tests
+// ---------------------------------------------------------------------------
+
+describe('TraceDetailPanel', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let TraceDetailPanel: any
+
+  beforeEach(async () => {
+    const mod = await import('./TraceDetailPanel.vue')
+    TraceDetailPanel = mod.default
+  })
+
+  // A simple trace: root -> child-a -> grandchild, root -> child-b
+  const rootSpan: TraceSpanItem = {
+    spanId: 'span-root',
+    operationName: 'HTTP GET /api',
+    serviceName: 'gateway',
+    startTime: 1000000, // 1s in microseconds
+    duration: 500000, // 500ms
+  }
+
+  const childA: TraceSpanItem = {
+    spanId: 'span-a',
+    parentSpanId: 'span-root',
+    operationName: 'db.query',
+    serviceName: 'user-service',
+    startTime: 1050000,
+    duration: 200000,
+  }
+
+  const grandchild: TraceSpanItem = {
+    spanId: 'span-gc',
+    parentSpanId: 'span-a',
+    operationName: 'SELECT * FROM users',
+    serviceName: 'user-service',
+    startTime: 1060000,
+    duration: 100000,
+  }
+
+  const childB: TraceSpanItem = {
+    spanId: 'span-b',
+    parentSpanId: 'span-root',
+    operationName: 'cache.get',
+    serviceName: 'cache-service',
+    startTime: 1100000,
+    duration: 50000,
+    status: 'error',
+  }
+
+  const allSpans: TraceSpanItem[] = [rootSpan, childA, grandchild, childB]
+
+  // Test 1: Renders rows for each span
+  it('renders a row for each span', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const rows = wrapper.findAll('[data-testid="trace-span-row"]')
+    expect(rows).toHaveLength(4)
+  })
+
+  // Test 2: Root span (no parentSpanId) rendered at top level (no indent)
+  it('root span has no indent', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const rows = wrapper.findAll('[data-testid="trace-span-row"]')
+    // First row is root (DFS order); check its label area indent
+    const labelArea = rows[0].find('[data-testid="span-label"]')
+    expect(labelArea.exists()).toBe(true)
+    // Root has depth 0, so paddingLeft should be 0px (or minimal base)
+    const style = labelArea.attributes('style') ?? ''
+    // depth=0 means padding-left: 0px
+    expect(style).toContain('padding-left: 0px')
+  })
+
+  // Test 3: Child spans indented based on depth
+  it('child spans are indented based on depth', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const rows = wrapper.findAll('[data-testid="trace-span-row"]')
+    // DFS order: root(0), child-a(1), grandchild(2), child-b(1)
+    const labels = rows.map((r) => r.find('[data-testid="span-label"]'))
+
+    // child-a at depth 1 → 16px indent
+    expect(labels[1].attributes('style')).toContain('padding-left: 16px')
+    // grandchild at depth 2 → 32px indent
+    expect(labels[2].attributes('style')).toContain('padding-left: 32px')
+    // child-b at depth 1 → 16px indent
+    expect(labels[3].attributes('style')).toContain('padding-left: 16px')
+  })
+
+  // Test 4: Bar width proportional to duration
+  it('bar width proportional to duration', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const bars = wrapper.findAll('[data-testid="span-bar"]')
+    expect(bars).toHaveLength(4)
+
+    // traceDuration auto-detected as 500000 (root span: starts at 1000000, duration 500000)
+    // But traceDuration = max(startTime+duration) - min(startTime) = (1500000 - 1000000) = 500000
+    // Root bar width = 500000/500000 * 100 = 100%
+    const rootBar = bars[0]
+    const rootStyle = rootBar.attributes('style') ?? ''
+    expect(rootStyle).toContain('width: 100%')
+
+    // child-a bar width = 200000/500000 * 100 = 40%
+    const childABar = bars[1]
+    const childAStyle = childABar.attributes('style') ?? ''
+    expect(childAStyle).toContain('width: 40%')
+  })
+
+  // Test 5: Bar left position proportional to start time offset
+  it('bar left position proportional to start time offset', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const bars = wrapper.findAll('[data-testid="span-bar"]')
+
+    // Root starts at traceStartTime, so left = 0%
+    const rootStyle = bars[0].attributes('style') ?? ''
+    expect(rootStyle).toContain('left: 0%')
+
+    // child-a: (1050000 - 1000000) / 500000 * 100 = 10%
+    const childAStyle = bars[1].attributes('style') ?? ''
+    expect(childAStyle).toContain('left: 10%')
+
+    // child-b: (1100000 - 1000000) / 500000 * 100 = 20%
+    const childBStyle = bars[3].attributes('style') ?? ''
+    expect(childBStyle).toContain('left: 20%')
+  })
+
+  // Test 6: Error spans use thresholdColors.critical
+  it('error spans use thresholdColors.critical color', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const bars = wrapper.findAll('[data-testid="span-bar"]')
+
+    // child-b is the error span (index 3 in DFS)
+    const errorBarStyle = bars[3].attributes('style') ?? ''
+    expect(errorBarStyle).toContain(thresholdColors.critical)
+  })
+
+  // Test 7: Same service name gets same color
+  it('same service name gets same color', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const bars = wrapper.findAll('[data-testid="span-bar"]')
+
+    // child-a and grandchild both have serviceName 'user-service'
+    const childAStyle = bars[1].attributes('style') ?? ''
+    const grandchildStyle = bars[2].attributes('style') ?? ''
+
+    // Extract background-color from both — they should match
+    // Both use the same service so get the same getSeriesColor index
+    // Service order: gateway(0), user-service(1), cache-service(2)
+    const expectedColor = getSeriesColor(1)
+    expect(childAStyle).toContain(expectedColor)
+    expect(grandchildStyle).toContain(expectedColor)
+  })
+
+  // Test 8: Duration formatted correctly (us/ms/s thresholds)
+  it('duration formatted correctly (us/ms/s thresholds)', () => {
+    const spansWithVariousDurations: TraceSpanItem[] = [
+      {
+        spanId: 'fast',
+        operationName: 'fast-op',
+        serviceName: 'svc',
+        startTime: 0,
+        duration: 500, // 500us
+      },
+      {
+        spanId: 'medium',
+        operationName: 'medium-op',
+        serviceName: 'svc',
+        startTime: 0,
+        duration: 5000, // 5ms (5000us)
+      },
+      {
+        spanId: 'slow',
+        operationName: 'slow-op',
+        serviceName: 'svc',
+        startTime: 0,
+        duration: 2500000, // 2.5s
+      },
+    ]
+
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: spansWithVariousDurations },
+    })
+    const durationLabels = wrapper.findAll('[data-testid="span-duration"]')
+    expect(durationLabels).toHaveLength(3)
+
+    // 500us → "500us"
+    expect(durationLabels[0].text()).toContain('500')
+    expect(durationLabels[0].text()).toContain('us')
+    // 5000us = 5ms → "5ms"
+    expect(durationLabels[1].text()).toContain('5')
+    expect(durationLabels[1].text()).toContain('ms')
+    // 2500000us = 2.5s → "2.5s"
+    expect(durationLabels[2].text()).toContain('2.5')
+    expect(durationLabels[2].text()).toContain('s')
+  })
+
+  // Test 9: Service name and operation name displayed
+  it('displays service name and operation name', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: [rootSpan] },
+    })
+    const row = wrapper.find('[data-testid="trace-span-row"]')
+    expect(row.text()).toContain('gateway')
+    expect(row.text()).toContain('HTTP GET /api')
+  })
+
+  // Test 10: Handles empty spans (empty state)
+  it('handles empty spans gracefully', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: [] },
+    })
+    const rows = wrapper.findAll('[data-testid="trace-span-row"]')
+    expect(rows).toHaveLength(0)
+    // Container should still render
+    const container = wrapper.find('[data-testid="trace-detail-container"]')
+    expect(container.exists()).toBe(true)
+  })
+
+  // Test 11: Handles single span (root only)
+  it('handles single span (root only)', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: [rootSpan] },
+    })
+    const rows = wrapper.findAll('[data-testid="trace-span-row"]')
+    expect(rows).toHaveLength(1)
+
+    // Bar should span full width
+    const bar = wrapper.find('[data-testid="span-bar"]')
+    const style = bar.attributes('style') ?? ''
+    expect(style).toContain('width: 100%')
+    expect(style).toContain('left: 0%')
+  })
+
+  // Test 12: Auto-detects traceStartTime and traceDuration from spans
+  it('auto-detects traceStartTime and traceDuration when not provided', () => {
+    // Two spans: one starts at 100, duration 50; another starts at 120, duration 80
+    // traceStart = 100, traceEnd = max(100+50, 120+80) = 200, traceDuration = 100
+    const spans: TraceSpanItem[] = [
+      {
+        spanId: 's1',
+        operationName: 'op1',
+        serviceName: 'svc',
+        startTime: 100,
+        duration: 50,
+      },
+      {
+        spanId: 's2',
+        operationName: 'op2',
+        serviceName: 'svc',
+        startTime: 120,
+        duration: 80,
+      },
+    ]
+
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans },
+    })
+    const bars = wrapper.findAll('[data-testid="span-bar"]')
+
+    // s1: left = (100-100)/100 = 0%, width = 50/100 = 50%
+    expect(bars[0].attributes('style')).toContain('left: 0%')
+    expect(bars[0].attributes('style')).toContain('width: 50%')
+
+    // s2: left = (120-100)/100 = 20%, width = 80/100 = 80%
+    expect(bars[1].attributes('style')).toContain('left: 20%')
+    expect(bars[1].attributes('style')).toContain('width: 80%')
+  })
+
+  // Test 13: Container is scrollable
+  it('container is scrollable', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const container = wrapper.find('[data-testid="trace-detail-container"]')
+    expect(container.exists()).toBe(true)
+    const style = container.attributes('style') ?? ''
+    expect(style).toContain('overflow')
+  })
+
+  // Test 14: Explicit traceStartTime and traceDuration override auto-detection
+  it('respects explicit traceStartTime and traceDuration props', () => {
+    const spans: TraceSpanItem[] = [
+      {
+        spanId: 's1',
+        operationName: 'op1',
+        serviceName: 'svc',
+        startTime: 200,
+        duration: 100,
+      },
+    ]
+    const wrapper = mount(TraceDetailPanel, {
+      props: {
+        spans,
+        traceStartTime: 0,
+        traceDuration: 1000,
+      },
+    })
+    const bar = wrapper.find('[data-testid="span-bar"]')
+    const style = bar.attributes('style') ?? ''
+    // left = (200 - 0) / 1000 * 100 = 20%
+    expect(style).toContain('left: 20%')
+    // width = 100 / 1000 * 100 = 10%
+    expect(style).toContain('width: 10%')
+  })
+
+  // Test 15: Different services get different colors
+  it('different services get different colors', () => {
+    const wrapper = mount(TraceDetailPanel, {
+      props: { spans: allSpans },
+    })
+    const bars = wrapper.findAll('[data-testid="span-bar"]')
+
+    // gateway (index 0), user-service (index 1) should have different colors
+    // (skip error span for this check)
+    const gatewayStyle = bars[0].attributes('style') ?? ''
+    const userSvcStyle = bars[1].attributes('style') ?? ''
+
+    const gatewayColor = getSeriesColor(0)
+    const userSvcColor = getSeriesColor(1)
+
+    expect(gatewayStyle).toContain(gatewayColor)
+    expect(userSvcStyle).toContain(userSvcColor)
+    expect(gatewayColor).not.toBe(userSvcColor)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Registration tests
+// ---------------------------------------------------------------------------
+
+describe('trace_detail panel registration', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  let reg: any
+
+  beforeEach(async () => {
+    clearRegistry()
+    const { registerPanel } = await import('../../utils/panelRegistry')
+    const { GitBranch } = await import('lucide-vue-next')
+    registerPanel({
+      type: 'trace_detail',
+      component: () => import('./TraceDetailPanel.vue'),
+      dataAdapter: () => {
+        return { spans: [] }
+      },
+      defaultQuery: {},
+      category: 'observability',
+      label: 'Trace Detail',
+      icon: GitBranch,
+    })
+    const { lookupPanel } = await import('../../utils/panelRegistry')
+    reg = lookupPanel('trace_detail')
+  })
+
+  afterEach(() => {
+    clearRegistry()
+  })
+
+  it('registers with type "trace_detail"', () => {
+    expect(reg).not.toBeNull()
+    expect(reg?.type).toBe('trace_detail')
+  })
+
+  it('registers with category "observability"', () => {
+    expect(reg?.category).toBe('observability')
+  })
+
+  it('registers with label "Trace Detail"', () => {
+    expect(reg?.label).toBe('Trace Detail')
+  })
+
+  it('dataAdapter returns empty spans', () => {
+    const result = reg!.dataAdapter({ series: [] })
+    expect(result.spans).toBeDefined()
+    expect(result.spans).toHaveLength(0)
+  })
+
+  it('defaultQuery is an empty object', () => {
+    expect(reg?.defaultQuery).toEqual({})
+  })
+
+  it('icon is defined', () => {
+    expect(reg?.icon).toBeDefined()
+  })
+})

--- a/frontend/src/components/panels/TraceDetailPanel.vue
+++ b/frontend/src/components/panels/TraceDetailPanel.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { getSeriesColor, thresholdColors } from '../../utils/chartTheme'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TraceSpanItem {
+  spanId: string
+  parentSpanId?: string
+  operationName: string
+  serviceName: string
+  startTime: number // Unix timestamp in microseconds
+  duration: number // Duration in microseconds
+  status?: 'ok' | 'error'
+  tags?: Record<string, string>
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+const props = defineProps<{
+  spans: TraceSpanItem[]
+  traceStartTime?: number
+  traceDuration?: number
+}>()
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INDENT_PX = 16
+const ROW_HEIGHT = 28
+const ROW_GAP = 2
+
+// ---------------------------------------------------------------------------
+// Tree building + DFS flattening
+// ---------------------------------------------------------------------------
+
+interface FlatSpan {
+  span: TraceSpanItem
+  depth: number
+}
+
+function buildFlatSpans(spans: TraceSpanItem[]): FlatSpan[] {
+  if (spans.length === 0) return []
+
+  // Build parent -> children map
+  const childrenMap = new Map<string, TraceSpanItem[]>()
+  const spanById = new Map<string, TraceSpanItem>()
+  const roots: TraceSpanItem[] = []
+
+  for (const span of spans) {
+    spanById.set(span.spanId, span)
+    if (!span.parentSpanId) {
+      roots.push(span)
+    } else {
+      const siblings = childrenMap.get(span.parentSpanId) ?? []
+      siblings.push(span)
+      childrenMap.set(span.parentSpanId, siblings)
+    }
+  }
+
+  // Handle orphan spans (parentSpanId set but parent not in the list)
+  for (const span of spans) {
+    if (span.parentSpanId && !spanById.has(span.parentSpanId)) {
+      roots.push(span)
+    }
+  }
+
+  // DFS from roots
+  const result: FlatSpan[] = []
+  function dfs(span: TraceSpanItem, depth: number) {
+    result.push({ span, depth })
+    const children = childrenMap.get(span.spanId) ?? []
+    for (const child of children) {
+      dfs(child, depth + 1)
+    }
+  }
+
+  for (const root of roots) {
+    dfs(root, 0)
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Computed
+// ---------------------------------------------------------------------------
+
+const flatSpans = computed(() => buildFlatSpans(props.spans))
+
+const resolvedTraceStartTime = computed(() => {
+  if (props.traceStartTime !== undefined) return props.traceStartTime
+  if (props.spans.length === 0) return 0
+  return Math.min(...props.spans.map((s) => s.startTime))
+})
+
+const resolvedTraceDuration = computed(() => {
+  if (props.traceDuration !== undefined) return props.traceDuration
+  if (props.spans.length === 0) return 1
+  const traceEnd = Math.max(...props.spans.map((s) => s.startTime + s.duration))
+  const dur = traceEnd - resolvedTraceStartTime.value
+  return dur > 0 ? dur : 1
+})
+
+// Map service names to stable color indices
+const serviceColorMap = computed(() => {
+  const map = new Map<string, number>()
+  let idx = 0
+  for (const span of props.spans) {
+    if (!map.has(span.serviceName)) {
+      map.set(span.serviceName, idx++)
+    }
+  }
+  return map
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function barLeft(span: TraceSpanItem): string {
+  const pct = ((span.startTime - resolvedTraceStartTime.value) / resolvedTraceDuration.value) * 100
+  return `${pct}%`
+}
+
+function barWidth(span: TraceSpanItem): string {
+  const pct = (span.duration / resolvedTraceDuration.value) * 100
+  return `${pct}%`
+}
+
+function barColor(span: TraceSpanItem): string {
+  if (span.status === 'error') return thresholdColors.critical
+  const idx = serviceColorMap.value.get(span.serviceName) ?? 0
+  return getSeriesColor(idx)
+}
+
+function formatDuration(us: number): string {
+  if (us < 1000) return `${us}us`
+  if (us < 1000000) {
+    const ms = us / 1000
+    return `${Number.isInteger(ms) ? ms : ms.toFixed(1)}ms`
+  }
+  const s = us / 1000000
+  return `${Number.isInteger(s) ? s : s.toFixed(1)}s`
+}
+</script>
+
+<template>
+  <div
+    data-testid="trace-detail-container"
+    :style="{
+      overflow: 'auto',
+      height: '100%',
+      width: '100%',
+      backgroundColor: 'transparent',
+      fontFamily: '\'DM Sans\', sans-serif',
+    }"
+  >
+    <div
+      v-for="(entry, i) in flatSpans"
+      :key="entry.span.spanId + '-' + i"
+      data-testid="trace-span-row"
+      :style="{
+        display: 'flex',
+        alignItems: 'center',
+        height: ROW_HEIGHT + 'px',
+        marginBottom: ROW_GAP + 'px',
+        cursor: 'pointer',
+      }"
+      class="trace-span-row"
+    >
+      <!-- Left: span label area (fixed width) -->
+      <div
+        data-testid="span-label"
+        :style="{
+          width: '200px',
+          minWidth: '200px',
+          paddingLeft: entry.depth * INDENT_PX + 'px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontSize: '12px',
+          lineHeight: ROW_HEIGHT + 'px',
+        }"
+      >
+        <span :style="{ color: 'var(--color-on-surface-variant)', marginRight: '4px' }">{{
+          entry.span.serviceName
+        }}</span>
+        <span :style="{ color: 'var(--color-on-surface)' }">{{
+          entry.span.operationName
+        }}</span>
+      </div>
+
+      <!-- Right: timeline bar area -->
+      <div
+        :style="{
+          flex: '1',
+          position: 'relative',
+          height: '100%',
+        }"
+      >
+        <div
+          data-testid="span-bar"
+          :style="{
+            position: 'absolute',
+            top: '4px',
+            bottom: '4px',
+            left: barLeft(entry.span),
+            width: barWidth(entry.span),
+            backgroundColor: barColor(entry.span),
+            borderRadius: '2px',
+            minWidth: '1px',
+          }"
+        />
+        <span
+          data-testid="span-duration"
+          :style="{
+            position: 'absolute',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            left: 'calc(' + barLeft(entry.span) + ' + ' + barWidth(entry.span) + ' + 4px)',
+            fontSize: '10px',
+            fontFamily: '\'JetBrains Mono\', monospace',
+            color: 'var(--color-on-surface-variant)',
+            whiteSpace: 'nowrap',
+          }"
+        >
+          {{ formatDuration(entry.span.duration) }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.trace-span-row:hover {
+  background-color: var(--color-surface-hover, rgba(255, 255, 255, 0.04));
+}
+</style>

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -2,6 +2,7 @@ import {
   BarChart3,
   Bell,
   FileText,
+  Flame,
   GanttChart,
   GaugeCircle,
   Grid3x3,
@@ -203,4 +204,23 @@ registerPanel({
   category: 'observability',
   label: 'Status History',
   icon: LayoutGrid,
+})
+
+// Register Flame Graph
+registerPanel({
+  type: 'flame_graph',
+  component: () => import('./FlameGraphPanel.vue'),
+  dataAdapter: (_raw: RawQueryResult) => {
+    // Flame graphs typically come from trace/profiling data
+    // For now, return a stub root node
+    // Real integration would parse trace spans into a call tree
+    return {
+      root: { name: 'root', value: 0, children: [] },
+      unit: 'ms',
+    }
+  },
+  defaultQuery: {},
+  category: 'observability',
+  label: 'Flame Graph',
+  icon: Flame,
 })

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -2,6 +2,7 @@ import {
   BarChart3,
   Bell,
   FileText,
+  GanttChart,
   GaugeCircle,
   Grid3x3,
   ScatterChart as ScatterIcon,
@@ -122,6 +123,38 @@ registerPanel({
   category: 'widgets',
   label: 'Alert List',
   icon: Bell,
+})
+
+// Register State Timeline
+registerPanel({
+  type: 'state_timeline',
+  component: () => import('./StateTimelinePanel.vue'),
+  dataAdapter: (raw: RawQueryResult) => {
+    // Transform metric series into state segments
+    // Each series = one entity, value thresholds determine state
+    const segments: Array<{ entity: string; state: string; start: number; end: number }> = []
+    for (const series of raw.series) {
+      const points = series.data as Array<{ timestamp: number; value: number }>
+      if (points.length === 0) continue
+      let currentState = points[0].value > 0 ? 'up' : 'down'
+      let segStart = points[0].timestamp
+      for (let i = 1; i < points.length; i++) {
+        const newState = points[i].value > 0 ? 'up' : 'down'
+        if (newState !== currentState) {
+          segments.push({ entity: series.name, state: currentState, start: segStart, end: points[i].timestamp })
+          currentState = newState
+          segStart = points[i].timestamp
+        }
+      }
+      // Close final segment
+      segments.push({ entity: series.name, state: currentState, start: segStart, end: points[points.length - 1].timestamp })
+    }
+    return { segments }
+  },
+  defaultQuery: {},
+  category: 'observability',
+  label: 'State Timeline',
+  icon: GanttChart,
 })
 
 // Register Histogram

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -7,6 +7,7 @@ import {
   GaugeCircle,
   Grid3x3,
   LayoutGrid,
+  Network,
   ScatterChart as ScatterIcon,
 } from 'lucide-vue-next'
 import type { RawQueryResult } from '../../types/panel'
@@ -223,4 +224,19 @@ registerPanel({
   category: 'observability',
   label: 'Flame Graph',
   icon: Flame,
+})
+
+// Register Node Graph
+registerPanel({
+  type: 'node_graph',
+  component: () => import('./NodeGraphPanel.vue'),
+  dataAdapter: (_raw: RawQueryResult) => {
+    // Node graph typically comes from trace service maps
+    // Stub: return empty graph
+    return { nodes: [], edges: [] }
+  },
+  defaultQuery: {},
+  category: 'observability',
+  label: 'Node Graph',
+  icon: Network,
 })

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -5,6 +5,7 @@ import {
   Flame,
   GanttChart,
   GaugeCircle,
+  GitBranch,
   Grid3x3,
   LayoutGrid,
   Network,
@@ -144,13 +145,23 @@ registerPanel({
       for (let i = 1; i < points.length; i++) {
         const newState = points[i].value > 0 ? 'up' : 'down'
         if (newState !== currentState) {
-          segments.push({ entity: series.name, state: currentState, start: segStart, end: points[i].timestamp })
+          segments.push({
+            entity: series.name,
+            state: currentState,
+            start: segStart,
+            end: points[i].timestamp,
+          })
           currentState = newState
           segStart = points[i].timestamp
         }
       }
       // Close final segment
-      segments.push({ entity: series.name, state: currentState, start: segStart, end: points[points.length - 1].timestamp })
+      segments.push({
+        entity: series.name,
+        state: currentState,
+        start: segStart,
+        end: points[points.length - 1].timestamp,
+      })
     }
     return { segments }
   },
@@ -239,4 +250,19 @@ registerPanel({
   category: 'observability',
   label: 'Node Graph',
   icon: Network,
+})
+
+// Register Trace Detail
+registerPanel({
+  type: 'trace_detail',
+  component: () => import('./TraceDetailPanel.vue'),
+  dataAdapter: (_raw: RawQueryResult) => {
+    // Trace detail gets span data from trace queries
+    // Stub: return empty spans
+    return { spans: [] }
+  },
+  defaultQuery: {},
+  category: 'observability',
+  label: 'Trace Detail',
+  icon: GitBranch,
 })

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -5,6 +5,7 @@ import {
   GanttChart,
   GaugeCircle,
   Grid3x3,
+  LayoutGrid,
   ScatterChart as ScatterIcon,
 } from 'lucide-vue-next'
 import type { RawQueryResult } from '../../types/panel'
@@ -177,4 +178,29 @@ registerPanel({
   category: 'charts',
   label: 'Histogram',
   icon: BarChart3,
+})
+
+// Register Status History
+registerPanel({
+  type: 'status_history',
+  component: () => import('./StatusHistoryPanel.vue'),
+  dataAdapter: (raw: RawQueryResult) => {
+    // Transform series into status cells
+    // Each series = entity, each data point = time bucket
+    const cells: Array<{ entity: string; bucket: string; state: string }> = []
+    for (const series of raw.series) {
+      const points = series.data as Array<{ timestamp: number; value: number }>
+      for (const point of points) {
+        const date = new Date(point.timestamp * 1000)
+        const bucket = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
+        const state = point.value > 0.5 ? 'up' : point.value > 0 ? 'degraded' : 'down'
+        cells.push({ entity: series.name, bucket, state })
+      }
+    }
+    return { cells }
+  },
+  defaultQuery: {},
+  category: 'observability',
+  label: 'Status History',
+  icon: LayoutGrid,
 })


### PR DESCRIPTION
## Summary

Adds 5 observability-focused panel types — the second tier of the Grafana chart parity initiative.

### New Panel Types (Tier 2)

| Type | Panel Key | Category | Rendering | Tests |
|------|-----------|----------|-----------|-------|
| State Timeline | `state_timeline` | observability | ECharts custom series (horizontal bars per state) | 24 |
| Status History | `status_history` | observability | ECharts heatmap (categorical grid) | 22 |
| Flame Graph | `flame_graph` | observability | Custom SVG (recursive tree → rect layout) | 21 |
| Node Graph | `node_graph` | observability | SVG + d3-force (force-directed layout) | 18 |
| Trace Detail | `trace_detail` | observability | Custom HTML/CSS (Gantt waterfall) | 21 |

### Architecture

- **State Timeline & Status History**: ECharts-based, follow Tier 1 patterns. Both use state→color mapping via `thresholdColors` (good/warning/critical).
- **Flame Graph**: Pure SVG rendering. Recursive tree flattening, deterministic colors via name hash into `chartPalette`, bottom-up stack layout.
- **Node Graph**: SVG + `d3-force` simulation. Force-directed layout with 300-iteration cap, node colors from `chartPalette`, edge thickness normalized by value.
- **Trace Detail**: Pure HTML/CSS Gantt waterfall. Builds span tree from `parentSpanId`, DFS flatten with depth, proportional timing bars. Error spans highlighted with `thresholdColors.critical`.

### New Dependencies

| Package | Purpose | Size |
|---------|---------|------|
| `d3-force` | Node Graph force-directed layout | ~15KB |
| `@types/d3-force` | TypeScript types | dev only |

## Test Coverage

- **Tests: 889 → 995 (+106 new)**
- All 5 new panels: 106 tests total
- All panels use `chartTheme.ts` — zero hardcoded hex values
- dataAdapter stubs for all panels (real integration in follow-up)

## Test plan

- [x] All Vitest tests pass (995 tests, 9 pre-existing HomeView failures)
- [x] All new panels registered in panelRegistry via panels/index.ts
- [x] No hardcoded colors — all panels use chartTheme.ts
- [ ] Manual: verify each panel renders with sample data
- [ ] Manual: verify flame graph handles deep call stacks
- [ ] Manual: verify node graph layout stabilizes

## What's Next

- **Tier 3**: Geomap, Candlestick, Canvas (Excalidraw), Annotation List, Dashboard List
- **PanelEditModal**: Categorized panel type picker (deferred)
- **Backend integration**: Real dataAdapters for trace/alert panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)