### PR TITLE
ci: push ArtifactHub metadata for verified publisher badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,14 +348,18 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
-      - name: Log in to GHCR
+      - name: Log in to GHCR (Helm)
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
 
-      - name: Add Helm repositories
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add victoriametrics https://victoriametrics.github.io/helm-charts/
-          helm repo update
+      - name: Log in to GHCR (ORAS)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install ORAS
+        uses: oras-project/setup-oras@v1
 
       - name: Add Helm repositories
         run: |
@@ -374,6 +378,13 @@ jobs:
           set -euo pipefail
           chart_pkg=$(ls .helm-pkg/*.tgz)
           helm push "$chart_pkg" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER,,}"
+
+      - name: Push ArtifactHub repository metadata
+        run: |
+          set -euo pipefail
+          oras push "ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/ace:artifacthub.io" \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            charts/ace/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 
   checksums:
     name: Create Artifact Checksums


### PR DESCRIPTION
## Summary
- Pushes `artifacthub-repo.yml` as a separate OCI artifact (tagged `artifacthub.io`) using ORAS after the Helm chart push
- Adds ORAS CLI setup and GHCR login for ORAS in the release workflow
- Removes a duplicate "Add Helm repositories" step
- Required for OCI-based Helm repos to get the ArtifactHub verified publisher badge — having the file inside the chart `.tgz` alone is not sufficient

## Test plan
- [ ] Trigger a release and verify the `oras push` step succeeds
- [ ] Check ArtifactHub after the next processing cycle for the verified publisher badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)