### PR TITLE
fix: mock useDatasource in HomeView tests

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,52 @@
 # TODOS
 
+## AI Providers
+
+### Copilot token caching
+
+**What:** Cache short-lived Copilot session tokens in a sync.Map keyed by userID with TTL = expires_at minus 60s buffer.
+
+**Why:** Eliminates one GitHub API round-trip (~200-500ms) per chat request for Copilot users. Currently fetchCopilotToken hits GitHub's API on every single chat request even though tokens are valid for ~30 minutes.
+
+**Pros:** Faster Copilot chat responses, fewer GitHub API calls.
+**Cons:** Minimal — cache invalidation is simple (TTL-based, tokens have explicit expires_at).
+
+**Context:** The CopilotProvider implementation in the multi-provider refactor is the right place to add this. The token response includes `expires_at` as a unix timestamp. Cache key is userID, eviction is TTL-based. ~20 lines of code.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** Multi-provider AI support
+
+### Per-user rate limiting for org providers
+
+**What:** Add configurable per-user request quotas (e.g., 100 requests/hour) for org-level AI providers.
+
+**Why:** When an admin configures a shared API key, all org members share it with no limits. One user could burn through the org's entire API budget. Rate limiting protects against accidental or excessive usage.
+
+**Pros:** Cost protection for shared API keys, fair usage across org members.
+**Cons:** Adds complexity — needs a counter store (Redis or in-memory with TTL), admin UI for quota config, and user-facing quota exceeded messaging.
+
+**Context:** For MVP, admins manage quotas externally (provider dashboard rate limits, billing alerts). This TODO tracks adding native rate limiting within Ace. Consider a simple in-memory sliding window counter per (user_id, provider_id) before reaching for Redis.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** Multi-provider AI support
+
+### Anthropic native API provider
+
+**What:** Implement an AnthropicProvider that translates OpenAI-format messages to Anthropic's /v1/messages format.
+
+**Why:** Enables direct Anthropic API keys without needing OpenRouter as a gateway. Anthropic's API uses different auth (`x-api-key` header), request schema (top-level `system` field instead of system message role), and streaming format (custom SSE event types like `content_block_delta`).
+
+**Pros:** Direct Anthropic access without a middleman, potentially lower latency and cost.
+**Cons:** Maintenance burden for one vendor's proprietary format. Message format translation adds complexity.
+
+**Context:** OpenRouter already wraps Anthropic in an OpenAI-compatible API, so this is a convenience feature. The AIProvider interface makes it straightforward to add — implement ListModels and Chat with the Anthropic-specific request/response translation.
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** Multi-provider AI support
+
 ## Copilot
 
 ### Add iterative spec refinement

--- a/docs/superpowers/plans/2026-03-24-cmdk-datasource-tools.md
+++ b/docs/superpowers/plans/2026-03-24-cmdk-datasource-tools.md
@@ -1,0 +1,942 @@
+# Cmd+K Datasource Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the "invalid datasource id" error in Cmd+K chat tools and add full metrics/logs/traces tool support with datasource discovery.
+
+**Architecture:** Explore tabs emit their selected datasource to the parent view, which registers it in the command context. The chat panel reads context to select type-appropriate tools and pass datasource IDs. A `list_datasources` tool enables discovery when no context exists. Backend system prompts are updated to mention available tools per datasource type.
+
+**Tech Stack:** Vue 3 Composition API, TypeScript, Vitest, Go (backend system prompts only)
+
+**Spec:** `docs/superpowers/specs/2026-03-23-cmdk-datasource-tools-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `frontend/src/composables/useCopilotTools.ts` | Modify | Tool definitions (type-aware), executor (list_datasources, dsId override, trace services, type-aware navigation) |
+| `frontend/src/composables/useCopilotTools.spec.ts` | Modify | Unit tests for tool definitions and executor |
+| `frontend/src/components/CmdKChatView.vue` | Modify | Pass orgId to executor, system message, type-aware tool selection, track discovered dsId for generate_dashboard |
+| `frontend/src/components/CmdKChatView.spec.ts` | Modify | Tests for system message, tool set selection |
+| `frontend/src/components/CmdKModal.vue` | Modify | Fix no-context defaults (empty type/name instead of victoriametrics/default) |
+| `frontend/src/components/CmdKModal.spec.ts` | Modify | Test no-context defaults |
+| `frontend/src/views/UnifiedExploreView.vue` | Modify | Listen for datasource-changed, re-register context |
+| `frontend/src/views/MetricsExploreTab.vue` | Modify | Emit datasource-changed on auto-select and user selection |
+| `frontend/src/views/LogsExploreTab.vue` | Modify | Emit datasource-changed on auto-select and user selection |
+| `frontend/src/views/TracesExploreTab.vue` | Modify | Emit datasource-changed on auto-select and user selection |
+| `frontend/src/components/CmdKChatView.integration.spec.ts` | Create | Integration tests (real executor, mocked HTTP) |
+| `backend/internal/handlers/github_copilot.go` | Modify | Update system prompts to mention tools per type |
+
+---
+
+### Task 1: Tool Definitions — list_datasources, datasource_id override, get_trace_services
+
+**Files:**
+- Modify: `frontend/src/composables/useCopilotTools.ts`
+- Modify: `frontend/src/composables/useCopilotTools.spec.ts`
+
+- [ ] **Step 1: Write failing tests for new tool definitions**
+
+Add to `useCopilotTools.spec.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { getToolsForDatasourceType } from './useCopilotTools'
+
+describe('getToolsForDatasourceType', () => {
+  it('includes list_datasources for all types', () => {
+    for (const type of ['victoriametrics', 'prometheus', 'loki', 'victorialogs', 'tempo', '']) {
+      const tools = getToolsForDatasourceType(type)
+      expect(tools.find((t) => t.function.name === 'list_datasources')).toBeDefined()
+    }
+  })
+
+  it('includes get_metrics for metrics datasource types', () => {
+    for (const type of ['victoriametrics', 'prometheus']) {
+      const tools = getToolsForDatasourceType(type)
+      expect(tools.find((t) => t.function.name === 'get_metrics')).toBeDefined()
+    }
+  })
+
+  it('excludes get_metrics for logs datasource types', () => {
+    for (const type of ['loki', 'victorialogs']) {
+      const tools = getToolsForDatasourceType(type)
+      expect(tools.find((t) => t.function.name === 'get_metrics')).toBeUndefined()
+    }
+  })
+
+  it('includes get_trace_services for trace datasource types', () => {
+    for (const type of ['tempo', 'victoriatraces']) {
+      const tools = getToolsForDatasourceType(type)
+      expect(tools.find((t) => t.function.name === 'get_trace_services')).toBeDefined()
+    }
+  })
+
+  it('includes generate_dashboard only for metrics types', () => {
+    const metricsTools = getToolsForDatasourceType('victoriametrics')
+    expect(metricsTools.find((t) => t.function.name === 'generate_dashboard')).toBeDefined()
+
+    const logsTools = getToolsForDatasourceType('loki')
+    expect(logsTools.find((t) => t.function.name === 'generate_dashboard')).toBeUndefined()
+  })
+
+  it('includes all tool types when datasource type is empty', () => {
+    const tools = getToolsForDatasourceType('')
+    const names = tools.map((t) => t.function.name)
+    expect(names).toContain('list_datasources')
+    expect(names).toContain('get_metrics')
+    expect(names).toContain('get_labels')
+    expect(names).toContain('get_label_values')
+    expect(names).toContain('get_trace_services')
+    expect(names).toContain('write_query')
+    expect(names).toContain('run_query')
+    expect(names).toContain('generate_dashboard')
+  })
+
+  it('get_metrics has optional datasource_id parameter', () => {
+    const tools = getToolsForDatasourceType('victoriametrics')
+    const getMetrics = tools.find((t) => t.function.name === 'get_metrics')
+    const props = getMetrics!.function.parameters as { properties?: Record<string, unknown> }
+    expect(props.properties).toHaveProperty('datasource_id')
+  })
+
+  it('get_labels has optional datasource_id parameter', () => {
+    const tools = getToolsForDatasourceType('victoriametrics')
+    const getLabels = tools.find((t) => t.function.name === 'get_labels')
+    const props = getLabels!.function.parameters as { properties?: Record<string, unknown> }
+    expect(props.properties).toHaveProperty('datasource_id')
+  })
+
+  it('get_label_values has optional datasource_id parameter', () => {
+    const tools = getToolsForDatasourceType('victoriametrics')
+    const getLabelValues = tools.find((t) => t.function.name === 'get_label_values')
+    const props = getLabelValues!.function.parameters as { properties?: Record<string, unknown> }
+    expect(props.properties).toHaveProperty('datasource_id')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/composables/useCopilotTools.spec.ts`
+Expected: FAIL — `getToolsForDatasourceType` not exported
+
+- [ ] **Step 3: Implement getToolsForDatasourceType**
+
+In `useCopilotTools.ts`, add the `list_datasources` and `get_trace_services` tool definitions, add `datasource_id` to discovery tools, and create the type-aware function. Keep `getMetricsTools()` as an alias for backward compatibility until CmdKChatView is updated.
+
+```ts
+// Add to tool definition objects inside a new function:
+
+const listDatasourcesTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'list_datasources',
+    description:
+      'List all datasources available in the current organization. Use this to discover datasource IDs before querying metrics or labels.',
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+  },
+}
+
+const getTraceServicesTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'get_trace_services',
+    description:
+      'List service names from a tracing datasource. Use this to discover what services are reporting traces.',
+    parameters: {
+      type: 'object',
+      properties: {
+        datasource_id: {
+          type: 'string',
+          description: 'Override the default datasource. Use an ID from list_datasources.',
+        },
+      },
+    },
+  },
+}
+
+// Add datasource_id property to get_metrics, get_labels, get_label_values:
+// datasource_id: {
+//   type: 'string',
+//   description: 'Override the default datasource. Use an ID from list_datasources.',
+// },
+
+const METRICS_TYPES = new Set(['victoriametrics', 'prometheus'])
+const LOGS_TYPES = new Set(['loki', 'victorialogs'])
+const TRACES_TYPES = new Set(['tempo', 'victoriatraces'])
+
+export function getToolsForDatasourceType(datasourceType: string): ToolDefinition[] {
+  const tools: ToolDefinition[] = [listDatasourcesTool]
+
+  const isMetrics = METRICS_TYPES.has(datasourceType)
+  const isLogs = LOGS_TYPES.has(datasourceType)
+  const isTraces = TRACES_TYPES.has(datasourceType)
+  const isUnknown = !isMetrics && !isLogs && !isTraces
+
+  // Discovery tools
+  if (isMetrics || isUnknown) tools.push(getMetricsTool)
+  tools.push(getLabelsTool, getLabelValuesTool)
+  if (isTraces || isUnknown) tools.push(getTraceServicesTool)
+
+  // Query tools
+  tools.push(writeQueryTool, runQueryTool)
+
+  // Dashboard generation (metrics only, or unknown)
+  if (isMetrics || isUnknown) tools.push(generateDashboardTool)
+
+  return tools
+}
+```
+
+Refactor the existing tool definitions from the inline array into named constants (e.g. `getMetricsTool`, `getLabelsTool`, etc.) so they can be composed. Keep `getMetricsTools()` calling `getToolsForDatasourceType('victoriametrics')` for backward compat.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/composables/useCopilotTools.spec.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/composables/useCopilotTools.ts frontend/src/composables/useCopilotTools.spec.ts
+git commit -m "feat: add type-aware tool sets with list_datasources and get_trace_services"
+```
+
+---
+
+### Task 2: Tool Executor — list_datasources, dsId override, trace services, type-aware navigation
+
+**Files:**
+- Modify: `frontend/src/composables/useCopilotTools.ts`
+- Modify: `frontend/src/composables/useCopilotTools.spec.ts`
+
+- [ ] **Step 1: Write failing tests for executor changes**
+
+Add to `useCopilotTools.spec.ts`:
+
+```ts
+import { vi } from 'vitest'
+import type { ToolCall } from './useCopilot'
+
+// Mock the API modules
+vi.mock('../api/datasources', () => ({
+  fetchDataSourceMetricNames: vi.fn(),
+  fetchDataSourceLabels: vi.fn(),
+  fetchDataSourceLabelValues: vi.fn(),
+  fetchDataSourceTraceServices: vi.fn(),
+  listDataSources: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('./useQueryEditor', () => ({
+  useQueryEditor: () => ({
+    hasEditor: () => false,
+    setQuery: vi.fn(),
+    execute: vi.fn(),
+  }),
+}))
+
+import {
+  fetchDataSourceLabels,
+  fetchDataSourceLabelValues,
+  fetchDataSourceMetricNames,
+  fetchDataSourceTraceServices,
+  listDataSources,
+} from '../api/datasources'
+import { useCopilotToolExecutor } from './useCopilotTools'
+
+function makeToolCall(name: string, args: Record<string, unknown> = {}): ToolCall {
+  return {
+    id: 'tc-1',
+    type: 'function',
+    function: { name, arguments: JSON.stringify(args) },
+  }
+}
+
+describe('useCopilotToolExecutor', () => {
+  const mockDsId = () => 'ds-default'
+  const mockOrgId = () => 'org-1'
+  const mockDsType = () => 'victoriametrics'
+
+  it('list_datasources returns datasource list as JSON', async () => {
+    vi.mocked(listDataSources).mockResolvedValue([
+      { id: 'ds-1', name: 'Prom', type: 'prometheus' } as any,
+    ])
+    const { executeTool } = useCopilotToolExecutor(mockDsId, mockOrgId, mockDsType)
+    const result = await executeTool(makeToolCall('list_datasources'))
+    expect(result).toContain('ds-1')
+    expect(result).toContain('Prom')
+    expect(listDataSources).toHaveBeenCalledWith('org-1')
+  })
+
+  it('list_datasources returns error when orgId is empty', async () => {
+    const { executeTool } = useCopilotToolExecutor(mockDsId, () => '', mockDsType)
+    const result = await executeTool(makeToolCall('list_datasources'))
+    expect(result).toContain('Error')
+    expect(result).toContain('no organization')
+  })
+
+  it('get_metrics uses override datasource_id when provided', async () => {
+    vi.mocked(fetchDataSourceMetricNames).mockResolvedValue(['up', 'http_requests_total'])
+    const { executeTool } = useCopilotToolExecutor(mockDsId, mockOrgId, mockDsType)
+    await executeTool(makeToolCall('get_metrics', { datasource_id: 'ds-override' }))
+    expect(fetchDataSourceMetricNames).toHaveBeenCalledWith('ds-override', undefined)
+  })
+
+  it('get_metrics falls back to context datasource_id', async () => {
+    vi.mocked(fetchDataSourceMetricNames).mockResolvedValue(['up'])
+    const { executeTool } = useCopilotToolExecutor(mockDsId, mockOrgId, mockDsType)
+    await executeTool(makeToolCall('get_metrics'))
+    expect(fetchDataSourceMetricNames).toHaveBeenCalledWith('ds-default', undefined)
+  })
+
+  it('get_metrics returns error when no datasource available', async () => {
+    const { executeTool } = useCopilotToolExecutor(() => '', mockOrgId, mockDsType)
+    const result = await executeTool(makeToolCall('get_metrics'))
+    expect(result).toContain('Error')
+    expect(result).toContain('no datasource')
+  })
+
+  it('get_labels uses override datasource_id', async () => {
+    vi.mocked(fetchDataSourceLabels).mockResolvedValue(['job', 'instance'])
+    const { executeTool } = useCopilotToolExecutor(mockDsId, mockOrgId, mockDsType)
+    await executeTool(makeToolCall('get_labels', { datasource_id: 'ds-2' }))
+    expect(fetchDataSourceLabels).toHaveBeenCalledWith('ds-2', undefined)
+  })
+
+  it('get_label_values uses override datasource_id', async () => {
+    vi.mocked(fetchDataSourceLabelValues).mockResolvedValue(['node1', 'node2'])
+    const { executeTool } = useCopilotToolExecutor(mockDsId, mockOrgId, mockDsType)
+    await executeTool(makeToolCall('get_label_values', { label: 'instance', datasource_id: 'ds-3' }))
+    expect(fetchDataSourceLabelValues).toHaveBeenCalledWith('ds-3', 'instance', undefined)
+  })
+
+  it('get_trace_services returns services list', async () => {
+    vi.mocked(fetchDataSourceTraceServices).mockResolvedValue(['frontend', 'api', 'db'])
+    const { executeTool } = useCopilotToolExecutor(mockDsId, mockOrgId, mockDsType)
+    const result = await executeTool(makeToolCall('get_trace_services'))
+    expect(result).toContain('frontend')
+    expect(result).toContain('api')
+    expect(fetchDataSourceTraceServices).toHaveBeenCalledWith('ds-default')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/composables/useCopilotTools.spec.ts`
+Expected: FAIL — signature mismatch, missing cases
+
+- [ ] **Step 3: Implement executor changes**
+
+In `useCopilotTools.ts`:
+
+1. Change signature: `export function useCopilotToolExecutor(datasourceId: () => string, orgId: () => string, datasourceType: () => string)`
+
+2. Add helper:
+```ts
+function resolveDatasourceId(args: Record<string, unknown>, defaultId: string): string | null {
+  const id = (args.datasource_id as string) || defaultId
+  return id || null
+}
+```
+
+3. Add `list_datasources` case:
+```ts
+case 'list_datasources': {
+  const org = orgId()
+  if (!org) return 'Error: no organization selected'
+  const sources = await listDataSources(org)
+  return JSON.stringify(sources.map((ds) => ({ id: ds.id, name: ds.name, type: ds.type })))
+}
+```
+
+4. Update `get_metrics`, `get_labels`, `get_label_values` to use `resolveDatasourceId`:
+```ts
+case 'get_metrics': {
+  const dsId = resolveDatasourceId(args, datasourceId())
+  if (!dsId) return 'Error: no datasource selected. Call list_datasources first to get a datasource ID.'
+  // ... existing logic with dsId
+}
+```
+
+5. Add `get_trace_services` case:
+```ts
+case 'get_trace_services': {
+  const dsId = resolveDatasourceId(args, datasourceId())
+  if (!dsId) return 'Error: no datasource selected. Call list_datasources first to get a datasource ID.'
+  const services = await fetchDataSourceTraceServices(dsId)
+  if (services.length === 0) return 'No services found'
+  return services.join('\n')
+}
+```
+
+6. Update `write_query` to navigate based on datasource type:
+```ts
+case 'write_query': {
+  if (!args.query) return 'Error: query parameter is required'
+  if (queryEditor.hasEditor()) {
+    queryEditor.setQuery(args.query as string)
+    return `Query written to editor: ${args.query}`
+  }
+  const dsType = datasourceType()
+  let route = '/app/explore/metrics'
+  if (['loki', 'victorialogs'].includes(dsType)) route = '/app/explore/logs'
+  else if (['tempo', 'victoriatraces'].includes(dsType)) route = '/app/explore/traces'
+  await router.push(route)
+  // ... rest stays the same
+}
+```
+
+7. Add imports for `listDataSources` and `fetchDataSourceTraceServices`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/composables/useCopilotTools.spec.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/composables/useCopilotTools.ts frontend/src/composables/useCopilotTools.spec.ts
+git commit -m "feat: executor with list_datasources, dsId override, trace services, type-aware nav"
+```
+
+---
+
+### Task 3: CmdKChatView — system message, type-aware tools, track discovered dsId
+
+**Files:**
+- Modify: `frontend/src/components/CmdKChatView.vue`
+- Modify: `frontend/src/components/CmdKChatView.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `CmdKChatView.spec.ts`. Update the mock for `useCopilotToolExecutor` to match new signature. Add tests:
+
+```ts
+// Update mock to match new 3-param signature:
+vi.mock('../composables/useCopilotTools', () => ({
+  getToolsForDatasourceType: vi.fn().mockReturnValue([]),
+  getMetricsTools: () => [],
+  useCopilotToolExecutor: () => ({
+    executeTool: mockExecuteTool,
+  }),
+}))
+
+// Add useOrganization mock:
+vi.mock('../composables/useOrganization', () => ({
+  useOrganization: () => ({
+    currentOrg: ref({ id: 'org-1', name: 'Test Org' }),
+  }),
+}))
+
+// Test: system message with datasource context
+it('prepends system message with datasource info when datasourceId is set', async () => {
+  wrapper = createWrapper()
+  await flushPromises()
+
+  const call = mockSendChatRequest.mock.calls[0]!
+  const messages = call[2] as Array<{ role: string; content: string }>
+  const systemMsg = messages.find((m) => m.role === 'system')
+  expect(systemMsg).toBeDefined()
+  expect(systemMsg!.content).toContain('ds-1')
+  expect(systemMsg!.content).toContain('VictoriaMetrics')
+})
+
+// Test: system message without datasource context
+it('prepends system message instructing list_datasources when datasourceId is empty', async () => {
+  wrapper = createWrapper({
+    ...defaultProps,
+    datasourceId: '',
+    datasourceType: '',
+    datasourceName: '',
+  })
+  await flushPromises()
+
+  const call = mockSendChatRequest.mock.calls[0]!
+  const messages = call[2] as Array<{ role: string; content: string }>
+  const systemMsg = messages.find((m) => m.role === 'system')
+  expect(systemMsg).toBeDefined()
+  expect(systemMsg!.content).toContain('list_datasources')
+})
+
+// Test: calls getToolsForDatasourceType with correct type
+it('uses type-aware tool set based on datasourceType prop', async () => {
+  const { getToolsForDatasourceType } = await import('../composables/useCopilotTools')
+  wrapper = createWrapper()
+  await flushPromises()
+
+  expect(getToolsForDatasourceType).toHaveBeenCalledWith('victoriametrics')
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/CmdKChatView.spec.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement CmdKChatView changes**
+
+In `CmdKChatView.vue`:
+
+1. Import `useOrganization` and `getToolsForDatasourceType`:
+```ts
+import { useOrganization } from '../composables/useOrganization'
+import { getToolsForDatasourceType, useCopilotToolExecutor } from '../composables/useCopilotTools'
+```
+
+2. Get orgId:
+```ts
+const { currentOrg } = useOrganization()
+```
+
+3. Update executor call (3 params):
+```ts
+const { executeTool } = useCopilotToolExecutor(
+  () => props.datasourceId,
+  () => currentOrg.value?.id ?? '',
+  () => props.datasourceType,
+)
+```
+
+4. Track last used datasource_id for generate_dashboard:
+```ts
+const lastUsedDatasourceId = ref('')
+```
+
+5. Update `buildChatRequestMessages()` to prepend system message:
+```ts
+function buildChatRequestMessages(): ChatRequestMessage[] {
+  const messages: ChatRequestMessage[] = []
+
+  if (props.datasourceId) {
+    messages.push({
+      role: 'system',
+      content: `You have tools to explore datasource data. You are currently working with datasource '${props.datasourceName}' (type: ${props.datasourceType}, id: ${props.datasourceId}). You can use the data discovery tools directly.`,
+    })
+  } else {
+    messages.push({
+      role: 'system',
+      content: 'You have tools to explore datasource data. No datasource is currently selected. Call list_datasources first to discover available datasources, then pass the datasource_id to other tools.',
+    })
+  }
+
+  messages.push(...chatMessages.value.map((m) => ({ role: m.role, content: m.content })))
+  return messages
+}
+```
+
+6. Replace `getMetricsTools()` with `getToolsForDatasourceType(props.datasourceType)`:
+```ts
+const tools = getToolsForDatasourceType(props.datasourceType)
+```
+
+7. Track datasource_id from tool calls and use it for generate_dashboard:
+```ts
+// Inside the tool call loop, after executeTool:
+if (args.datasource_id) {
+  lastUsedDatasourceId.value = args.datasource_id as string
+}
+
+// In the generate_dashboard handler:
+spec.panels?.forEach((p) => {
+  if (p.query) p.query.datasource_id = props.datasourceId || lastUsedDatasourceId.value
+})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/CmdKChatView.spec.ts`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/CmdKChatView.vue frontend/src/components/CmdKChatView.spec.ts
+git commit -m "feat: CmdKChatView with system message, type-aware tools, discovered dsId tracking"
+```
+
+---
+
+### Task 4: CmdKModal — fix no-context defaults
+
+**Files:**
+- Modify: `frontend/src/components/CmdKModal.vue:156-158`
+- Modify: `frontend/src/components/CmdKModal.spec.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `CmdKModal.spec.ts`:
+
+```ts
+it('passes empty datasourceType and datasourceName when no context', async () => {
+  mockContext.value = null
+  wrapper = createWrapper({ isOpen: true })
+  await flushPromises()
+
+  // Enter chat mode
+  // ... trigger handleEnterChat
+
+  const chatView = wrapper.findComponent({ name: 'CmdKChatView' })
+  if (chatView.exists()) {
+    expect(chatView.props('datasourceType')).toBe('')
+    expect(chatView.props('datasourceName')).toBe('')
+  }
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/CmdKModal.spec.ts`
+Expected: FAIL — currently defaults to `'victoriametrics'` and `'default'`
+
+- [ ] **Step 3: Implement fix**
+
+In `CmdKModal.vue`, change lines 156-158:
+
+```vue
+<!-- Before -->
+:datasource-type="currentContext?.datasourceType ?? 'victoriametrics'"
+:datasource-name="currentContext?.datasourceName ?? 'default'"
+:datasource-id="currentContext?.datasourceId ?? ''"
+
+<!-- After -->
+:datasource-type="currentContext?.datasourceType ?? ''"
+:datasource-name="currentContext?.datasourceName ?? ''"
+:datasource-id="currentContext?.datasourceId ?? ''"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/CmdKModal.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/CmdKModal.vue frontend/src/components/CmdKModal.spec.ts
+git commit -m "fix: pass empty datasource defaults when no context in CmdKModal"
+```
+
+---
+
+### Task 5: Context Propagation — Explore tabs emit datasource-changed
+
+**Files:**
+- Modify: `frontend/src/views/MetricsExploreTab.vue`
+- Modify: `frontend/src/views/LogsExploreTab.vue`
+- Modify: `frontend/src/views/TracesExploreTab.vue`
+- Modify: `frontend/src/views/UnifiedExploreView.vue`
+
+- [ ] **Step 1: Add emit to MetricsExploreTab**
+
+Add emit definition:
+```ts
+const emit = defineEmits<{
+  'datasource-changed': [payload: { id: string; name: string; type: string }]
+}>()
+```
+
+Add watcher on `selectedDatasourceId` to emit:
+```ts
+watch(selectedDatasourceId, (newId) => {
+  const ds = metricsDatasources.value.find((d) => d.id === newId)
+  if (ds) {
+    emit('datasource-changed', { id: ds.id, name: ds.name, type: ds.type })
+  }
+})
+```
+
+This fires on both auto-select (the existing watcher sets `selectedDatasourceId`, which triggers this) and user selection.
+
+- [ ] **Step 2: Add emit to LogsExploreTab**
+
+Same pattern as MetricsExploreTab but using `logsDatasources`:
+
+```ts
+const emit = defineEmits<{
+  'datasource-changed': [payload: { id: string; name: string; type: string }]
+}>()
+
+watch(selectedDatasourceId, (newId) => {
+  const ds = logsDatasources.value.find((d) => d.id === newId)
+  if (ds) {
+    emit('datasource-changed', { id: ds.id, name: ds.name, type: ds.type })
+  }
+})
+```
+
+- [ ] **Step 3: Add emit to TracesExploreTab**
+
+Same pattern but using `tracingDatasources`:
+
+```ts
+const emit = defineEmits<{
+  'datasource-changed': [payload: { id: string; name: string; type: string }]
+}>()
+
+watch(selectedDatasourceId, (newId) => {
+  const ds = tracingDatasources.value.find((d) => d.id === newId)
+  if (ds) {
+    emit('datasource-changed', { id: ds.id, name: ds.name, type: ds.type })
+  }
+})
+```
+
+- [ ] **Step 4: Update UnifiedExploreView to listen and re-register context**
+
+```ts
+// Add to script setup:
+function handleDatasourceChanged(payload: { id: string; name: string; type: string }) {
+  registerContext({
+    viewName: 'Explore',
+    viewRoute: '/app/explore',
+    description: 'Query and visualize metrics, logs, and traces from connected datasources',
+    datasourceId: payload.id,
+    datasourceName: payload.name,
+    datasourceType: payload.type,
+  })
+}
+```
+
+Update template — add event listener on the dynamic component:
+```vue
+<component :is="activeComponent" :key="activeType" @datasource-changed="handleDatasourceChanged" />
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/views/MetricsExploreTab.vue frontend/src/views/LogsExploreTab.vue frontend/src/views/TracesExploreTab.vue frontend/src/views/UnifiedExploreView.vue
+git commit -m "feat: Explore tabs emit datasource-changed, UnifiedExploreView propagates to context"
+```
+
+---
+
+### Task 6: Backend System Prompts — add tool guidance per datasource type
+
+**Files:**
+- Modify: `backend/internal/handlers/github_copilot.go:120-193`
+
+- [ ] **Step 1: Update system prompts**
+
+Add tool usage instructions to each relevant prompt. Append to the end of each string:
+
+**loki:**
+```
+When you have tools available, use them:
+1. Use get_labels to discover available label names
+2. Use get_label_values to understand label dimensions
+3. Use write_query to write a LogQL query for the user to review`
+```
+
+**victorialogs:** Same pattern as loki but mention VictoriaLogs syntax.
+
+**prometheus:**
+```
+When you have tools available, use them:
+1. Use get_metrics to discover available metric names
+2. Use get_labels and get_label_values to understand dimensions
+3. Use write_query to write a PromQL query, or generate_dashboard for a dashboard`
+```
+
+**tempo:**
+```
+When you have tools available, use them:
+1. Use get_trace_services to discover services reporting traces
+2. Use get_labels and get_label_values to understand trace attributes
+3. Use write_query to write a TraceQL query for the user`
+```
+
+**victoriatraces:** Same pattern as tempo.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/internal/handlers/github_copilot.go
+git commit -m "feat: add tool usage guidance to backend system prompts for all datasource types"
+```
+
+---
+
+### Task 7: Integration Tests
+
+**Files:**
+- Create: `frontend/src/components/CmdKChatView.integration.spec.ts`
+
+- [ ] **Step 1: Write integration tests**
+
+These use the real `useCopilotToolExecutor` (unmocked) with mocked HTTP layer:
+
+```ts
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+// Mock HTTP layer (api/datasources), NOT the composables
+vi.mock('../api/datasources', () => ({
+  fetchDataSourceMetricNames: vi.fn().mockResolvedValue(['up', 'http_requests_total']),
+  fetchDataSourceLabels: vi.fn().mockResolvedValue(['job', 'instance']),
+  fetchDataSourceLabelValues: vi.fn().mockResolvedValue(['node1']),
+  fetchDataSourceTraceServices: vi.fn().mockResolvedValue(['frontend', 'api']),
+  listDataSources: vi.fn().mockResolvedValue([
+    { id: 'ds-1', name: 'Prometheus', type: 'prometheus', organization_id: 'org-1', url: '', is_default: true, auth_type: 'none', trace_id_field: '', created_at: '', updated_at: '' },
+    { id: 'ds-2', name: 'Loki', type: 'loki', organization_id: 'org-1', url: '', is_default: false, auth_type: 'none', trace_id_field: '', created_at: '', updated_at: '' },
+  ]),
+}))
+
+vi.mock('../composables/useOrganization', () => ({
+  useOrganization: () => ({ currentOrg: ref({ id: 'org-1', name: 'Test' }) }),
+}))
+
+const mockSendChatRequest = vi.fn()
+vi.mock('../composables/useCopilot', () => ({
+  useCopilot: () => ({
+    sendChatRequest: mockSendChatRequest,
+    chatMessages: ref([]),
+    models: ref([]),
+    selectedModel: ref(''),
+    fetchModels: vi.fn(),
+    isLoading: ref(false),
+    error: ref(null),
+  }),
+}))
+
+vi.mock('../utils/markdown', () => ({
+  initMarkdown: vi.fn().mockResolvedValue(undefined),
+  renderMarkdown: vi.fn().mockResolvedValue('<p>test</p>'),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+import { fetchDataSourceMetricNames, fetchDataSourceLabels, listDataSources } from '../api/datasources'
+import CmdKChatView from './CmdKChatView.vue'
+
+describe('CmdKChatView integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendChatRequest.mockResolvedValue({ content: 'Done', toolCalls: [] })
+  })
+
+  it('metrics context: get_metrics tool call uses context datasource ID', async () => {
+    // Simulate model returning a get_metrics tool call
+    mockSendChatRequest
+      .mockResolvedValueOnce({
+        content: null,
+        toolCalls: [{ id: 'tc-1', type: 'function', function: { name: 'get_metrics', arguments: '{}' } }],
+      })
+      .mockResolvedValueOnce({ content: 'Found metrics: up', toolCalls: [] })
+
+    mount(CmdKChatView, {
+      props: {
+        initialQuery: 'show metrics',
+        datasourceType: 'victoriametrics',
+        datasourceName: 'VM',
+        datasourceId: 'ds-vm',
+      },
+      global: { stubs: { DashboardSpecPreview: true } },
+    })
+    await flushPromises()
+
+    expect(fetchDataSourceMetricNames).toHaveBeenCalledWith('ds-vm', undefined)
+  })
+
+  it('logs context: get_labels tool call uses context datasource ID', async () => {
+    mockSendChatRequest
+      .mockResolvedValueOnce({
+        content: null,
+        toolCalls: [{ id: 'tc-1', type: 'function', function: { name: 'get_labels', arguments: '{}' } }],
+      })
+      .mockResolvedValueOnce({ content: 'Found labels', toolCalls: [] })
+
+    mount(CmdKChatView, {
+      props: {
+        initialQuery: 'show labels',
+        datasourceType: 'loki',
+        datasourceName: 'Loki',
+        datasourceId: 'ds-loki',
+      },
+      global: { stubs: { DashboardSpecPreview: true } },
+    })
+    await flushPromises()
+
+    expect(fetchDataSourceLabels).toHaveBeenCalledWith('ds-loki', undefined)
+  })
+
+  it('no context: list_datasources then override works', async () => {
+    mockSendChatRequest
+      .mockResolvedValueOnce({
+        content: null,
+        toolCalls: [{ id: 'tc-1', type: 'function', function: { name: 'list_datasources', arguments: '{}' } }],
+      })
+      .mockResolvedValueOnce({
+        content: null,
+        toolCalls: [{ id: 'tc-2', type: 'function', function: { name: 'get_metrics', arguments: '{"datasource_id":"ds-1"}' } }],
+      })
+      .mockResolvedValueOnce({ content: 'Here are your metrics', toolCalls: [] })
+
+    mount(CmdKChatView, {
+      props: {
+        initialQuery: 'show metrics',
+        datasourceType: '',
+        datasourceName: '',
+        datasourceId: '',
+      },
+      global: { stubs: { DashboardSpecPreview: true } },
+    })
+    await flushPromises()
+
+    expect(listDataSources).toHaveBeenCalledWith('org-1')
+    expect(fetchDataSourceMetricNames).toHaveBeenCalledWith('ds-1', undefined)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd frontend && npx vitest run src/components/CmdKChatView.integration.spec.ts`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/CmdKChatView.integration.spec.ts
+git commit -m "test: add integration tests for Cmd+K datasource tool chain"
+```
+
+---
+
+### Task 8: Run Full Test Suite & Lint
+
+- [ ] **Step 1: Run all tests**
+
+Run: `cd frontend && npm run test`
+Expected: All PASS
+
+- [ ] **Step 2: Run linter**
+
+Run: `cd frontend && npm run lint:fix`
+Expected: No errors (auto-fixes applied)
+
+- [ ] **Step 3: Build check**
+
+Run: `cd frontend && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Final commit if lint made changes**
+
+```bash
+git add -A && git diff --cached --quiet || git commit -m "chore: lint fixes"
+```

--- a/docs/superpowers/plans/2026-03-24-multi-provider-ai.md
+++ b/docs/superpowers/plans/2026-03-24-multi-provider-ai.md
@@ -1,0 +1,1061 @@
+# Multi-Provider AI Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Copilot-only chat system with a provider abstraction supporting OpenAI, OpenRouter, Ollama, and any OpenAI-compatible endpoint, with Copilot as a personal fallback.
+
+**Architecture:** Go backend with AIProvider interface (OpenAICompatibleProvider + CopilotProvider). Org-scoped endpoints under `/api/orgs/{id}/ai/`. Frontend composable `useAIProvider.ts` replaces `useCopilot.ts`. System prompts injected at orchestration layer.
+
+**Tech Stack:** Go 1.22+ (stdlib net/http, pgxpool), Vue 3 Composition API, TypeScript, Vitest, Tailwind CSS + Kinetic design tokens.
+
+**Spec:** `docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md`
+
+---
+
+## File Structure
+
+### Backend — New Files
+- `backend/internal/crypto/crypto.go` — extracted encrypt/decrypt token functions
+- `backend/internal/crypto/crypto_test.go` — round-trip tests
+- `backend/internal/handlers/ai_provider.go` — AIProvider interface + OpenAICompatibleProvider + CopilotProvider
+- `backend/internal/handlers/ai_provider_test.go` — provider unit tests with mock HTTP server
+- `backend/internal/handlers/ai_handler.go` — AI HTTP handler (CRUD, chat, models, resolution)
+- `backend/internal/handlers/ai_handler_test.go` — handler tests
+- `backend/internal/handlers/system_prompts.go` — extracted from github_copilot.go
+- `backend/internal/auth/org_middleware.go` — RequireOrgMember middleware
+- `backend/internal/auth/org_middleware_test.go` — middleware tests
+
+### Backend — Modified Files
+- `backend/internal/db/migrations.go` — add ai_providers table migration
+- `backend/internal/handlers/github_copilot.go` — remove Chat, ListModels, ConfigureGitHubApp, GetGitHubApp; keep auth endpoints
+- `backend/cmd/api/main.go` — register new AI routes, remove old Copilot routes
+
+### Frontend — New Files
+- `frontend/src/composables/useAIProvider.ts` — provider-aware composable replacing useCopilot
+- `frontend/src/composables/useAIProvider.spec.ts` — tests
+- `frontend/src/composables/useCopilotAuth.ts` — extracted Copilot auth state
+- `frontend/src/composables/useCopilotAuth.spec.ts` — tests
+- `frontend/src/api/aiProviders.ts` — API functions for provider CRUD
+- `frontend/src/api/aiProviders.spec.ts` — API function tests
+- `frontend/src/components/AIProviderSettings.vue` — admin settings UI
+- `frontend/src/components/AIProviderSettings.spec.ts` — tests
+
+### Frontend — Modified Files
+- `frontend/src/components/CmdKModal.vue` — gate on providers instead of isConnected
+- `frontend/src/components/CmdKModal.spec.ts` — updated tests
+- `frontend/src/components/CmdKChatView.vue` — use useAIProvider, grouped model selector
+- `frontend/src/components/CmdKChatView.spec.ts` — updated tests
+- `frontend/src/components/CmdKSearchResults.vue` — update useCopilot → useAIProvider
+- `frontend/src/components/CmdKSearchResults.spec.ts` — updated tests
+- `frontend/src/components/CopilotConnectionPanel.vue` — import from useCopilotAuth
+- `frontend/src/components/CopilotConnectionPanel.spec.ts` — updated mock
+- `frontend/src/views/UnifiedSettingsView.vue` — AI section with provider list + Copilot fallback
+
+---
+
+## Task 1: Extract crypto to shared package
+
+**Files:**
+- Create: `backend/internal/crypto/crypto.go`
+- Create: `backend/internal/crypto/crypto_test.go`
+- Modify: `backend/internal/handlers/github_copilot.go`
+
+- [ ] **Step 1: Write the failing test for encrypt/decrypt round-trip**
+
+```go
+// backend/internal/crypto/crypto_test.go
+package crypto
+
+import "testing"
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-key-for-encryption")
+	plaintext := "sk-abc123-my-api-key"
+
+	encrypted, err := EncryptToken(plaintext)
+	if err != nil {
+		t.Fatalf("encrypt failed: %v", err)
+	}
+	if encrypted == plaintext {
+		t.Fatal("encrypted should differ from plaintext")
+	}
+
+	decrypted, err := DecryptToken(encrypted)
+	if err != nil {
+		t.Fatalf("decrypt failed: %v", err)
+	}
+	if decrypted != plaintext {
+		t.Errorf("expected %q, got %q", plaintext, decrypted)
+	}
+}
+
+func TestDecryptToken_InvalidCiphertext(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-key")
+	_, err := DecryptToken("not-valid-base64!!")
+	if err == nil {
+		t.Fatal("expected error for invalid ciphertext")
+	}
+}
+
+func TestDeriveEncryptionKey_MissingSecret(t *testing.T) {
+	t.Setenv("JWT_SECRET", "")
+	t.Setenv("JWT_PRIVATE_KEY", "")
+	_, err := DeriveEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error when no secret available")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/crypto/ -v`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 3: Move encrypt/decrypt functions to new package**
+
+Create `backend/internal/crypto/crypto.go` by extracting the `deriveEncryptionKey`, `encryptToken`, `decryptToken` functions from `github_copilot.go`. Export them as `DeriveEncryptionKey`, `EncryptToken`, `DecryptToken`.
+
+```go
+// backend/internal/crypto/crypto.go
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+func DeriveEncryptionKey() ([]byte, error) {
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		secret = os.Getenv("JWT_PRIVATE_KEY")
+	}
+	if secret == "" {
+		data, err := os.ReadFile(".data/jwt.key")
+		if err != nil {
+			return nil, fmt.Errorf("no encryption key material available")
+		}
+		secret = string(data)
+	}
+	hash := sha256.Sum256([]byte(secret))
+	return hash[:], nil
+}
+
+func EncryptToken(plaintext string) (string, error) {
+	key, err := DeriveEncryptionKey()
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	ciphertext := aesGCM.Seal(nonce, nonce, []byte(plaintext), nil)
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+func DecryptToken(encoded string) (string, error) {
+	key, err := DeriveEncryptionKey()
+	if err != nil {
+		return "", err
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonceSize := aesGCM.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/crypto/ -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Update github_copilot.go to use the new package**
+
+Replace the local `encryptToken`/`decryptToken`/`deriveEncryptionKey` functions in `github_copilot.go` with imports from `crypto` package. Remove the local functions (lines 199-276). Update all call sites: `encryptToken(...)` → `crypto.EncryptToken(...)`, `decryptToken(...)` → `crypto.DecryptToken(...)`.
+
+- [ ] **Step 6: Verify existing code still compiles**
+
+Run: `cd backend && go build ./...`
+Expected: builds successfully
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/crypto/ backend/internal/handlers/github_copilot.go
+git commit -m "refactor: extract encrypt/decrypt to internal/crypto package"
+```
+
+---
+
+## Task 2: Extract system prompts
+
+**Files:**
+- Create: `backend/internal/handlers/system_prompts.go`
+- Create: `backend/internal/handlers/system_prompts_test.go`
+- Modify: `backend/internal/handlers/github_copilot.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// backend/internal/handlers/system_prompts_test.go
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSystemPrompts_ContainsExpectedTypes(t *testing.T) {
+	expectedTypes := []string{"prometheus", "victoriametrics", "loki", "elasticsearch", "tempo"}
+	for _, dsType := range expectedTypes {
+		if _, ok := SystemPrompts[dsType]; !ok {
+			t.Errorf("SystemPrompts missing key %q", dsType)
+		}
+	}
+}
+
+func TestSystemPrompts_PrometheusContainsPromQL(t *testing.T) {
+	prompt, ok := SystemPrompts["prometheus"]
+	if !ok {
+		t.Fatal("missing prometheus prompt")
+	}
+	if !strings.Contains(prompt, "PromQL") {
+		t.Error("prometheus prompt should mention PromQL")
+	}
+}
+
+func TestDefaultSystemPrompt_NotEmpty(t *testing.T) {
+	if DefaultSystemPrompt == "" {
+		t.Fatal("DefaultSystemPrompt should not be empty")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestSystemPrompts -v`
+Expected: FAIL — `SystemPrompts` and `DefaultSystemPrompt` not defined
+
+- [ ] **Step 3: Create system_prompts.go**
+
+Move the `copilotSystemPrompts` map and `defaultSystemPrompt` constant from `github_copilot.go` to a new file. Rename to exported `SystemPrompts` and `DefaultSystemPrompt`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestSystemPrompts -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Update github_copilot.go to use exported names**
+
+In the `Chat` method of `github_copilot.go`, replace `copilotSystemPrompts` with `SystemPrompts` and `defaultSystemPrompt` with `DefaultSystemPrompt`. Remove the old local declarations.
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cd backend && go build ./...`
+Expected: builds successfully
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/handlers/system_prompts.go backend/internal/handlers/system_prompts_test.go backend/internal/handlers/github_copilot.go
+git commit -m "refactor: extract system prompts to shared file"
+```
+
+---
+
+## Task 3: Database migration for ai_providers table
+
+**Files:**
+- Create: `backend/internal/db/migrations/010_ai_providers.sql` (documentation)
+- Modify: `backend/internal/db/migrations.go`
+
+- [ ] **Step 1: Add migration SQL to migrations.go**
+
+Add the ai_providers table creation to the migrations slice in `migrations.go`, after the existing migrations. Use the same inline string pattern.
+
+```go
+// Add to migrations slice in migrations.go:
+`CREATE TABLE IF NOT EXISTS ai_providers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider_type VARCHAR(50) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    base_url TEXT NOT NULL,
+    api_key TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    models_override JSONB,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE(organization_id, display_name)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_providers_org_id ON ai_providers(organization_id);`,
+```
+
+- [ ] **Step 2: Create documentation migration file**
+
+```sql
+-- backend/internal/db/migrations/010_ai_providers.sql
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS ai_providers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider_type VARCHAR(50) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    base_url TEXT NOT NULL,
+    api_key TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    models_override JSONB,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE(organization_id, display_name)
+);
+CREATE INDEX IF NOT EXISTS idx_ai_providers_org_id ON ai_providers(organization_id);
+
+-- +migrate Down
+DROP TABLE IF EXISTS ai_providers;
+DROP INDEX IF EXISTS idx_ai_providers_org_id;
+```
+
+- [ ] **Step 3: Verify the app starts and migration runs**
+
+Run: `cd backend && go build ./... && go run ./cmd/api/`
+Expected: starts without errors (migration creates table idempotently)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/db/migrations.go backend/internal/db/migrations/010_ai_providers.sql
+git commit -m "feat: add ai_providers database migration"
+```
+
+---
+
+## Task 4: RequireOrgMember middleware
+
+**Files:**
+- Create: `backend/internal/auth/org_middleware.go`
+- Create: `backend/internal/auth/org_middleware_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// backend/internal/auth/org_middleware_test.go
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestRequireOrgMember_MissingOrgID(t *testing.T) {
+	handler := RequireOrgMember(nil, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	})
+	req := httptest.NewRequest("GET", "/api/orgs/invalid/ai/providers", nil)
+	req.SetPathValue("id", "not-a-uuid")
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestRequireOrgMember_MissingUserID(t *testing.T) {
+	handler := RequireOrgMember(nil, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	})
+	orgID := uuid.New()
+	req := httptest.NewRequest("GET", "/api/orgs/"+orgID.String()+"/ai/providers", nil)
+	req.SetPathValue("id", orgID.String())
+	// No user ID in context
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/auth/ -run TestRequireOrgMember -v`
+Expected: FAIL — function not defined
+
+- [ ] **Step 3: Implement RequireOrgMember**
+
+```go
+// backend/internal/auth/org_middleware.go
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type orgIDContextKey struct{}
+
+// GetOrgID extracts the validated org ID from the request context.
+func GetOrgID(ctx context.Context) (uuid.UUID, bool) {
+	id, ok := ctx.Value(orgIDContextKey{}).(uuid.UUID)
+	return id, ok
+}
+
+// RequireOrgMember validates that the authenticated user is a member of the org
+// specified in the URL path parameter "id". Injects org_id into context.
+func RequireOrgMember(pool *pgxpool.Pool, handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		orgID, err := uuid.Parse(r.PathValue("id"))
+		if err != nil {
+			http.Error(w, `{"error":"invalid organization id"}`, http.StatusBadRequest)
+			return
+		}
+
+		userID, ok := GetUserID(r.Context())
+		if !ok {
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			return
+		}
+
+		// Verify membership
+		var role string
+		err = pool.QueryRow(r.Context(),
+			`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
+			userID, orgID,
+		).Scan(&role)
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":"not a member of this organization"}`), http.StatusForbidden)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), orgIDContextKey{}, orgID)
+		handler(w, r.WithContext(ctx))
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && go test ./internal/auth/ -run TestRequireOrgMember -v`
+Expected: PASS (the DB-dependent test with nil pool will panic on membership check — update tests to check for the expected path)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/auth/org_middleware.go backend/internal/auth/org_middleware_test.go
+git commit -m "feat: add RequireOrgMember middleware for org-scoped endpoints"
+```
+
+---
+
+## Task 5: AIProvider interface and OpenAICompatibleProvider
+
+**Files:**
+- Create: `backend/internal/handlers/ai_provider.go`
+- Create: `backend/internal/handlers/ai_provider_test.go`
+
+- [ ] **Step 1: Write tests for OpenAICompatibleProvider with mock HTTP server**
+
+```go
+// backend/internal/handlers/ai_provider_test.go
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOpenAICompatibleProvider_ListModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("missing auth header")
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]string{
+				{"id": "gpt-4o", "owned_by": "openai"},
+				{"id": "gpt-4o-mini", "owned_by": "openai"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	p := NewOpenAICompatibleProvider(server.URL, "test-key", "OpenAI")
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels failed: %v", err)
+	}
+	if len(models) != 2 {
+		t.Errorf("expected 2 models, got %d", len(models))
+	}
+	if models[0].ID != "gpt-4o" {
+		t.Errorf("expected gpt-4o, got %s", models[0].ID)
+	}
+}
+
+func TestOpenAICompatibleProvider_ListModels_NoAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Error("should not send auth header when no API key")
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]string{{"id": "llama3", "owned_by": "meta"}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewOpenAICompatibleProvider(server.URL, "", "Ollama")
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels failed: %v", err)
+	}
+	if len(models) != 1 {
+		t.Errorf("expected 1 model, got %d", len(models))
+	}
+}
+
+func TestOpenAICompatibleProvider_ListModels_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	p := NewOpenAICompatibleProvider(server.URL, "key", "Test")
+	_, err := p.ListModels(context.Background())
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestOpenAICompatible -v`
+Expected: FAIL — types not defined
+
+- [ ] **Step 3: Implement AIProvider interface and OpenAICompatibleProvider**
+
+Create `backend/internal/handlers/ai_provider.go` with the `AIProvider` interface, `AIModel`, `ChatRequest` types, and the `OpenAICompatibleProvider` struct implementing `ListModels()` and `Chat()`. The `Chat()` method handles both streaming (SSE passthrough) and non-streaming (JSON passthrough) modes.
+
+Key implementation details:
+- `NewOpenAICompatibleProvider(baseURL, apiKey, displayName string) *OpenAICompatibleProvider`
+- `ListModels()` calls `GET baseURL/models` with optional `Authorization: Bearer` header
+- `Chat()` calls `POST baseURL/chat/completions`, sets `Content-Type: application/json`
+- For streaming: set response headers `text/event-stream`, flush chunks as received
+- For non-streaming: forward JSON response body directly
+- No API key → no Authorization header (for Ollama/local providers)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestOpenAICompatible -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/handlers/ai_provider.go backend/internal/handlers/ai_provider_test.go
+git commit -m "feat: add AIProvider interface and OpenAICompatibleProvider"
+```
+
+---
+
+## Task 6: CopilotProvider implementation
+
+**Files:**
+- Modify: `backend/internal/handlers/ai_provider.go`
+- Modify: `backend/internal/handlers/ai_provider_test.go`
+- Modify: `backend/internal/handlers/github_copilot.go`
+
+- [ ] **Step 1: Write tests for CopilotProvider**
+
+Test `CopilotProvider.ListModels()` and `CopilotProvider.Chat()` using mock servers that simulate the Copilot token endpoint and API. Test the special headers (`Editor-Version`, `Copilot-Integration-Id`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestCopilotProvider -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement CopilotProvider**
+
+Add `CopilotProvider` struct to `ai_provider.go`. It wraps the existing `fetchCopilotToken()` logic from `github_copilot.go`. Extract `fetchCopilotToken` as an exported method or move the relevant code.
+
+Includes a `sync.Map`-based token cache keyed by userID. Each cached entry stores the Copilot session token and its `expires_at` timestamp. Before hitting GitHub's token endpoint, check the cache — if `expires_at - 60s > now`, reuse it.
+
+- `ListModels()`: decrypt token → fetchCopilotToken (cache-aware) → GET apiEndpoint/models with Copilot headers
+- `Chat()`: decrypt token → fetchCopilotToken (cache-aware) → POST apiEndpoint/chat/completions with Copilot headers, stream or JSON passthrough
+
+Include a test that calls `ListModels()` twice and verifies the mock token endpoint only receives one request (second call uses cache).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestCopilotProvider -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/handlers/ai_provider.go backend/internal/handlers/ai_provider_test.go backend/internal/handlers/github_copilot.go
+git commit -m "feat: add CopilotProvider wrapping existing Copilot token logic"
+```
+
+---
+
+## Task 7: AI handler — provider resolution, CRUD, chat, models
+
+**Files:**
+- Create: `backend/internal/handlers/ai_handler.go`
+- Create: `backend/internal/handlers/ai_handler_test.go`
+
+- [ ] **Step 1: Write tests for provider resolution**
+
+Test the three cases: org has providers → return them; no org providers + Copilot → return CopilotProvider; neither → error. Test admin CRUD: create provider (encrypts API key), list, update, delete. Test chat routing: provider_id=UUID → OpenAICompatibleProvider; provider_id="copilot" → CopilotProvider.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestAIHandler -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement AIHandler**
+
+```go
+type AIHandler struct {
+	pool *pgxpool.Pool
+}
+
+func NewAIHandler(pool *pgxpool.Pool) *AIHandler {
+	return &AIHandler{pool: pool}
+}
+```
+
+Implement methods:
+- `ListProviders(w, r)` — resolve providers for the user's org (from context via RequireOrgMember), include Copilot fallback
+- `ListModels(w, r)` — get provider by ID, call ListModels(), fall back to models_override
+- `Chat(w, r)` — parse request, resolve provider, prepend system prompt from SystemPrompts map, call provider.Chat()
+- `CreateProvider(w, r)` — admin check, validate, encrypt API key, INSERT
+- `UpdateProvider(w, r)` — admin check, encrypt API key if changed, UPDATE
+- `DeleteProvider(w, r)` — admin check, DELETE
+- `TestProvider(w, r)` — admin check, build provider from DB row, call ListModels()
+
+System prompt injection: before calling `provider.Chat()`, prepend `{"role": "system", "content": systemPrompt}` to the messages array based on `datasource_type`.
+
+Graceful tool degradation in `Chat()`: if the provider returns an error response when tools are included (e.g., 400/422 with a message about unsupported tools), retry the request without the `tools` field and include a `"tools_unsupported": true` flag in the response metadata. Include tests for: (a) detecting a tool-incompatible error, (b) retrying without tools, (c) the flag in the response.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestAIHandler -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/handlers/ai_handler.go backend/internal/handlers/ai_handler_test.go
+git commit -m "feat: add AI handler with provider resolution, CRUD, and chat"
+```
+
+---
+
+## Task 8: Route registration and cleanup
+
+**Files:**
+- Modify: `backend/cmd/api/main.go`
+- Modify: `backend/internal/handlers/github_copilot.go`
+
+- [ ] **Step 1: Register new AI routes in main.go**
+
+```go
+// AI routes (org-scoped)
+aiHandler := handlers.NewAIHandler(pool)
+mux.HandleFunc("GET /api/orgs/{id}/ai/providers", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.ListProviders)))
+mux.HandleFunc("GET /api/orgs/{id}/ai/models", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.ListModels)))
+mux.HandleFunc("POST /api/orgs/{id}/ai/chat", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.Chat)))
+mux.HandleFunc("POST /api/orgs/{id}/ai/providers", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.CreateProvider)))
+mux.HandleFunc("PUT /api/orgs/{id}/ai/providers/{pid}", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.UpdateProvider)))
+mux.HandleFunc("DELETE /api/orgs/{id}/ai/providers/{pid}", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.DeleteProvider)))
+mux.HandleFunc("POST /api/orgs/{id}/ai/providers/{pid}/test", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.TestProvider)))
+```
+
+- [ ] **Step 2: Remove old Copilot routes**
+
+Remove from main.go:
+- `GET /api/copilot/models`
+- `POST /api/copilot/chat`
+- `POST /api/orgs/{id}/github-app`
+- `GET /api/orgs/{id}/github-app`
+
+- [ ] **Step 3: Remove dead code from github_copilot.go**
+
+Remove the `Chat`, `ListModels`, `ConfigureGitHubApp`, `GetGitHubApp` methods and related types (`copilotChatRequest`, `copilotModel`, `premiumMultipliers`). Keep: `StartDeviceFlow`, `PollDeviceFlow`, `GetConnection`, `Disconnect`, `fetchGitHubUser`, `fetchCopilotToken`.
+
+- [ ] **Step 3.5: Increase WriteTimeout for SSE streaming**
+
+The existing `WriteTimeout: 15 * time.Second` in `main.go` will kill SSE streams before they complete (chat can run 60+ seconds). Set `WriteTimeout: 0` (no timeout — the per-request context timeout of 60s handles this) or increase to 120s.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cd backend && go build ./...`
+Expected: builds successfully
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cmd/api/main.go backend/internal/handlers/github_copilot.go
+git commit -m "feat: register AI routes, remove old Copilot chat/models endpoints"
+```
+
+---
+
+## Task 9: Frontend — extract useCopilotAuth.ts
+
+**Files:**
+- Create: `frontend/src/composables/useCopilotAuth.ts`
+- Create: `frontend/src/composables/useCopilotAuth.spec.ts`
+
+- [ ] **Step 1: Write tests for shared auth state**
+
+```typescript
+// frontend/src/composables/useCopilotAuth.spec.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+  useRoute: vi.fn(() => ({ params: {}, query: {} })),
+}))
+
+describe('useCopilotAuth', () => {
+  beforeEach(async () => { vi.resetModules() })
+
+  it('shares isConnected across calls', async () => {
+    const { useCopilotAuth } = await import('./useCopilotAuth')
+    const a = useCopilotAuth()
+    const b = useCopilotAuth()
+    a.isConnected.value = true
+    expect(b.isConnected.value).toBe(true)
+  })
+
+  it('does NOT share deviceFlowActive across calls', async () => {
+    const { useCopilotAuth } = await import('./useCopilotAuth')
+    const a = useCopilotAuth()
+    const b = useCopilotAuth()
+    a.deviceFlowActive.value = true
+    expect(b.deviceFlowActive.value).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/composables/useCopilotAuth.spec.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Create useCopilotAuth.ts**
+
+Extract from `useCopilot.ts`: the Copilot-specific auth state (`isConnected`, `hasCopilot`, `githubUsername`), device flow state, and methods (`checkConnection`, `connect`, `cancelDeviceFlow`, `disconnect`). Keep the same module-level shared state pattern.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd frontend && npx vitest run src/composables/useCopilotAuth.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/composables/useCopilotAuth.ts frontend/src/composables/useCopilotAuth.spec.ts
+git commit -m "refactor: extract useCopilotAuth from useCopilot"
+```
+
+---
+
+## Task 10: Frontend — useAIProvider.ts composable
+
+**Files:**
+- Create: `frontend/src/composables/useAIProvider.ts`
+- Create: `frontend/src/composables/useAIProvider.spec.ts`
+
+- [ ] **Step 1: Write tests**
+
+Test: `fetchProviders()` populates providers list, auto-selects first provider. `fetchModels()` populates models for selected provider. Shared state across calls. Org switch resets state. Error handling for provider unavailable.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/composables/useAIProvider.spec.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement useAIProvider.ts**
+
+Module-level shared state pattern matching `useCopilot.ts`. Key differences:
+- `providers` ref, `selectedProviderId` ref
+- All API calls include org ID from `useOrganization().currentOrgId`
+- `watch(currentOrgId)` resets all state and re-fetches
+- `sendMessage()` and `sendChatRequest()` include `provider_id` in request body
+- SSE parsing logic reused from current `useCopilot.ts`
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd frontend && npx vitest run src/composables/useAIProvider.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/composables/useAIProvider.ts frontend/src/composables/useAIProvider.spec.ts
+git commit -m "feat: add useAIProvider composable with provider resolution"
+```
+
+---
+
+## Task 11: Frontend — API functions for provider CRUD
+
+**Files:**
+- Create: `frontend/src/api/aiProviders.ts`
+- Create: `frontend/src/api/aiProviders.spec.ts`
+
+- [ ] **Step 1: Write tests for API functions**
+
+Test each function with a mocked `fetch`: verify correct URL construction, HTTP method, auth headers, and response parsing. Follow the same test pattern as existing API specs.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/api/aiProviders.spec.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Create API functions**
+
+Follow the pattern from `frontend/src/api/datasources.ts`. Create functions:
+- `listAIProviders(orgId: string)` — GET /api/orgs/{orgId}/ai/providers
+- `createAIProvider(orgId, data)` — POST
+- `updateAIProvider(orgId, providerId, data)` — PUT
+- `deleteAIProvider(orgId, providerId)` — DELETE
+- `testAIProvider(orgId, providerId)` — POST test endpoint
+- `listAIModels(orgId, providerId?)` — GET /api/orgs/{orgId}/ai/models
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd frontend && npx vitest run src/api/aiProviders.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/aiProviders.ts frontend/src/api/aiProviders.spec.ts
+git commit -m "feat: add AI provider API functions"
+```
+
+---
+
+## Task 12: Frontend — AIProviderSettings component
+
+**Files:**
+- Create: `frontend/src/components/AIProviderSettings.vue`
+- Create: `frontend/src/components/AIProviderSettings.spec.ts`
+- Modify: `frontend/src/views/UnifiedSettingsView.vue`
+
+- [ ] **Step 1: Write tests**
+
+Test: renders provider list, empty state with CTA, add provider form, test connection button, delete with confirmation. Mock the API functions.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/AIProviderSettings.spec.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement AIProviderSettings.vue**
+
+Admin-only component with:
+- Provider list with rows (display_name, base_url truncated, model count badge, enabled badge, overflow menu)
+- Empty state: "No providers configured. Add one to enable AI chat for your team."
+- Add/Edit form: provider_type select, display_name, base_url (pre-filled hint per type), api_key (password field, optional), enabled toggle
+- Test connection button with spinner and inline result
+- Delete with confirmation dialog
+- All styled with Kinetic tokens (`var(--color-surface-container-low)`, etc.)
+- Accessibility: provider list uses `role="list"`, each row `role="listitem"`, test connection button has `aria-label="Test connection for [name]"`, status badges have `aria-label` describing state, all buttons 44px min touch target
+- Include tests that verify `role` and `aria-label` attributes are rendered
+
+- [ ] **Step 4: Wire into UnifiedSettingsView.vue**
+
+Replace the AI section (lines 779-786) with the new component structure:
+```vue
+<section v-if="activeSection === 'ai'" class="flex flex-col gap-4 max-w-2xl">
+  <AIProviderSettings v-if="orgId" :org-id="orgId" :is-admin="isAdmin" />
+  <CopilotConnectionPanel v-if="orgId && !hasOrgProviders" :org-id="orgId" />
+</section>
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd frontend && npx vitest run src/components/AIProviderSettings.spec.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/AIProviderSettings.vue frontend/src/components/AIProviderSettings.spec.ts frontend/src/views/UnifiedSettingsView.vue
+git commit -m "feat: add AI provider settings component with CRUD"
+```
+
+---
+
+## Task 13: Frontend — Update CmdKModal, CmdKChatView, CmdKSearchResults
+
+**Files:**
+- Modify: `frontend/src/components/CmdKModal.vue`
+- Modify: `frontend/src/components/CmdKModal.spec.ts`
+- Modify: `frontend/src/components/CmdKChatView.vue`
+- Modify: `frontend/src/components/CmdKChatView.spec.ts`
+- Modify: `frontend/src/components/CmdKSearchResults.vue`
+- Modify: `frontend/src/components/CmdKSearchResults.spec.ts`
+
+- [ ] **Step 1: Update CmdKModal.vue**
+
+Replace `useCopilot` import with `useAIProvider`. Gate chat on `providers.length > 0` instead of `isConnected`. Update the not-connected message to "Configure an AI provider in Settings, or connect GitHub Copilot." with link to `/app/settings/ai`.
+
+- [ ] **Step 2: Update CmdKModal.spec.ts**
+
+Replace `mockIsConnected` with `mockProviders`. Test: providers exist → chat mode works; no providers → shows "no provider configured" message.
+
+- [ ] **Step 3: Update CmdKChatView.vue**
+
+Replace `useCopilot` import with `useAIProvider`. Update model selector to use `<optgroup>` per provider when multiple providers exist. Pass `provider_id` via `sendChatRequest()`.
+
+- [ ] **Step 4: Update CmdKChatView.spec.ts**
+
+Update mocks from `useCopilot` to `useAIProvider`. Add test for grouped model selector with multiple providers.
+
+- [ ] **Step 4.5: Update CmdKSearchResults.vue and spec**
+
+`CmdKSearchResults.vue` also imports `useCopilot` and checks `isConnected`. Update to use `useAIProvider` and check `providers.length > 0`. Update the mock in `CmdKSearchResults.spec.ts` accordingly.
+
+- [ ] **Step 5: Run all frontend tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/CmdKModal.vue frontend/src/components/CmdKModal.spec.ts frontend/src/components/CmdKChatView.vue frontend/src/components/CmdKChatView.spec.ts
+git commit -m "feat: update Cmd+K to use AI provider system"
+```
+
+---
+
+## Task 14: Remove old useCopilot.ts
+
+**Files:**
+- Delete: `frontend/src/composables/useCopilot.ts`
+- Delete: `frontend/src/composables/useCopilot.spec.ts`
+- Modify: `frontend/src/components/CopilotConnectionPanel.vue` — import from `useCopilotAuth`
+
+- [ ] **Step 1: Update CopilotConnectionPanel.vue and its spec**
+
+Change import from `useCopilot` to `useCopilotAuth`. The component only uses auth-related state. Also update `CopilotConnectionPanel.spec.ts` — change the mock from `vi.mock('../composables/useCopilot', ...)` to `vi.mock('../composables/useCopilotAuth', ...)`.
+
+- [ ] **Step 2: Search for remaining useCopilot imports**
+
+Run: `grep -r "useCopilot" frontend/src/ --include="*.ts" --include="*.vue" -l`
+Expected: only `useCopilotAuth.ts` and `useCopilotTools.ts` (which imports types, not the composable)
+
+- [ ] **Step 3: Update useCopilotTools.ts imports**
+
+If `useCopilotTools.ts` imports types from `useCopilot`, move those type definitions (`ToolDefinition`, `ToolCall`) to a shared types file or into `useAIProvider.ts` and update the import.
+
+- [ ] **Step 4: Delete old files**
+
+```bash
+rm frontend/src/composables/useCopilot.ts frontend/src/composables/useCopilot.spec.ts
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: all PASS
+
+- [ ] **Step 6: Run lint**
+
+Run: `cd frontend && npm run lint:fix`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A frontend/src/
+git commit -m "refactor: remove useCopilot.ts, migrate all consumers to useAIProvider/useCopilotAuth"
+```
+
+---
+
+## Task 15: End-to-end verification
+
+- [ ] **Step 1: Run all backend tests**
+
+Run: `cd backend && go test ./... -v`
+Expected: all PASS
+
+- [ ] **Step 2: Run all frontend tests**
+
+Run: `cd frontend && npm run test`
+Expected: all PASS
+
+- [ ] **Step 3: Run frontend build**
+
+Run: `cd frontend && npm run build`
+Expected: builds successfully with no type errors
+
+- [ ] **Step 4: Run lint**
+
+Run: `cd frontend && npm run lint:fix`
+Expected: clean
+
+- [ ] **Step 5: Manual smoke test (if dev server available)**
+
+Start the app, navigate to Settings > AI, verify the provider list renders (empty state). Open Cmd+K, verify the "no provider configured" message appears (if no providers and no Copilot). If Copilot is connected, verify chat still works through the new CopilotProvider path.
+
+- [ ] **Step 6: Final commit if any fixes needed**
+
+```bash
+git add -A && git commit -m "fix: address issues found during e2e verification"
+```

--- a/docs/superpowers/specs/2026-03-23-cmdk-datasource-tools-design.md
+++ b/docs/superpowers/specs/2026-03-23-cmdk-datasource-tools-design.md
@@ -1,0 +1,86 @@
+# Cmd+K Chat: Fix Datasource Tool Execution & Add list_datasources Tool
+
+**Date:** 2026-03-23
+**Status:** Approved
+
+## Problem
+
+The Cmd+K chat panel fails to run tools (`get_metrics`, `get_labels`, `get_label_values`) with `{"error":"invalid datasource id"}`. Two root causes:
+
+1. **No view passes `datasourceId` in command context.** Every `registerContext()` call only sets `viewName`, `viewRoute`, and `description`. `CmdKModal.vue` falls back to `''`, which the backend rejects as an invalid UUID.
+2. **No tool exists for datasource discovery.** When no context is available, the AI model has no way to find out which datasources exist.
+
+## Solution
+
+### A. Context Propagation (Explore tabs to CmdK)
+
+**Files changed:** `UnifiedExploreView.vue`, `MetricsExploreTab.vue`, `LogsExploreTab.vue`
+
+- `MetricsExploreTab` and `LogsExploreTab` emit a `datasource-changed` event with `{ id, name, type }` when the user selects a datasource.
+- `UnifiedExploreView` listens to the event and calls `registerContext()` with `datasourceId`, `datasourceName`, and `datasourceType` included.
+- Other views (Home, Settings, Alerts, Services, DashboardGen, DashboardDetail) remain unchanged — no datasource in context.
+
+### B. `list_datasources` Tool
+
+**Files changed:** `useCopilotTools.ts`, `CmdKChatView.vue`
+
+New tool definition:
+- **Name:** `list_datasources`
+- **Description:** List all datasources available in the current organization. Use this to discover datasource IDs before querying metrics or labels.
+- **Parameters:** none
+- **Returns:** JSON array of `{ id, name, type }` objects
+
+Executor changes:
+- `useCopilotToolExecutor` signature changes from `(datasourceId: () => string)` to `(datasourceId: () => string, orgId: () => string)`.
+- `CmdKChatView` passes `orgId` from `useOrganization().currentOrg.value?.id`.
+- The `list_datasources` case calls `listDataSources(orgId)` from `api/datasources.ts` (already exists).
+
+### C. Datasource ID Override in Discovery Tools
+
+**Files changed:** `useCopilotTools.ts`
+
+- `get_metrics`, `get_labels`, and `get_label_values` each gain an optional `datasource_id` string parameter: "Override the default datasource. Use an ID from list_datasources."
+- In the executor switch cases: `const dsId = args.datasource_id || datasourceId()`.
+- This allows the model to select a datasource via `list_datasources` and pass it explicitly to subsequent tools.
+
+### D. Frontend System Message for Tool Guidance
+
+**Files changed:** `CmdKChatView.vue`
+
+`buildChatRequestMessages()` prepends a system message before the conversation history:
+
+- **With context:** "You have tools to explore datasource data. You are currently working with datasource '{datasourceName}' (type: {datasourceType}, id: {datasourceId}). You can use get_metrics, get_labels, and get_label_values directly."
+- **Without context (empty datasourceId):** "You have tools to explore datasource data. No datasource is currently selected. Call list_datasources first to discover available datasources, then pass the datasource_id to other tools."
+
+This message is separate from the backend's system prompt (which provides query-language expertise).
+
+## Edge Cases & Error Handling
+
+- **Empty `orgId`:** If `useOrganization().currentOrg.value?.id` is undefined when `list_datasources` is called (org not yet loaded), the executor returns `"Error: no organization selected"` without making an API call.
+- **`list_datasources` API failure:** If `listDataSources(orgId)` throws, the existing `executeTool` catch handler in `CmdKChatView.vue` (line 109) catches it and returns `"Error: {message}"` to the model, which can relay the error to the user.
+- **Empty `datasourceId` with no override:** If the context datasource is empty and the model calls `get_metrics`/`get_labels`/`get_label_values` without passing `datasource_id`, the executor returns `"Error: no datasource selected. Call list_datasources first to get a datasource ID."` instead of hitting the backend with an invalid UUID.
+
+## Scope Boundaries
+
+- No backend changes — existing endpoints cover all needs.
+- No new API endpoints — `GET /api/orgs/{orgId}/datasources` already exists.
+- No changes to views other than `UnifiedExploreView`, `MetricsExploreTab`, and `LogsExploreTab`.
+- `TracesExploreTab` is out of scope (trace tools are a separate feature).
+
+## Data Flow
+
+```
+User opens Cmd+K on Explore (Metrics tab)
+  -> MetricsExploreTab emits datasource-changed({ id, name, type })
+  -> UnifiedExploreView calls registerContext({ ..., datasourceId, datasourceName, datasourceType })
+  -> CmdKModal reads currentContext.datasourceId
+  -> CmdKChatView receives props.datasourceId
+  -> Frontend prepends system message: "Working with datasource X..."
+  -> Model calls get_metrics → executeTool uses props.datasourceId → backend returns metrics
+
+User opens Cmd+K on Home (no datasource context)
+  -> CmdKModal falls back to datasourceId = ''
+  -> Frontend prepends system message: "No datasource selected, call list_datasources..."
+  -> Model calls list_datasources → returns [{ id, name, type }, ...]
+  -> Model calls get_metrics({ datasource_id: "<chosen-id>" }) → works
+```

--- a/docs/superpowers/specs/2026-03-23-cmdk-datasource-tools-design.md
+++ b/docs/superpowers/specs/2026-03-23-cmdk-datasource-tools-design.md
@@ -1,22 +1,24 @@
-# Cmd+K Chat: Fix Datasource Tool Execution & Add list_datasources Tool
+# Cmd+K Chat: Fix Datasource Tools & Add Full Metrics/Logs/Traces Tool Support
 
-**Date:** 2026-03-23
+**Date:** 2026-03-23 (updated 2026-03-24 after eng review)
 **Status:** Approved
 
 ## Problem
 
-The Cmd+K chat panel fails to run tools (`get_metrics`, `get_labels`, `get_label_values`) with `{"error":"invalid datasource id"}`. Two root causes:
+The Cmd+K chat panel fails to run tools (`get_metrics`, `get_labels`, `get_label_values`) with `{"error":"invalid datasource id"}`. Root causes:
 
 1. **No view passes `datasourceId` in command context.** Every `registerContext()` call only sets `viewName`, `viewRoute`, and `description`. `CmdKModal.vue` falls back to `''`, which the backend rejects as an invalid UUID.
 2. **No tool exists for datasource discovery.** When no context is available, the AI model has no way to find out which datasources exist.
+3. **Tools are metrics-only.** `getMetricsTools()` is always used regardless of datasource type. Logs and traces datasources get metrics tools that don't work for them.
+4. **Backend system prompt mismatch.** CmdKModal defaults to `datasourceType: 'victoriametrics'` when no context exists, causing the backend to inject a metrics-specific system prompt even when no datasource is selected.
 
 ## Solution
 
-### A. Context Propagation (Explore tabs to CmdK)
+### A. Context Propagation (All Explore tabs to CmdK)
 
-**Files changed:** `UnifiedExploreView.vue`, `MetricsExploreTab.vue`, `LogsExploreTab.vue`
+**Files changed:** `UnifiedExploreView.vue`, `MetricsExploreTab.vue`, `LogsExploreTab.vue`, `TracesExploreTab.vue`
 
-- `MetricsExploreTab` and `LogsExploreTab` emit a `datasource-changed` event with `{ id, name, type }` when the user selects a datasource.
+- All three Explore tabs emit a `datasource-changed` event with `{ id, name, type }` on both auto-select (mount) and user selection.
 - `UnifiedExploreView` listens to the event and calls `registerContext()` with `datasourceId`, `datasourceName`, and `datasourceType` included.
 - Other views (Home, Settings, Alerts, Services, DashboardGen, DashboardDetail) remain unchanged — no datasource in context.
 
@@ -40,8 +42,9 @@ Executor changes:
 **Files changed:** `useCopilotTools.ts`
 
 - `get_metrics`, `get_labels`, and `get_label_values` each gain an optional `datasource_id` string parameter: "Override the default datasource. Use an ID from list_datasources."
-- In the executor switch cases: `const dsId = args.datasource_id || datasourceId()`.
+- Extract a `resolveDatasourceId(args, defaultId)` helper for DRY across the switch cases.
 - This allows the model to select a datasource via `list_datasources` and pass it explicitly to subsequent tools.
+- **Empty dsId guard:** If no context + no override, return helpful error instead of hitting backend.
 
 ### D. Frontend System Message for Tool Guidance
 
@@ -49,23 +52,70 @@ Executor changes:
 
 `buildChatRequestMessages()` prepends a system message before the conversation history:
 
-- **With context:** "You have tools to explore datasource data. You are currently working with datasource '{datasourceName}' (type: {datasourceType}, id: {datasourceId}). You can use get_metrics, get_labels, and get_label_values directly."
+- **With context:** "You have tools to explore datasource data. You are currently working with datasource '{datasourceName}' (type: {datasourceType}, id: {datasourceId}). You can use the data discovery tools directly."
 - **Without context (empty datasourceId):** "You have tools to explore datasource data. No datasource is currently selected. Call list_datasources first to discover available datasources, then pass the datasource_id to other tools."
 
-This message is separate from the backend's system prompt (which provides query-language expertise).
+### E. Fix CmdKModal No-Context Defaults
+
+**Files changed:** `CmdKModal.vue`
+
+When no context exists, pass `datasourceType: ''` and `datasourceName: ''` instead of `'victoriametrics'`/`'default'`. This causes the backend to use the neutral `defaultSystemPrompt` instead of the metrics-specific one.
+
+### F. Type-Aware Tool Sets
+
+**Files changed:** `useCopilotTools.ts`, `CmdKChatView.vue`
+
+Instead of always using `getMetricsTools()`, provide datasource-type-aware tool sets:
+
+- **Metrics** (victoriametrics, prometheus): `get_metrics`, `get_labels`, `get_label_values`, `write_query`, `run_query`, `generate_dashboard`
+- **Logs** (loki, victorialogs): `get_labels`, `get_label_values`, `write_query`, `run_query` (no `get_metrics` — logs don't have metric names)
+- **Traces** (tempo, jaeger): `get_trace_services`, `get_labels`, `get_label_values`, `write_query`, `run_query` (trace service discovery tool)
+- **No context**: All tools from all types + `list_datasources` (model picks appropriate ones after discovering datasource type)
+
+New tool: `get_trace_services` — calls `fetchDataSourceTraceServices(dsId)` from `api/datasources.ts` (already exists).
+
+### G. Type-Aware Query Navigation
+
+**Files changed:** `useCopilotTools.ts`
+
+`write_query` currently hardcodes navigation to `/app/explore/metrics`. Change to:
+- If datasource type is logs (loki, victorialogs): navigate to `/app/explore/logs`
+- If datasource type is traces: navigate to `/app/explore/traces`
+- Default (metrics or unknown): navigate to `/app/explore/metrics`
+
+The executor needs access to the datasource type — either from context or from the tool args.
+
+### H. Fix generate_dashboard for Discovered Datasources
+
+**Files changed:** `CmdKChatView.vue`
+
+Currently `generate_dashboard` stamps `props.datasourceId` onto every panel (line 89). When the model discovers a datasource via `list_datasources`, this prop is empty.
+
+Fix: Track the last `datasource_id` used in tool calls during the conversation. Use it for `generate_dashboard` panels when `props.datasourceId` is empty.
+
+### I. Update Backend System Prompts
+
+**Files changed:** `backend/internal/handlers/github_copilot.go`
+
+Update system prompts for each datasource type to mention available tools:
+- **loki/victorialogs:** Mention `get_labels`, `get_label_values`, `write_query`, `run_query`
+- **prometheus:** Mention `get_metrics`, `get_labels`, `get_label_values`, `write_query`, `run_query`, `generate_dashboard`
+- **victoriametrics:** Already mentions tools (keep as-is)
 
 ## Edge Cases & Error Handling
 
 - **Empty `orgId`:** If `useOrganization().currentOrg.value?.id` is undefined when `list_datasources` is called (org not yet loaded), the executor returns `"Error: no organization selected"` without making an API call.
 - **`list_datasources` API failure:** If `listDataSources(orgId)` throws, the existing `executeTool` catch handler in `CmdKChatView.vue` (line 109) catches it and returns `"Error: {message}"` to the model, which can relay the error to the user.
-- **Empty `datasourceId` with no override:** If the context datasource is empty and the model calls `get_metrics`/`get_labels`/`get_label_values` without passing `datasource_id`, the executor returns `"Error: no datasource selected. Call list_datasources first to get a datasource ID."` instead of hitting the backend with an invalid UUID.
+- **Empty `datasourceId` with no override:** If the context datasource is empty and the model calls discovery tools without passing `datasource_id`, the executor returns `"Error: no datasource selected. Call list_datasources first to get a datasource ID."` instead of hitting the backend with an invalid UUID.
+- **Initial-turn race:** If Cmd+K opens before Explore tab auto-selects a datasource, the no-context fallback (`list_datasources`) handles it transparently.
+- **Wrong tool for datasource type:** Type-aware tool sets (section F) prevent the model from being offered `get_metrics` for a logs datasource.
 
 ## Scope Boundaries
 
-- No backend changes — existing endpoints cover all needs.
-- No new API endpoints — `GET /api/orgs/{orgId}/datasources` already exists.
-- No changes to views other than `UnifiedExploreView`, `MetricsExploreTab`, and `LogsExploreTab`.
-- `TracesExploreTab` is out of scope (trace tools are a separate feature).
+- Backend change is minimal: only system prompt text updates in `github_copilot.go`.
+- No new API endpoints — all required endpoints already exist.
+- All three Explore tabs wire up context propagation.
+- `generate_dashboard` works from both context and discovered datasources.
 
 ## Data Flow
 
@@ -73,14 +123,66 @@ This message is separate from the backend's system prompt (which provides query-
 User opens Cmd+K on Explore (Metrics tab)
   -> MetricsExploreTab emits datasource-changed({ id, name, type })
   -> UnifiedExploreView calls registerContext({ ..., datasourceId, datasourceName, datasourceType })
-  -> CmdKModal reads currentContext.datasourceId
-  -> CmdKChatView receives props.datasourceId
-  -> Frontend prepends system message: "Working with datasource X..."
+  -> CmdKModal reads currentContext.datasourceId, datasourceType
+  -> CmdKChatView receives props, selects metrics tool set
+  -> Frontend prepends system message: "Working with datasource X (victoriametrics)..."
+  -> Backend uses victoriametrics system prompt (mentions tools)
   -> Model calls get_metrics → executeTool uses props.datasourceId → backend returns metrics
 
+User opens Cmd+K on Explore (Logs tab)
+  -> LogsExploreTab emits datasource-changed({ id, name, type: 'loki' })
+  -> CmdKChatView receives props, selects logs tool set (no get_metrics)
+  -> Model calls get_labels → works against Loki
+
 User opens Cmd+K on Home (no datasource context)
-  -> CmdKModal falls back to datasourceId = ''
-  -> Frontend prepends system message: "No datasource selected, call list_datasources..."
+  -> CmdKModal passes datasourceType: '', datasourceName: ''
+  -> Backend uses neutral defaultSystemPrompt
+  -> Frontend prepends: "No datasource selected, call list_datasources..."
+  -> CmdKChatView provides all tools (metrics + logs + traces + list_datasources)
   -> Model calls list_datasources → returns [{ id, name, type }, ...]
   -> Model calls get_metrics({ datasource_id: "<chosen-id>" }) → works
+  -> Model calls generate_dashboard → uses tracked datasource_id from prior tool calls
 ```
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 7 findings, all addressed |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 2 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+
+**CODEX:** Found 7 issues — generate_dashboard ID gap, backend prompt mismatch, metrics-only tools, traces exclusion, initial-turn race, overbuilt concern, test confidence. All resolved: scope expanded to logs+traces, backend prompts included, integration tests added.
+**VERDICT:** ENG CLEARED — ready to implement.
+
+## Test Requirements
+
+### Unit Tests (16 paths)
+
+**useCopilotTools.spec.ts:**
+1. `list_datasources` tool definition exists with correct schema
+2. `get_metrics`, `get_labels`, `get_label_values` each have optional `datasource_id` param
+3. `get_trace_services` tool definition exists
+4. `resolveDatasourceId` helper: returns override when provided
+5. `resolveDatasourceId` helper: returns default when no override
+6. `resolveDatasourceId` helper: returns error when both empty
+7. `list_datasources` executor: happy path returns JSON
+8. `list_datasources` executor: empty orgId returns error string
+9. `get_metrics` executor: uses override datasource_id
+10. `get_metrics` executor: falls back to context datasource_id
+11. `get_trace_services` executor: happy path returns services
+
+**CmdKChatView.spec.ts:**
+12. `buildChatRequestMessages` with context: prepends system message with datasource info
+13. `buildChatRequestMessages` without context: prepends system message instructing list_datasources
+14. Metrics context → metrics tool set provided
+15. Logs context → logs tool set provided (no get_metrics)
+16. No context → all tools provided
+
+### Integration Tests (3 paths)
+
+**CmdKChatView.integration.spec.ts** (real executor, mocked HTTP):
+17. Metrics context → get_metrics tool call → successful API response
+18. Logs context → get_labels tool call → successful API response
+19. No context → list_datasources → datasource_id override → get_metrics succeeds

--- a/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
+++ b/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
@@ -28,7 +28,7 @@ CREATE TABLE ai_providers (
     models_override JSONB,              -- e.g. [{"id":"gpt-4o","name":"GPT-4o"}], null for auto-discover
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW(),
-    UNIQUE(organization_id, provider_type, base_url)
+    UNIQUE(organization_id, display_name)
 );
 ```
 
@@ -167,7 +167,17 @@ Copilot-specific auth state: `isConnected`, `hasCopilot`, `githubUsername`, devi
 - **`CmdKChatView.vue`** — model selector grouped by provider. Uses `useAIProvider` instead of `useCopilot`
 - **`CopilotConnectionPanel.vue`** — shown only when no org providers configured. Unchanged internally.
 - **`UnifiedSettingsView.vue`** — new "AI Providers" admin section: add/edit/delete providers, test connection, see discovered models. Copilot connection moves under "Personal Fallback" subsection.
-- **`useCopilotTools.ts`** — unchanged. Tools are datasource-specific, passed to whichever provider handles chat.
+- **`useCopilotTools.ts`** — unchanged. Tools are datasource-specific, passed to whichever provider handles chat. Note: tool calling (function calling) requires provider support. See "Tool Compatibility" below.
+
+## Org Switch State Reset
+
+The `useAIProvider` composable watches `currentOrgId` from `useOrganization()`. When the org changes, all provider state resets (providers list, models list, selected provider/model) and re-fetches from the new org's endpoints. This prevents stale providers/models from a previous org leaking into the current session.
+
+## Tool Compatibility
+
+Tool calling (OpenAI function-calling for dashboard generation, write_query, run_query, etc.) requires provider support. Not all "OpenAI-compatible" providers implement function calling reliably (especially Ollama, vLLM, and some gateways).
+
+Graceful degradation: if the provider returns an error indicating no tool support (or returns a malformed tool_calls response), the backend retries the request without tools. The frontend shows a note: "Dashboard generation is not available with this provider." Streaming chat continues to work — only tool-based features are disabled.
 
 ## Error Handling
 
@@ -182,6 +192,17 @@ Copilot-specific auth state: `isConnected`, `hasCopilot`, `githubUsername`, devi
 
 - **Rate limiting / usage tracking**: When an admin configures an API key for the org, all members share it. Per-user rate limiting and usage tracking are deferred to a future iteration. For now, the assumption is that org admins manage their API key quotas externally.
 - **Anthropic native API**: Anthropic's `/v1/messages` API is not OpenAI-compatible. Supporting it natively would require a separate provider implementation. Deferred — use OpenRouter or any OpenAI-compatible gateway for Anthropic models.
+
+## Eng Review Decisions
+
+1. **Shared RequireOrgMember middleware** — extracts org_id from URL, verifies membership, injects into context. Reused by all `/api/orgs/{id}/ai/*` endpoints. Admin checks layered on top per-handler.
+2. **Backend prepends system prompt** — providers are dumb pipes. Orchestration layer prepends the datasource-specific system prompt before calling `provider.Chat()`.
+3. **Extract encrypt/decrypt to `internal/crypto`** — shared by Copilot auth (GitHub tokens) and AI providers (API keys). Single source of truth.
+4. **Copilot token caching** — `sync.Map` keyed by userID, TTL = `expires_at - 60s`. Eliminates per-request GitHub API round-trip.
+5. **Full test coverage** — all new backend code + backfill Copilot auth endpoints (device flow, connection, disconnect).
+6. **Watch `currentOrgId` for state reset** — prevents stale provider/model state leaking across org switches.
+7. **Graceful tool degradation** — if provider doesn't support function calling, retry without tools. Tool-based features (dashboard generation) disabled with user-visible note.
+8. **UNIQUE(organization_id, display_name)** — allows multiple configs for the same provider/URL with different API keys.
 
 ## Route Registration
 

--- a/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
+++ b/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
@@ -1,0 +1,178 @@
+# Multi-Provider AI Support
+
+Replace the Copilot-only chat system with a provider abstraction that supports OpenAI, Anthropic, OpenRouter, Ollama, vLLM, and any OpenAI-compatible endpoint — while keeping Copilot as a personal fallback.
+
+## Provider Hierarchy
+
+1. Org has AI providers configured and enabled -> use those
+2. No org providers -> user's personal Copilot connection (if any)
+3. Neither -> "no AI provider configured" error
+
+When org providers exist, Copilot does not appear in the provider list regardless of user's Copilot connection status.
+
+## Database Schema
+
+### New table: `ai_providers`
+
+```sql
+CREATE TABLE ai_providers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider_type VARCHAR(50) NOT NULL,  -- 'openai', 'anthropic', 'openrouter', 'ollama', 'custom'
+    display_name VARCHAR(255) NOT NULL,
+    base_url TEXT NOT NULL,              -- e.g. 'https://api.openai.com/v1'
+    api_key TEXT,                        -- encrypted AES-GCM, nullable for local providers
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    models_override JSONB,              -- e.g. [{"id":"gpt-4o","name":"GPT-4o"}], null for auto-discover
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE(organization_id, provider_type, base_url)
+);
+```
+
+### Existing tables unchanged
+
+- `user_github_connections` — Copilot device flow auth (user-level)
+- `sso_configs` with `github_copilot` — org-level GitHub OAuth app config
+
+## Backend Provider Interface
+
+```go
+type AIProvider interface {
+    ListModels(ctx context.Context) ([]AIModel, error)
+    Chat(ctx context.Context, req ChatRequest, w http.ResponseWriter) error
+}
+
+type AIModel struct {
+    ID       string `json:"id"`
+    Name     string `json:"name"`
+    Vendor   string `json:"vendor"`
+    Category string `json:"category"`
+}
+
+type ChatRequest struct {
+    Model    string        `json:"model"`
+    Messages []interface{} `json:"messages"`
+    Tools    []interface{} `json:"tools,omitempty"`
+    Stream   bool          `json:"stream"`
+}
+```
+
+### Implementations
+
+**`OpenAICompatibleProvider`** — covers OpenAI, Anthropic, OpenRouter, Ollama, vLLM, custom. Needs `baseURL` + `apiKey`. Calls `baseURL/models` for discovery, `baseURL/chat/completions` for chat. Handles both SSE streaming and JSON non-streaming passthrough.
+
+**`CopilotProvider`** — wraps existing Copilot token-fetching logic. `ListModels()` fetches a Copilot token then hits the models endpoint with special headers. `Chat()` does the same token dance then forwards to Copilot chat completions with `Editor-Version`, `Copilot-Integration-Id`, etc.
+
+### Provider Resolution
+
+```
+1. Query ai_providers WHERE organization_id = user's org AND enabled = true
+2. If found -> return as available providers
+3. If none -> check user_github_connections for Copilot token
+4. If Copilot connected -> return CopilotProvider as sole provider
+5. If neither -> error
+```
+
+## API Endpoints
+
+### New endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/ai/providers` | List available providers for current user (resolved) |
+| `GET` | `/api/ai/models` | List models across all available providers |
+| `POST` | `/api/ai/chat` | Chat request with `provider_id` routing |
+| `POST` | `/api/orgs/{id}/ai-providers` | Admin: create provider |
+| `GET` | `/api/orgs/{id}/ai-providers` | Admin: list org providers |
+| `PUT` | `/api/orgs/{id}/ai-providers/{pid}` | Admin: update provider |
+| `DELETE` | `/api/orgs/{id}/ai-providers/{pid}` | Admin: delete provider |
+| `POST` | `/api/orgs/{id}/ai-providers/{pid}/test` | Admin: test connection |
+
+### Kept (Copilot auth is user-level)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/auth/github/device` | Start Copilot device flow |
+| `POST` | `/api/auth/github/device/poll` | Poll device flow |
+| `GET` | `/api/auth/github/connection` | Check Copilot connection |
+| `DELETE` | `/api/auth/github/connection` | Disconnect Copilot |
+
+### Removed
+
+- `GET /api/copilot/models` -> replaced by `GET /api/ai/models`
+- `POST /api/copilot/chat` -> replaced by `POST /api/ai/chat`
+- `POST /api/orgs/{id}/github-app` and `GET /api/orgs/{id}/github-app` -> replaced by generic provider CRUD
+
+### Chat request body
+
+```json
+{
+  "provider_id": "uuid-or-copilot",
+  "model": "claude-sonnet-4.6",
+  "datasource_type": "victoriametrics",
+  "datasource_name": "prod",
+  "messages": [],
+  "tools": [],
+  "stream": true
+}
+```
+
+## Frontend Changes
+
+### `useCopilot.ts` -> `useAIProvider.ts`
+
+Same module-level shared state pattern, provider-aware:
+
+```ts
+// State
+const providers = ref<AIProviderInfo[]>([])
+const selectedProviderId = ref<string>('')    // uuid or 'copilot'
+const models = ref<AIModel[]>([])
+const selectedModel = ref<string>('')
+
+// Functions
+fetchProviders()     // GET /api/ai/providers
+fetchModels()        // GET /api/ai/models?provider_id=X
+sendMessage()        // POST /api/ai/chat with provider_id (SSE streaming)
+sendChatRequest()    // POST /api/ai/chat non-streaming (tool calling)
+```
+
+### `useCopilotAuth.ts` (extracted)
+
+Copilot-specific auth state: `isConnected`, `hasCopilot`, `githubUsername`, device flow refs. Only used by `CopilotConnectionPanel` and provider resolution display.
+
+### Component changes
+
+- **`CmdKModal.vue`** — gate on `providers.length > 0` instead of `isConnected`
+- **`CmdKChatView.vue`** — model selector grouped by provider. Uses `useAIProvider` instead of `useCopilot`
+- **`CopilotConnectionPanel.vue`** — shown only when no org providers configured. Unchanged internally.
+- **`UnifiedSettingsView.vue`** — new "AI Providers" admin section: add/edit/delete providers, test connection, see discovered models. Copilot connection moves under "Personal Fallback" subsection.
+- **`useCopilotTools.ts`** — unchanged. Tools are datasource-specific, passed to whichever provider handles chat.
+
+## Error Handling
+
+- **Provider unavailable** (401, connection refused): return clear error, no automatic fallback to another provider. User can manually switch.
+- **Copilot token expiry**: `fetchCopilotToken()` gets fresh token per request, no change needed.
+- **API key rotation**: admin updates via PUT, takes effect immediately (read per-request, not cached).
+- **Provider deleted mid-session**: next request returns "provider not found", frontend refreshes provider list.
+- **Model discovery fails**: fall back to `models_override` from DB. If empty, return provider with empty model list and warning.
+- **Org providers exist + user has Copilot**: Copilot does NOT appear. Org providers take full precedence.
+
+## Testing
+
+### Backend
+
+- Provider resolution logic (org > copilot fallback > none)
+- `OpenAICompatibleProvider` against mock HTTP server (models list, streaming chat, non-streaming chat)
+- Provider CRUD endpoints (create, update, delete, test connection)
+- Full chat flow through `/api/ai/chat`
+- Existing Copilot tests adapted to new interface
+
+### Frontend
+
+- `useAIProvider.spec.ts` — provider fetching, model fetching, selection, Copilot fallback
+- `AIProviderSettings.spec.ts` — add/edit/delete provider, test connection
+- `CmdKChatView.spec.ts` — updated for provider_id, model grouping
+- `CmdKModal.spec.ts` — gate on providers instead of isConnected
+- `CopilotConnectionPanel.spec.ts` — only shown when no org providers

--- a/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
+++ b/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
@@ -1,6 +1,8 @@
 # Multi-Provider AI Support
 
-Replace the Copilot-only chat system with a provider abstraction that supports OpenAI, Anthropic, OpenRouter, Ollama, vLLM, and any OpenAI-compatible endpoint — while keeping Copilot as a personal fallback.
+Replace the Copilot-only chat system with a provider abstraction that supports OpenAI, OpenRouter, Ollama, vLLM, and any OpenAI-compatible endpoint — while keeping Copilot as a personal fallback.
+
+Note: Anthropic's native API (`/v1/messages`) is not OpenAI-compatible — different request schema, auth header (`x-api-key`), and streaming format. To use Anthropic models, configure them through OpenRouter (which wraps Anthropic in an OpenAI-compatible API) or any other OpenAI-compatible gateway. This avoids needing a separate provider implementation for a single vendor's proprietary format.
 
 ## Provider Hierarchy
 
@@ -18,7 +20,7 @@ When org providers exist, Copilot does not appear in the provider list regardles
 CREATE TABLE ai_providers (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-    provider_type VARCHAR(50) NOT NULL,  -- 'openai', 'anthropic', 'openrouter', 'ollama', 'custom'
+    provider_type VARCHAR(50) NOT NULL,  -- 'openai', 'openrouter', 'ollama', 'custom'
     display_name VARCHAR(255) NOT NULL,
     base_url TEXT NOT NULL,              -- e.g. 'https://api.openai.com/v1'
     api_key TEXT,                        -- encrypted AES-GCM, nullable for local providers
@@ -33,7 +35,7 @@ CREATE TABLE ai_providers (
 ### Existing tables unchanged
 
 - `user_github_connections` — Copilot device flow auth (user-level)
-- `sso_configs` with `github_copilot` — org-level GitHub OAuth app config
+- `sso_configs` with `github_copilot` — stays as-is. These rows store org-level GitHub OAuth app credentials for the device flow (client_id/client_secret). They are independent of the AI provider system — they configure *how users authenticate with GitHub*, not which AI provider to use. The old `POST/GET /api/orgs/{id}/github-app` endpoints are removed; the same config can be managed via the existing `sso_configs` admin UI if needed in the future.
 
 ## Backend Provider Interface
 
@@ -44,50 +46,67 @@ type AIProvider interface {
 }
 
 type AIModel struct {
-    ID       string `json:"id"`
-    Name     string `json:"name"`
-    Vendor   string `json:"vendor"`
-    Category string `json:"category"`
+    ID       string                 `json:"id"`
+    Name     string                 `json:"name"`
+    Vendor   string                 `json:"vendor"`
+    Category string                 `json:"category"`
+    Meta     map[string]interface{} `json:"meta,omitempty"` // provider-specific (e.g. Copilot premium_multiplier, preview)
 }
 
 type ChatRequest struct {
-    Model    string        `json:"model"`
-    Messages []interface{} `json:"messages"`
-    Tools    []interface{} `json:"tools,omitempty"`
-    Stream   bool          `json:"stream"`
+    Model    string            `json:"model"`
+    Messages []json.RawMessage `json:"messages"`  // preserved as raw JSON for provider passthrough
+    Tools    []json.RawMessage `json:"tools,omitempty"`
+    Stream   bool              `json:"stream"`
 }
 ```
 
 ### Implementations
 
-**`OpenAICompatibleProvider`** — covers OpenAI, Anthropic, OpenRouter, Ollama, vLLM, custom. Needs `baseURL` + `apiKey`. Calls `baseURL/models` for discovery, `baseURL/chat/completions` for chat. Handles both SSE streaming and JSON non-streaming passthrough.
+**`OpenAICompatibleProvider`** — covers OpenAI, OpenRouter, Ollama, and any OpenAI-compatible endpoint (vLLM, LiteLLM, etc. use `provider_type = 'custom'`). Needs `baseURL` + `apiKey`. Calls `baseURL/models` for discovery, `baseURL/chat/completions` for chat. Handles both SSE streaming and JSON non-streaming passthrough.
 
 **`CopilotProvider`** — wraps existing Copilot token-fetching logic. `ListModels()` fetches a Copilot token then hits the models endpoint with special headers. `Chat()` does the same token dance then forwards to Copilot chat completions with `Editor-Version`, `Copilot-Integration-Id`, etc.
+
+### System Prompt Injection
+
+System prompts are injected at the orchestration layer *before* dispatching to any provider. The existing `copilotSystemPrompts` map (mapping `datasource_type` to expert prompts for PromQL, LogQL, TraceQL, etc.) moves out of `github_copilot.go` into a shared `system_prompts.go` file. The `AIHandler.Chat()` method prepends the appropriate system prompt to the messages array before calling `provider.Chat()`. This ensures all providers get the same datasource-specific expertise regardless of backend.
 
 ### Provider Resolution
 
 ```
-1. Query ai_providers WHERE organization_id = user's org AND enabled = true
+1. Query ai_providers WHERE organization_id = org_id (from URL) AND enabled = true
 2. If found -> return as available providers
 3. If none -> check user_github_connections for Copilot token
 4. If Copilot connected -> return CopilotProvider as sole provider
 5. If neither -> error
 ```
 
+### Copilot as provider_id
+
+When the user's Copilot fallback is active, it appears with `provider_id = "copilot"` (a reserved string). The backend routing logic: if `provider_id == "copilot"`, use `CopilotProvider` with the user's stored GitHub token; otherwise, parse as UUID and look up in `ai_providers`.
+
 ## API Endpoints
 
 ### New endpoints
 
+All AI endpoints are scoped to an org via the URL path. This is consistent with existing patterns (e.g., `/api/orgs/{id}/github-app`) and avoids ambiguity for users in multiple orgs. The frontend already tracks the current org via `useOrganization()`.
+
+**User-facing (any org member):**
+
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/ai/providers` | List available providers for current user (resolved) |
-| `GET` | `/api/ai/models` | List models across all available providers |
-| `POST` | `/api/ai/chat` | Chat request with `provider_id` routing |
-| `POST` | `/api/orgs/{id}/ai-providers` | Admin: create provider |
-| `GET` | `/api/orgs/{id}/ai-providers` | Admin: list org providers |
-| `PUT` | `/api/orgs/{id}/ai-providers/{pid}` | Admin: update provider |
-| `DELETE` | `/api/orgs/{id}/ai-providers/{pid}` | Admin: delete provider |
-| `POST` | `/api/orgs/{id}/ai-providers/{pid}/test` | Admin: test connection |
+| `GET` | `/api/orgs/{id}/ai/providers` | List available providers (resolved: org providers + Copilot fallback) |
+| `GET` | `/api/orgs/{id}/ai/models` | List models across available providers |
+| `POST` | `/api/orgs/{id}/ai/chat` | Chat request with `provider_id` routing |
+
+**Admin-only (org admin):**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/orgs/{id}/ai/providers` | Create a provider |
+| `PUT` | `/api/orgs/{id}/ai/providers/{pid}` | Update a provider |
+| `DELETE` | `/api/orgs/{id}/ai/providers/{pid}` | Delete a provider |
+| `POST` | `/api/orgs/{id}/ai/providers/{pid}/test` | Test connection (hits `/models`) |
 
 ### Kept (Copilot auth is user-level)
 
@@ -100,9 +119,9 @@ type ChatRequest struct {
 
 ### Removed
 
-- `GET /api/copilot/models` -> replaced by `GET /api/ai/models`
-- `POST /api/copilot/chat` -> replaced by `POST /api/ai/chat`
-- `POST /api/orgs/{id}/github-app` and `GET /api/orgs/{id}/github-app` -> replaced by generic provider CRUD
+- `GET /api/copilot/models` -> replaced by `GET /api/orgs/{id}/ai/models`
+- `POST /api/copilot/chat` -> replaced by `POST /api/orgs/{id}/ai/chat`
+- `POST /api/orgs/{id}/github-app` and `GET /api/orgs/{id}/github-app` -> removed (sso_configs stays for GitHub OAuth credentials)
 
 ### Chat request body
 
@@ -131,11 +150,11 @@ const selectedProviderId = ref<string>('')    // uuid or 'copilot'
 const models = ref<AIModel[]>([])
 const selectedModel = ref<string>('')
 
-// Functions
-fetchProviders()     // GET /api/ai/providers
-fetchModels()        // GET /api/ai/models?provider_id=X
-sendMessage()        // POST /api/ai/chat with provider_id (SSE streaming)
-sendChatRequest()    // POST /api/ai/chat non-streaming (tool calling)
+// Functions (all org-scoped, orgId from useOrganization())
+fetchProviders()     // GET /api/orgs/{orgId}/ai/providers
+fetchModels()        // GET /api/orgs/{orgId}/ai/models?provider_id=X
+sendMessage()        // POST /api/orgs/{orgId}/ai/chat with provider_id (SSE streaming)
+sendChatRequest()    // POST /api/orgs/{orgId}/ai/chat non-streaming (tool calling)
 ```
 
 ### `useCopilotAuth.ts` (extracted)
@@ -156,8 +175,17 @@ Copilot-specific auth state: `isConnected`, `hasCopilot`, `githubUsername`, devi
 - **Copilot token expiry**: `fetchCopilotToken()` gets fresh token per request, no change needed.
 - **API key rotation**: admin updates via PUT, takes effect immediately (read per-request, not cached).
 - **Provider deleted mid-session**: next request returns "provider not found", frontend refreshes provider list.
-- **Model discovery fails**: fall back to `models_override` from DB. If empty, return provider with empty model list and warning.
+- **Model discovery fails**: fall back to `models_override` from DB for the model *listing* endpoint only. If `models_override` is also empty, return the provider with an empty model list and a warning. Note: a provider being unreachable for model listing likely means it will also fail for chat — but these are separate error paths. Chat errors are handled independently per the "provider unavailable" case above.
 - **Org providers exist + user has Copilot**: Copilot does NOT appear. Org providers take full precedence.
+
+## Deferred
+
+- **Rate limiting / usage tracking**: When an admin configures an API key for the org, all members share it. Per-user rate limiting and usage tracking are deferred to a future iteration. For now, the assumption is that org admins manage their API key quotas externally.
+- **Anthropic native API**: Anthropic's `/v1/messages` API is not OpenAI-compatible. Supporting it natively would require a separate provider implementation. Deferred — use OpenRouter or any OpenAI-compatible gateway for Anthropic models.
+
+## Route Registration
+
+New endpoints follow the same router registration pattern and `auth.RequireAuth` middleware as existing endpoints. Admin endpoints additionally check `role = 'admin'` in `organization_memberships` (same pattern as the existing `ConfigureGitHubApp` handler).
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
+++ b/docs/superpowers/specs/2026-03-23-multi-provider-ai-design.md
@@ -163,11 +163,33 @@ Copilot-specific auth state: `isConnected`, `hasCopilot`, `githubUsername`, devi
 
 ### Component changes
 
-- **`CmdKModal.vue`** — gate on `providers.length > 0` instead of `isConnected`
-- **`CmdKChatView.vue`** — model selector grouped by provider. Uses `useAIProvider` instead of `useCopilot`
-- **`CopilotConnectionPanel.vue`** — shown only when no org providers configured. Unchanged internally.
-- **`UnifiedSettingsView.vue`** — new "AI Providers" admin section: add/edit/delete providers, test connection, see discovered models. Copilot connection moves under "Personal Fallback" subsection.
+- **`CmdKModal.vue`** — gate on `providers.length > 0` instead of `isConnected`. Empty state when no providers: "Configure an AI provider in Settings, or connect GitHub Copilot." with a link to Settings > AI.
+- **`CmdKChatView.vue`** — model selector uses `<select>` with `<optgroup>` per provider (e.g., `<optgroup label="OpenAI">`, `<optgroup label="Copilot">`). When only one provider exists, no grouping (flat list like today). Uses `useAIProvider` instead of `useCopilot`.
+- **`CopilotConnectionPanel.vue`** — shown only when no org providers configured. Unchanged internally. When shown, prefixed with note: "Your organization has no AI providers configured. Connect your GitHub Copilot as a personal fallback."
+- **`UnifiedSettingsView.vue`** — AI section split into two sub-sections:
+  1. **"AI Providers"** (admin-only): provider list with [+ Add] button. Each row shows: display_name, base_url (truncated), model count badge, enabled/disabled badge (`var(--color-secondary)` / `var(--color-outline)`), overflow menu ([···] → Edit, Test, Delete). Empty state: "No providers configured. Add one to enable AI chat for your team." Form follows existing SSO config form pattern (inline labels, compact layout).
+  2. **"Personal Fallback"** (all users): existing CopilotConnectionPanel, hidden when org providers exist.
 - **`useCopilotTools.ts`** — unchanged. Tools are datasource-specific, passed to whichever provider handles chat. Note: tool calling (function calling) requires provider support. See "Tool Compatibility" below.
+
+### Interaction states
+
+| Feature | Loading | Empty | Error | Success |
+|---|---|---|---|---|
+| Provider list | 2 skeleton rows | "No providers" + Add CTA | "Failed to load" + retry | Provider rows |
+| Add provider form | Save button spinner | Pre-filled base_url hint per type | Inline field validation | Toast "Provider added" |
+| Test connection | "Testing..." spinner on button | — | "Connection failed: [reason]" inline | "Connected, N models found" inline |
+| Delete provider | Confirmation dialog | — | "Failed to delete" toast | Toast "Provider removed" |
+| Model discovery | "Discovering models..." text | "No models found" + override hint | "Discovery failed" note | Model count badge on row |
+| Cmd+K (no provider) | — | "Configure an AI provider in Settings, or connect GitHub Copilot." | — | — |
+
+### Accessibility
+
+- Provider list: `role="list"`, each provider `role="listitem"`
+- Test connection button: `aria-label="Test connection for [provider name]"`
+- Status badges: `aria-label` describing state (e.g., "Enabled", "3 models available")
+- Cmd+K model selector: keyboard navigable via arrow keys, `<optgroup>` is natively accessible
+- All interactive elements: 44px minimum touch target
+- Color contrast: uses existing Kinetic tokens (WCAG AA compliant)
 
 ## Org Switch State Reset
 

--- a/frontend/src/views/HomeView.spec.ts
+++ b/frontend/src/views/HomeView.spec.ts
@@ -29,6 +29,25 @@ vi.mock('../composables/useFavorites', () => ({
   }),
 }))
 
+const mockDatasources = ref<{ id: string; type: string }[]>([])
+
+vi.mock('../composables/useDatasource', () => ({
+  useDatasource: () => ({
+    datasources: mockDatasources,
+    loading: ref(false),
+    error: ref(null),
+    metricsDatasources: ref([]),
+    logsDatasources: ref([]),
+    tracingDatasources: ref([]),
+    vmalertDatasources: ref([]),
+    alertingDatasources: ref([]),
+    fetchDatasources: vi.fn(),
+    addDatasource: vi.fn(),
+    editDatasource: vi.fn(),
+    removeDatasource: vi.fn(),
+  }),
+}))
+
 vi.mock('vue-router', () => ({
   useRoute: () => ({
     path: '/app',
@@ -62,13 +81,10 @@ describe('HomeView', () => {
   let wrapper: VueWrapper
 
   function createWrapper(opts: { hasDataSources?: boolean } = {}) {
-    // By default, the view shows the normal (non-empty) state.
-    // When hasDataSources is false, we set a localStorage flag so the view
-    // renders the empty state instead.
     if (opts.hasDataSources === false) {
-      localStorage.setItem('ace-has-datasources', 'false')
+      mockDatasources.value = []
     } else {
-      localStorage.setItem('ace-has-datasources', 'true')
+      mockDatasources.value = [{ id: 'ds-1', type: 'prometheus' }]
     }
 
     return mount(HomeView, {
@@ -120,6 +136,7 @@ describe('HomeView', () => {
     vi.clearAllMocks()
     mockFavorites.value = []
     mockRecentDashboards.value = []
+    mockDatasources.value = []
     localStorage.clear()
   })
 


### PR DESCRIPTION
## Summary
- HomeView tests were failing (9/15) because `useDatasource` was not mocked — `datasources` was always empty, so the empty state always rendered
- Added `vi.mock` for `useDatasource` with a controllable `mockDatasources` ref
- Updated `createWrapper` to populate the mock instead of using localStorage

## Test plan
- [x] All 15 HomeView tests pass
- [x] Full test suite passes (729/729 tests, 63/63 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)