### PR TITLE
fix: add OCI source label to Dockerfiles for GHCR access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,12 @@ jobs:
           sed -i "s/^version:.*/version: ${version}/" charts/ace/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${version}\"/" charts/ace/Chart.yaml
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add victoriametrics https://victoriametrics.github.io/helm-charts/
+          helm repo update
+
       - name: Build Helm dependencies
         run: helm dependency build charts/ace
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /out/d
 
 FROM gcr.io/distroless/static-debian12:nonroot
 
+LABEL org.opencontainers.image.source=https://github.com/aceobservability/ace
+
 COPY --from=builder /out/dash-api /usr/local/bin/dash-api
 
 EXPOSE 8080

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,8 @@ RUN bun run build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 
+LABEL org.opencontainers.image.source=https://github.com/aceobservability/ace
+
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreDependencies": ["@vitest/coverage-v8"],
-  "ignore": [],
+  "ignore": ["src/env.d.ts"],
   "rules": {
     "exports": "warn",
     "types": "warn"

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}


### PR DESCRIPTION
## Summary
- Adds `org.opencontainers.image.source` label to both `backend/Dockerfile` and `frontend/Dockerfile`
- This links GHCR packages to the repository, allowing `GITHUB_TOKEN` to push images (fixes 403 Forbidden) and enabling public access for ArtifactHub (fixes DENIED on pull)

## Test plan
- [ ] Trigger a release and verify Docker images push successfully to GHCR
- [ ] Verify ArtifactHub can pull the Helm chart after setting packages to public

🤖 Generated with [Claude Code](https://claude.com/claude-code)