### PR TITLE
ci: auto-generate Helm docs and sync Chart.yaml version via release-please

### DIFF
--- a/.github/actions/setup-helm-docs/action.yml
+++ b/.github/actions/setup-helm-docs/action.yml
@@ -1,0 +1,24 @@
+name: Setup helm-docs
+description: Install helm-docs with checksum verification
+
+inputs:
+  version:
+    description: helm-docs version to install
+    required: false
+    default: "1.14.2"
+
+runs:
+  using: composite
+  steps:
+    - name: Install helm-docs
+      shell: bash
+      env:
+        HELM_DOCS_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+          -o helm-docs.tar.gz
+        curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/checksums.txt" \
+          | grep "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" | sha256sum -c -
+        tar xzf helm-docs.tar.gz helm-docs
+        chmod +x helm-docs

--- a/.github/actions/setup-helm-docs/action.yml
+++ b/.github/actions/setup-helm-docs/action.yml
@@ -16,9 +16,10 @@ runs:
         HELM_DOCS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
-          -o helm-docs.tar.gz
+        archive="helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+        curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/${archive}" \
+          -o "$archive"
         curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/checksums.txt" \
-          | grep "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" | sha256sum -c -
-        tar xzf helm-docs.tar.gz helm-docs
+          | grep "$archive" | sha256sum -c -
+        tar xzf "$archive" helm-docs
         chmod +x helm-docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,11 +59,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install helm-docs
-        run: |
-          HELM_DOCS_VERSION="1.14.2"
-          curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
-            | tar xz helm-docs
-          chmod +x helm-docs
+        uses: ./.github/actions/setup-helm-docs
 
       - name: Generate and diff
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,3 +50,25 @@ jobs:
       - name: Run frontend dead-code lint
         run: bun run lint:dead-code
         working-directory: frontend
+
+  helm-docs:
+    name: Helm Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install helm-docs
+        run: |
+          HELM_DOCS_VERSION="1.14.2"
+          curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar xz helm-docs
+          chmod +x helm-docs
+
+      - name: Generate and diff
+        run: |
+          ./helm-docs --chart-search-root charts --log-level warn
+          if ! git diff --exit-code charts/ace/README.md; then
+            echo "::error::charts/ace/README.md is out of date. Run 'helm-docs --chart-search-root charts' and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -72,6 +72,10 @@ jobs:
           fi
           printf "branch=%s\n" "$branch" >> "$GITHUB_OUTPUT"
 
+      - name: Install helm-docs
+        if: steps.pr-info.outputs.branch != ''
+        uses: ./.github/actions/setup-helm-docs
+
       - name: Generate Helm docs
         if: steps.pr-info.outputs.branch != ''
         run: |
@@ -79,13 +83,6 @@ jobs:
           git fetch origin "${{ steps.pr-info.outputs.branch }}"
           git checkout "${{ steps.pr-info.outputs.branch }}"
 
-          # Install helm-docs
-          HELM_DOCS_VERSION="1.14.2"
-          curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
-            | tar xz helm-docs
-          chmod +x helm-docs
-
-          # Generate docs
           ./helm-docs --chart-search-root charts --log-level warn
 
           # Commit if changed

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Run release-please (bootstrap v0.1.0)
         if: steps.bootstrap.outputs.has_tags == 'false'
+        id: release-bootstrap
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -52,8 +53,46 @@ jobs:
 
       - name: Run release-please
         if: steps.bootstrap.outputs.has_tags == 'true'
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Set PR branch
+        id: pr-info
+        env:
+          RP_PR: ${{ steps.release.outputs.pr || steps.release-bootstrap.outputs.pr || '' }}
+        run: |
+          if [ -n "$RP_PR" ]; then
+            branch="$(echo "$RP_PR" | jq -r '.headBranchName // empty')"
+          else
+            branch=""
+          fi
+          printf "branch=%s\n" "$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Helm docs
+        if: steps.pr-info.outputs.branch != ''
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ steps.pr-info.outputs.branch }}"
+          git checkout "${{ steps.pr-info.outputs.branch }}"
+
+          # Install helm-docs
+          HELM_DOCS_VERSION="1.14.2"
+          curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar xz helm-docs
+          chmod +x helm-docs
+
+          # Generate docs
+          ./helm-docs --chart-search-root charts --log-level warn
+
+          # Commit if changed
+          if ! git diff --quiet charts/ace/README.md; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add charts/ace/README.md
+            git commit -m "docs: regenerate Helm chart README"
+            git push origin "${{ steps.pr-info.outputs.branch }}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,12 @@ jobs:
           sed -i "s/^version:.*/version: ${version}/" charts/ace/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${version}\"/" charts/ace/Chart.yaml
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add victoriametrics https://victoriametrics.github.io/helm-charts/
+          helm repo update
+
       - name: Build Helm dependencies
         run: helm dependency build charts/ace
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,13 +351,6 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
 
-      - name: Update Chart.yaml version
-        run: |
-          set -euo pipefail
-          version="${RELEASE_TAG#v}"
-          sed -i "s/^version:.*/version: ${version}/" charts/ace/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${version}\"/" charts/ace/Chart.yaml
-
       - name: Add Helm repositories
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,6 +5,18 @@
     ".": {
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "charts/ace/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/ace/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ],
       "changelog-sections": [
         {
           "type": "feat",

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /out/d
 
 FROM gcr.io/distroless/static-debian12:nonroot
 
+LABEL org.opencontainers.image.source=https://github.com/aceobservability/ace
+
 COPY --from=builder /out/dash-api /usr/local/bin/dash-api
 
 EXPOSE 8080

--- a/charts/ace/Chart.yaml
+++ b/charts/ace/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: ace
+name: ace-observability-platform
 description: Ace Observability Platform — unified metrics, logs, and traces powered by VictoriaMetrics
 type: application
 version: 0.1.0

--- a/charts/ace/Chart.yaml
+++ b/charts/ace/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: ace-observability-platform
+name: ace
 description: Ace Observability Platform — unified metrics, logs, and traces powered by VictoriaMetrics
 type: application
 version: 0.1.0
@@ -18,6 +18,7 @@ maintainers:
   - name: Jan Hoon
     url: https://github.com/janhoon
 annotations:
+  artifacthub.io/displayName: Ace Observability Platform
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Source

--- a/charts/ace/README.md
+++ b/charts/ace/README.md
@@ -1,4 +1,4 @@
-# Ace Observability Platform — Helm Chart
+# ace
 
 Production-ready Helm chart for deploying the **Ace Observability Platform** to Kubernetes, including the full VictoriaMetrics stack for metrics, logs, and traces.
 
@@ -95,120 +95,144 @@ helm install ace charts/ace --dry-run -f charts/ace/values-dev.yaml -n ace
 | **Traces** | `victoria-metrics-single` (as vtraces) | VictoriaTraces with OTLP ingestion |
 | **Log Shipper** | Vector (DaemonSet) | Ships container logs to VictoriaLogs |
 
-## Values Reference
+## Requirements
 
-### Global
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | postgresql | 16.4.1 |
+| https://victoriametrics.github.io/helm-charts/ | vlogs(victoria-logs-single) | 0.11.28 |
+| https://victoriametrics.github.io/helm-charts/ | vmetrics(victoria-metrics-k8s-stack) | 0.45.0 |
+| https://victoriametrics.github.io/helm-charts/ | vtraces(victoria-metrics-single) | 0.18.0 |
 
-| Key | Description | Default |
-|-----|-------------|---------|
-| `nameOverride` | Override chart name | `""` |
-| `fullnameOverride` | Override full release name | `""` |
-| `global.imagePullSecrets` | Image pull secrets | `[]` |
+## Values
 
-### Service Account & RBAC
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `serviceAccount.create` | Create ServiceAccount | `true` |
-| `serviceAccount.annotations` | SA annotations (e.g., IRSA) | `{}` |
-| `rbac.create` | Create ClusterRole for metrics scraping | `true` |
-
-### Backend
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `backend.replicaCount` | Replicas (when HPA disabled) | `2` |
-| `backend.image.repository` | Backend image | `ghcr.io/aceobservability/ace-backend` |
-| `backend.image.tag` | Image tag | `Chart.appVersion` |
-| `backend.autoscaling.enabled` | Enable HPA | `true` |
-| `backend.autoscaling.minReplicas` | HPA min | `2` |
-| `backend.autoscaling.maxReplicas` | HPA max | `10` |
-| `backend.pdb.enabled` | Enable PodDisruptionBudget | `true` |
-| `backend.pdb.minAvailable` | Minimum available pods | `1` |
-| `backend.jwt.secret` | JWT HMAC secret (stored in Secret) | `""` |
-| `backend.jwt.privateKey` | JWT asymmetric private key PEM | `""` |
-| `backend.jwt.publicKey` | JWT asymmetric public key PEM | `""` |
-| `backend.existingSecret` | Use an existing K8s Secret | `""` |
-| `backend.valkey.url` | Valkey/Redis URL for refresh tokens | `""` |
-| `backend.otlp.enabled` | Enable OTLP trace export | `true` |
-| `backend.otlp.endpoint` | OTLP endpoint (auto-detected) | `""` |
-| `backend.prometheus.url` | Metrics query URL (auto-detected) | `""` |
-| `backend.victoriaLogs.url` | Logs query URL (auto-detected) | `""` |
-| `backend.baseURL` | Backend base URL (for SSO callbacks) | `""` |
-| `backend.frontendURL` | Frontend URL (for SSO redirects) | `""` |
-| `backend.posthog.enabled` | Enable PostHog analytics | `false` |
-| `backend.resources` | Resource requests/limits | See values.yaml |
-
-### Frontend
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `frontend.replicaCount` | Replicas (when HPA disabled) | `2` |
-| `frontend.image.repository` | Frontend image | `ghcr.io/aceobservability/ace-frontend` |
-| `frontend.autoscaling.enabled` | Enable HPA | `true` |
-| `frontend.nginxConfigOverride` | Use ConfigMap nginx.conf | `false` |
-| `frontend.resources` | Resource requests/limits | See values.yaml |
-
-### Ingress
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `ingress.enabled` | Enable Ingress | `false` |
-| `ingress.className` | Ingress class | `nginx` |
-| `ingress.annotations` | Annotations (cert-manager, etc.) | See values.yaml |
-| `ingress.hosts` | Host rules | `[{host: ace.example.com}]` |
-| `ingress.tls` | TLS configuration | See values.yaml |
-
-### PostgreSQL
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `postgresql.enabled` | Deploy PostgreSQL subchart | `true` |
-| `postgresql.auth.username` | DB username | `ace` |
-| `postgresql.auth.password` | DB password (**set in production!**) | `""` |
-| `postgresql.auth.database` | DB name | `ace` |
-| `postgresql.primary.persistence.size` | PVC size | `10Gi` |
-| `externalDatabase.url` | External DB connection string | `""` |
-
-### VictoriaMetrics K8s Stack
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `victoria-metrics-k8s-stack.enabled` | Deploy the full metrics stack | `true` |
-| `vmsingle.spec.retentionPeriod` | Metrics retention | `90d` |
-| `vmsingle.spec.storage.resources.requests.storage` | Metrics PVC size | `50Gi` |
-| `vmagent.enabled` | Deploy VMAgent for scraping | `true` |
-| `vmalert.enabled` | Deploy VMAlert for rule evaluation | `true` |
-| `alertmanager.enabled` | Deploy Alertmanager | `true` |
-
-### VictoriaLogs
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `victoria-logs-single.enabled` | Deploy VictoriaLogs | `true` |
-| `server.persistentVolume.size` | Logs PVC size | `50Gi` |
-| `server.extraArgs.retentionPeriod` | Log retention | `30d` |
-
-### VictoriaTraces
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `victoriatraces.enabled` | Deploy VictoriaTraces | `true` |
-| `vtraces.server.persistentVolume.size` | Traces PVC size | `30Gi` |
-
-### Vector (Log Shipper)
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `vector.enabled` | Deploy Vector DaemonSet | `true` |
-| `vector.sink.endpoint` | Custom sink URL (when vlogs disabled) | See values.yaml |
-
-### Network Policy
-
-| Key | Description | Default |
-|-----|-------------|---------|
-| `networkPolicy.enabled` | Enable NetworkPolicy resources | `false` |
-| `networkPolicy.ingressControllerLabels` | Labels for ingress controller pods | `{app.kubernetes.io/name: ingress-nginx}` |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| backend.affinity | object | `{}` |  |
+| backend.autoscaling | object | `{"enabled":true,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":70,"targetMemoryUtilizationPercentage":80}` | HPA configuration |
+| backend.baseURL | string | `""` | Backend base URL (for SSO callbacks) |
+| backend.existingSecret | string | `""` | Use an existing Secret instead of the chart-managed one. Must contain keys: database-password, jwt-secret, jwt-private-key, jwt-public-key |
+| backend.extraEnv | object | `{}` | Extra environment variables as key-value pairs |
+| backend.frontendURL | string | `""` | Frontend URL (for SSO redirects) |
+| backend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| backend.image.repository | string | `"ghcr.io/aceobservability/ace-backend"` |  |
+| backend.image.tag | string | `""` | Overrides the image tag (default: Chart.appVersion) |
+| backend.jwt | object | `{"privateKey":"","publicKey":"","secret":""}` | JWT configuration (stored in Secret) |
+| backend.jwt.privateKey | string | `""` | RSA/ECDSA private key PEM (optional, for asymmetric JWT) |
+| backend.jwt.publicKey | string | `""` | RSA/ECDSA public key PEM (optional) |
+| backend.jwt.secret | string | `""` | HMAC secret for JWT signing (set one of secret OR privateKey/publicKey) |
+| backend.nodeSelector | object | `{}` |  |
+| backend.otlp | object | `{"enabled":true,"endpoint":""}` | OpenTelemetry tracing configuration |
+| backend.otlp.enabled | bool | `true` | Enable OTLP trace export from the backend |
+| backend.otlp.endpoint | string | `""` | OTLP endpoint (auto-detected from VictoriaTraces subchart if empty) |
+| backend.pdb | object | `{"enabled":true,"minAvailable":1}` | PodDisruptionBudget |
+| backend.podAnnotations | object | `{}` | Pod annotations (e.g., Prometheus scrape config) |
+| backend.podLabels | object | `{}` | Extra pod labels |
+| backend.podSecurityContext.fsGroup | int | `65534` |  |
+| backend.podSecurityContext.runAsNonRoot | bool | `true` |  |
+| backend.podSecurityContext.runAsUser | int | `65534` |  |
+| backend.posthog | object | `{"apiKey":"","enabled":false,"host":""}` | PostHog analytics (optional) |
+| backend.prometheus | object | `{"url":""}` | Prometheus/VictoriaMetrics query endpoint |
+| backend.prometheus.url | string | `""` | Override the metrics query URL (auto-detected from k8s-stack if empty) |
+| backend.replicaCount | int | `2` | Number of replicas (ignored when autoscaling is enabled) |
+| backend.resources.limits.cpu | string | `"500m"` |  |
+| backend.resources.limits.memory | string | `"512Mi"` |  |
+| backend.resources.requests.cpu | string | `"100m"` |  |
+| backend.resources.requests.memory | string | `"128Mi"` |  |
+| backend.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| backend.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| backend.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| backend.service.port | int | `8080` |  |
+| backend.service.type | string | `"ClusterIP"` |  |
+| backend.tolerations | list | `[]` |  |
+| backend.valkey | object | `{"url":""}` | Valkey (Redis-compatible) for refresh tokens |
+| backend.victoriaLogs | object | `{"url":""}` | VictoriaLogs query endpoint |
+| backend.victoriaLogs.url | string | `""` | Override the logs query URL (auto-detected from vlogs subchart if empty) |
+| externalDatabase.password | string | `nil` | Password (stored in Secret; referenced by DATABASE_URL) |
+| externalDatabase.url | string | `""` | Full connection string (overrides all other fields) |
+| frontend.affinity | object | `{}` |  |
+| frontend.autoscaling.enabled | bool | `true` |  |
+| frontend.autoscaling.maxReplicas | int | `6` |  |
+| frontend.autoscaling.minReplicas | int | `2` |  |
+| frontend.autoscaling.targetCPUUtilizationPercentage | int | `70` |  |
+| frontend.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| frontend.image.repository | string | `"ghcr.io/aceobservability/ace-frontend"` |  |
+| frontend.image.tag | string | `""` |  |
+| frontend.nginxConfigOverride | bool | `false` | Override the default nginx.conf from the container image |
+| frontend.nodeSelector | object | `{}` |  |
+| frontend.podAnnotations | object | `{}` |  |
+| frontend.podLabels | object | `{}` |  |
+| frontend.podSecurityContext.fsGroup | int | `101` |  |
+| frontend.podSecurityContext.runAsNonRoot | bool | `true` |  |
+| frontend.podSecurityContext.runAsUser | int | `101` |  |
+| frontend.replicaCount | int | `2` |  |
+| frontend.resources.limits.cpu | string | `"200m"` |  |
+| frontend.resources.limits.memory | string | `"128Mi"` |  |
+| frontend.resources.requests.cpu | string | `"50m"` |  |
+| frontend.resources.requests.memory | string | `"64Mi"` |  |
+| frontend.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| frontend.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| frontend.securityContext.readOnlyRootFilesystem | bool | `false` |  |
+| frontend.service.port | int | `80` |  |
+| frontend.service.type | string | `"ClusterIP"` |  |
+| frontend.tolerations | list | `[]` |  |
+| fullnameOverride | string | `""` | Override the full release name |
+| global.imagePullSecrets | list | `[]` | Image pull secrets for private registries |
+| ingress.annotations."cert-manager.io/cluster-issuer" | string | `"letsencrypt-prod"` |  |
+| ingress.className | string | `"nginx"` | Ingress class name (e.g., nginx, traefik) |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"ace.example.com"` |  |
+| ingress.tls[0].hosts[0] | string | `"ace.example.com"` |  |
+| ingress.tls[0].secretName | string | `"ace-tls"` |  |
+| nameOverride | string | `""` | Override the chart name |
+| networkPolicy.enabled | bool | `false` | Enable NetworkPolicy resources |
+| networkPolicy.ingressControllerLabels | object | `{"app.kubernetes.io/name":"ingress-nginx"}` | Labels to match the ingress controller pods (for ingress allowlisting) |
+| postgresql.auth.database | string | `"ace"` |  |
+| postgresql.auth.password | string | `nil` |  |
+| postgresql.auth.username | string | `"ace"` |  |
+| postgresql.enabled | bool | `true` |  |
+| postgresql.primary.persistence.enabled | bool | `true` |  |
+| postgresql.primary.persistence.size | string | `"10Gi"` |  |
+| postgresql.primary.persistence.storageClass | string | `""` |  |
+| postgresql.primary.resources.limits.cpu | string | `"1"` |  |
+| postgresql.primary.resources.limits.memory | string | `"1Gi"` |  |
+| postgresql.primary.resources.requests.cpu | string | `"100m"` |  |
+| postgresql.primary.resources.requests.memory | string | `"256Mi"` |  |
+| rbac.create | bool | `true` | Create ClusterRole/ClusterRoleBinding for metrics scraping |
+| serviceAccount.annotations | object | `{}` | Annotations (e.g., for IRSA on EKS) |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Disable auto-mounting tokens unless needed |
+| serviceAccount.create | bool | `true` | Create a dedicated ServiceAccount |
+| serviceAccount.name | string | `""` | Override the ServiceAccount name |
+| vector.enabled | bool | `true` | Deploy Vector as a DaemonSet to ship logs to VictoriaLogs |
+| vector.image.pullPolicy | string | `"IfNotPresent"` |  |
+| vector.image.repository | string | `"timberio/vector"` |  |
+| vector.image.tag | string | `"0.43.1-alpine"` |  |
+| vector.resources.limits.cpu | string | `"200m"` |  |
+| vector.resources.limits.memory | string | `"256Mi"` |  |
+| vector.resources.requests.cpu | string | `"50m"` |  |
+| vector.resources.requests.memory | string | `"64Mi"` |  |
+| vector.sink | object | `{"endpoint":"http://victoria-logs:9428/insert/elasticsearch/"}` | Sink endpoint (only used when victoria-logs-single is disabled) |
+| victoria-logs-single.enabled | bool | `true` |  |
+| victoria-logs-single.server.extraArgs | object | `{"retentionPeriod":"30d"}` | Log retention period |
+| victoria-logs-single.server.persistentVolume.enabled | bool | `true` |  |
+| victoria-logs-single.server.persistentVolume.size | string | `"50Gi"` |  |
+| victoria-logs-single.server.persistentVolume.storageClass | string | `""` |  |
+| victoria-logs-single.server.resources.limits.cpu | string | `"2"` |  |
+| victoria-logs-single.server.resources.limits.memory | string | `"4Gi"` |  |
+| victoria-logs-single.server.resources.requests.cpu | string | `"200m"` |  |
+| victoria-logs-single.server.resources.requests.memory | string | `"512Mi"` |  |
+| victoria-metrics-k8s-stack.alertmanager | object | `{"enabled":true,"spec":{"resources":{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}}}` | Alertmanager for alert routing and notifications |
+| victoria-metrics-k8s-stack.enabled | bool | `true` |  |
+| victoria-metrics-k8s-stack.grafana | object | `{"enabled":false}` | Disable Grafana (Ace is the UI) |
+| victoria-metrics-k8s-stack.kube-state-metrics | object | `{"enabled":true}` | kube-state-metrics for cluster state metrics |
+| victoria-metrics-k8s-stack.prometheus | object | `{"enabled":false}` | Disable default Prometheus (we use VMSingle) |
+| victoria-metrics-k8s-stack.prometheus-node-exporter | object | `{"enabled":true}` | node-exporter for node-level metrics |
+| victoria-metrics-k8s-stack.vmagent | object | `{"enabled":true,"spec":{"resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"scrapeInterval":"30s"}}` | VMAgent for scraping Kubernetes metrics |
+| victoria-metrics-k8s-stack.vmalert | object | `{"enabled":true,"spec":{"resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"128Mi"}}}}` | VMAlert for alerting rules evaluation |
+| victoria-metrics-k8s-stack.vmsingle | object | `{"enabled":true,"spec":{"resources":{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"200m","memory":"512Mi"}},"retentionPeriod":"90d","storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"50Gi"}},"storageClassName":""}}}` | VMSingle for metrics storage |
+| victoriatraces.enabled | bool | `true` |  |
+| vtraces | object | `{"server":{"extraArgs":{"opentelemetry.enabled":"true"},"extraContainerPorts":[{"containerPort":4317,"name":"otlp-grpc","protocol":"TCP"},{"containerPort":4318,"name":"otlp-http","protocol":"TCP"}],"image":{"repository":"victoriametrics/victoria-traces","tag":"v1.8.0-victoriametrics"},"persistentVolume":{"enabled":true,"size":"30Gi","storageClass":""},"resources":{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}}}` | victoria-metrics-single subchart config (alias: vtraces) |
 
 ## Toggling Components
 

--- a/charts/ace/README.md
+++ b/charts/ace/README.md
@@ -1,4 +1,4 @@
-# ace
+# ace-observability-platform
 
 Production-ready Helm chart for deploying the **Ace Observability Platform** to Kubernetes, including the full VictoriaMetrics stack for metrics, logs, and traces.
 

--- a/charts/ace/README.md
+++ b/charts/ace/README.md
@@ -1,4 +1,4 @@
-# ace-observability-platform
+# ace
 
 Production-ready Helm chart for deploying the **Ace Observability Platform** to Kubernetes, including the full VictoriaMetrics stack for metrics, logs, and traces.
 

--- a/charts/ace/README.md.gotmpl
+++ b/charts/ace/README.md.gotmpl
@@ -1,0 +1,200 @@
+{{ template "chart.header" . }}
+
+Production-ready Helm chart for deploying the **Ace Observability Platform** to Kubernetes, including the full VictoriaMetrics stack for metrics, logs, and traces.
+
+## Architecture
+
+```
+┌──────────────┐    ┌──────────────┐
+│   Ingress    │───▶│   Frontend   │  (Vue 3 SPA / nginx)
+│  (optional)  │    └──────────────┘
+│              │    ┌──────────────┐    ┌────────────┐
+│              │───▶│   Backend    │───▶│ PostgreSQL │
+│              │    │   (Go API)   │    └────────────┘
+└──────────────┘    └──────┬───────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+     ┌────────────┐ ┌───────────┐ ┌───────────────┐
+     │VictoriaMetrics│ │VictoriaLogs│ │VictoriaTraces │
+     │  (metrics)    │ │  (logs)    │ │  (traces)     │
+     └────────────┘ └───────────┘ └───────────────┘
+              ▲            ▲
+              │            │
+     ┌────────────┐ ┌───────────┐
+     │  VMAgent   │ │  Vector   │
+     │ (scraper)  │ │(log ship) │
+     └────────────┘ └───────────┘
+```
+
+## Prerequisites
+
+- Kubernetes 1.28+
+- Helm 3.14+
+- PV provisioner (for persistent storage)
+- (Optional) cert-manager for TLS
+- (Optional) ingress controller (nginx, traefik, etc.)
+
+## Quick Start
+
+```bash
+# Add the VictoriaMetrics Helm repo (required for subchart deps)
+helm repo add vm https://victoriametrics.github.io/helm-charts/
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+
+# Download subchart dependencies
+helm dependency build charts/ace
+
+# Install with dev settings
+helm install ace charts/ace \
+  -f charts/ace/values-dev.yaml \
+  --set postgresql.auth.password=MyDevPassword123 \
+  --set backend.jwt.secret=my-dev-jwt-secret \
+  -n ace --create-namespace
+
+# Install with production settings
+helm install ace charts/ace \
+  -f charts/ace/values-prod.yaml \
+  --set postgresql.auth.password=STRONG_RANDOM_PASSWORD \
+  --set backend.jwt.secret=STRONG_RANDOM_SECRET \
+  --set ingress.hosts[0].host=ace.yourdomain.com \
+  --set ingress.tls[0].hosts[0]=ace.yourdomain.com \
+  -n ace --create-namespace
+```
+
+## Validation
+
+```bash
+# Lint the chart
+helm lint charts/ace
+
+# Render templates without installing
+helm template ace charts/ace -f charts/ace/values-dev.yaml
+
+# Dry-run install
+helm install ace charts/ace --dry-run -f charts/ace/values-dev.yaml -n ace
+```
+
+## Components
+
+### Ace Application
+
+| Component | Description | Port |
+|-----------|-------------|------|
+| **Backend** | Go API server — auth, dashboards, datasource proxy, alerting | 8080 |
+| **Frontend** | Vue 3 SPA served by nginx | 8080 |
+| **PostgreSQL** | Bitnami subchart (togglable for external DB) | 5432 |
+
+### VictoriaMetrics Stack (all independently togglable)
+
+| Component | Chart | Description |
+|-----------|-------|-------------|
+| **Metrics** | `victoria-metrics-k8s-stack` | VMSingle + VMAgent + VMAlert + Alertmanager |
+| **Logs** | `victoria-logs-single` | High-performance log storage |
+| **Traces** | `victoria-metrics-single` (as vtraces) | VictoriaTraces with OTLP ingestion |
+| **Log Shipper** | Vector (DaemonSet) | Ships container logs to VictoriaLogs |
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+## Toggling Components
+
+Each major component is independently togglable:
+
+```yaml
+# Disable metrics stack
+victoria-metrics-k8s-stack:
+  enabled: false
+
+# Disable logs
+victoria-logs-single:
+  enabled: false
+vector:
+  enabled: false  # No point shipping logs without a log store
+
+# Disable traces
+victoriatraces:
+  enabled: false
+
+# Disable alerting (within the k8s-stack)
+victoria-metrics-k8s-stack:
+  vmalert:
+    enabled: false
+  alertmanager:
+    enabled: false
+
+# Use external PostgreSQL
+postgresql:
+  enabled: false
+externalDatabase:
+  url: "postgres://user:pass@external-db:5432/ace?sslmode=require"
+```
+
+## OTLP Trace Ingestion
+
+VictoriaTraces exposes OTLP endpoints for trace ingestion:
+
+| Protocol | Port | Endpoint |
+|----------|------|----------|
+| gRPC | 4317 | `<release>-vtraces-victoria-metrics-single-server:4317` |
+| HTTP | 4318 | `<release>-vtraces-victoria-metrics-single-server:4318/v1/traces` |
+
+Configure your applications to send traces to these endpoints:
+
+```yaml
+# OpenTelemetry SDK configuration
+env:
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://ace-vtraces-victoria-metrics-single-server:4318"
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: "http/protobuf"
+```
+
+## Datasource Configuration
+
+When the VictoriaMetrics stack is deployed alongside Ace, the backend is automatically configured with the correct datasource URLs:
+
+| Datasource | Auto-configured URL |
+|------------|-------------------|
+| Metrics (VictoriaMetrics) | `http://<release>-vmetrics-...-vmsingle:8429` |
+| Logs (VictoriaLogs) | `http://<release>-vlogs-...-server:9428` |
+| Traces (VictoriaTraces) | `http://<release>-vtraces-...-server:4318` |
+
+These can be overridden via `backend.prometheus.url`, `backend.victoriaLogs.url`, and `backend.otlp.endpoint`.
+
+## Environment Value Files
+
+| File | Purpose |
+|------|---------|
+| `values.yaml` | Production defaults (sane baselines) |
+| `values-dev.yaml` | Development: 1 replica, small storage, 3-7d retention |
+| `values-prod.yaml` | Production: HA replicas, large storage, 90-180d retention, TLS |
+
+## Security Notes
+
+- All sensitive values (DB password, JWT keys, API keys) are stored in Kubernetes Secrets
+- Use `backend.existingSecret` to reference a pre-created Secret (e.g., from Vault or Sealed Secrets)
+- Pod security contexts enforce non-root execution and drop all capabilities
+- NetworkPolicy resources are available (enable with `networkPolicy.enabled: true`)
+- RBAC is scoped to the minimum required permissions for metrics scraping
+
+## Upgrading
+
+```bash
+# Update subchart dependencies
+helm dependency update charts/ace
+
+# Upgrade the release
+helm upgrade ace charts/ace -f charts/ace/values-prod.yaml -n ace
+```
+
+## Uninstalling
+
+```bash
+helm uninstall ace -n ace
+
+# PVCs are retained by default — delete manually if needed
+kubectl delete pvc -l app.kubernetes.io/instance=ace -n ace
+```

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,8 @@ RUN bun run build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 
+LABEL org.opencontainers.image.source=https://github.com/aceobservability/ace
+
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreDependencies": ["@vitest/coverage-v8"],
-  "ignore": [],
+  "ignore": ["src/env.d.ts"],
   "rules": {
     "exports": "warn",
     "types": "warn"

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}


### PR DESCRIPTION
## Summary
- Set up **helm-docs** to auto-generate `charts/ace/README.md` from a `.gotmpl` template + `values.yaml` comments (`# --` annotations)
- Configure **release-please** `extra-files` to bump `version` and `appVersion` in `charts/ace/Chart.yaml` on each release
- Add a step to the **release-pr workflow** that regenerates helm-docs and pushes the updated README to the release PR branch
- Add a **helm-docs lint job** to the PR CI that fails if the README is stale
- Remove the now-redundant `sed`-based Chart.yaml version patching from the release workflow

## Test plan
- [ ] Verify helm-docs lint job passes on this PR
- [ ] Merge a `feat:` or `fix:` commit to main and confirm release-please PR updates Chart.yaml version/appVersion
- [ ] Confirm the release PR also contains the regenerated README with updated version
- [ ] Verify the release workflow still packages and pushes the Helm chart correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)