### PR TITLE
fix: resolve release pipeline helm repo and frontend Docker build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,12 @@ jobs:
           sed -i "s/^version:.*/version: ${version}/" charts/ace/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${version}\"/" charts/ace/Chart.yaml
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add victoriametrics https://victoriametrics.github.io/helm-charts/
+          helm repo update
+
       - name: Build Helm dependencies
         run: helm dependency build charts/ace
 

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreDependencies": ["@vitest/coverage-v8"],
-  "ignore": [],
+  "ignore": ["src/env.d.ts"],
   "rules": {
     "exports": "warn",
     "types": "warn"

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}


### PR DESCRIPTION
## Summary
- Add `helm repo add` step for bitnami and victoriametrics before `helm dependency build` in the release workflow — CI runners don't have repos registered
- Add `frontend/src/env.d.ts` with Vue module type declarations so `vue-tsc` can resolve `.vue` imports in the Docker build environment (`oven/bun:1-alpine`)

Fixes the failures from https://github.com/aceobservability/ace/actions/runs/24027299895

## Test plan
- [x] Docker build verified locally: `docker build -f frontend/Dockerfile --target builder .`
- [x] Local `bun run build` still passes
- [ ] Re-run release pipeline after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)