### PR TITLE
fix: rename legacy 'dash' and 'janhoon' references to 'ace'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,11 +158,11 @@ jobs:
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
-          base="dash-backend_${version}_${GOOS}_${GOARCH}"
+          base="ace-backend_${version}_${GOOS}_${GOARCH}"
           staging="dist/${base}"
 
           mkdir -p "$staging"
-          CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -trimpath -o "$staging/dash-api${EXT}" ./cmd/api
+          CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -trimpath -o "$staging/ace-api${EXT}" ./cmd/api
 
           if [ "$ARCHIVE" = "zip" ]; then
             (cd dist && zip -r "${base}.zip" "${base}")
@@ -212,7 +212,7 @@ jobs:
           set -euo pipefail
           version="${RELEASE_TAG#v}"
           mkdir -p dist-release
-          tar -czf "dist-release/dash-frontend_${version}.tar.gz" -C frontend dist
+          tar -czf "dist-release/ace-frontend_${version}.tar.gz" -C frontend dist
 
       - name: Upload frontend package
         uses: actions/upload-artifact@v7
@@ -256,7 +256,7 @@ jobs:
           major="${version%%.*}"
           remainder="${version#*.}"
           minor="${remainder%%.*}"
-          repo="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/dash-backend"
+          repo="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/ace-backend"
 
           {
             printf "image_repo=%s\n" "$repo"
@@ -282,8 +282,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.vars.outputs.tags }}
           labels: |
-            org.opencontainers.image.title=Dash Backend
-            org.opencontainers.image.description=Dash backend API service
+            org.opencontainers.image.title=Ace Backend
+            org.opencontainers.image.description=Ace backend API service
             org.opencontainers.image.version=${{ env.RELEASE_TAG }}
             org.opencontainers.image.revision=${{ github.sha }}
 
@@ -352,7 +352,7 @@ jobs:
           major="${version%%.*}"
           remainder="${version#*.}"
           minor="${remainder%%.*}"
-          repo="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/dash-frontend"
+          repo="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/ace-frontend"
 
           {
             printf "image_repo=%s\n" "$repo"
@@ -378,8 +378,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.vars.outputs.tags }}
           labels: |
-            org.opencontainers.image.title=Dash Frontend
-            org.opencontainers.image.description=Dash frontend SPA
+            org.opencontainers.image.title=Ace Frontend
+            org.opencontainers.image.description=Ace frontend SPA
             org.opencontainers.image.version=${{ env.RELEASE_TAG }}
             org.opencontainers.image.revision=${{ github.sha }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,77 +536,77 @@
 * unblock dependabot security workflow ([045990f](https://github.com/aceobservability/ace/commit/045990fd11f93107c82097f1a2f1039a47a3da33))
 * unblock dependabot security workflow ([ae49aa4](https://github.com/aceobservability/ace/commit/ae49aa47cea6925a7f140e6b65372c71771f2382))
 
-## [0.3.0](https://github.com/janhoon/ace/compare/v0.2.0...v0.3.0) (2026-02-20)
+## [0.3.0](https://github.com/aceobservability/ace/compare/v0.2.0...v0.3.0) (2026-02-20)
 
 
 ### Features
 
-* 265 add ClickHouse backend datasource core ([2b3cb60](https://github.com/janhoon/ace/commit/2b3cb604ba57f8d10452746e860e24c67e4c6ece))
-* 266 - agent/prd.json.backup agent/progress.txt.backup frontend/src/components/Panel.vue frontend/src/composables/useDatasource.ts frontend/src/types/datasource.ts frontend/src/views/Explore.vue frontend/src/views/ExploreLogs.spec.ts frontend/src/views/ExploreLogs.vue frontend/src/views/ExploreTraces.vue ([fa19d15](https://github.com/janhoon/ace/commit/fa19d15b4200b10fbd1a9cc51dec07610c119d86))
-* 266 - agent/prd.json.backup agent/progress.txt.backup frontend/src/components/Panel.vue frontend/src/composables/useDatasource.ts frontend/src/types/datasource.ts frontend/src/views/Explore.vue frontend/src/views/ExploreLogs.spec.ts frontend/src/views/ExploreLogs.vue frontend/src/views/ExploreTraces.vue ([c8d4296](https://github.com/janhoon/ace/commit/c8d429637a4fe3aeabf89dae8f12992684253463))
-* 266 add clickhouse sql editor and settings ([1e10f39](https://github.com/janhoon/ace/commit/1e10f39935091eb8da6f06904d99d2a7662ff623))
-* 267 clickhouse explore views and panel routing ([8a4803b](https://github.com/janhoon/ace/commit/8a4803b0efaf8765d4bd43dc70cdf5bfa2aa6146))
-* add ClickHouse datasource tickets [#265](https://github.com/janhoon/ace/issues/265), [#266](https://github.com/janhoon/ace/issues/266), [#267](https://github.com/janhoon/ace/issues/267) to PRD ([102aea5](https://github.com/janhoon/ace/commit/102aea5e10f4638d3960ae443f38f1d823e6dd50))
-* LANDING-COMPARISON-001 add comparison table ([ae27477](https://github.com/janhoon/ace/commit/ae27477149537798dd61014d89c6ae06b7715cb6))
-* LANDING-FEATURES-001 add landing feature cards ([3ca4ae5](https://github.com/janhoon/ace/commit/3ca4ae5b3535866016fb96ef225a84700b570443))
-* LANDING-FOOTER-001 add landing footer CTA ([1bb0bf9](https://github.com/janhoon/ace/commit/1bb0bf9b45d7fd0f9db6c4c2a497b7440185faa5))
-* LANDING-HERO-001 build landing hero section ([ac8cb1e](https://github.com/janhoon/ace/commit/ac8cb1edc9fc67b89938909b3a7b061829bf5726))
-* LANDING-SCREENSHOTS-001 add landing screenshot gallery ([3c5cbc3](https://github.com/janhoon/ace/commit/3c5cbc3429acf0c1adfbde9e0b445cc32bd8c8a3))
-* LANDING-SETUP-001 add landing route and SEO foundation ([92698c3](https://github.com/janhoon/ace/commit/92698c331208fbafd79a9efb12b883ee8157b041))
-* POSTHOG-BACKEND-001 add backend PostHog analytics ([f80f912](https://github.com/janhoon/ace/commit/f80f91268afb4c0b0885888e96e4cd3e2062c2fd))
-* POSTHOG-FRONTEND-001 add frontend analytics ([64590d6](https://github.com/janhoon/ace/commit/64590d65149e216e9e20ceb5205b7d5f4777de95))
-* task-1 - frontend/src/views/Explore.spec.ts ([c1a67b0](https://github.com/janhoon/ace/commit/c1a67b0499e67a886528c904b151ba8b824e4b29))
-* task-1 - frontend/src/views/Explore.spec.ts ([e58d36f](https://github.com/janhoon/ace/commit/e58d36f4de4065cfbf29116234f56bf170391a65))
-* update Ralph workflow to use PRs for changelog tracking ([646f101](https://github.com/janhoon/ace/commit/646f101044a6c30bc526b5a1f76c18dcd372c9d4))
+* 265 add ClickHouse backend datasource core ([2b3cb60](https://github.com/aceobservability/ace/commit/2b3cb604ba57f8d10452746e860e24c67e4c6ece))
+* 266 - agent/prd.json.backup agent/progress.txt.backup frontend/src/components/Panel.vue frontend/src/composables/useDatasource.ts frontend/src/types/datasource.ts frontend/src/views/Explore.vue frontend/src/views/ExploreLogs.spec.ts frontend/src/views/ExploreLogs.vue frontend/src/views/ExploreTraces.vue ([fa19d15](https://github.com/aceobservability/ace/commit/fa19d15b4200b10fbd1a9cc51dec07610c119d86))
+* 266 - agent/prd.json.backup agent/progress.txt.backup frontend/src/components/Panel.vue frontend/src/composables/useDatasource.ts frontend/src/types/datasource.ts frontend/src/views/Explore.vue frontend/src/views/ExploreLogs.spec.ts frontend/src/views/ExploreLogs.vue frontend/src/views/ExploreTraces.vue ([c8d4296](https://github.com/aceobservability/ace/commit/c8d429637a4fe3aeabf89dae8f12992684253463))
+* 266 add clickhouse sql editor and settings ([1e10f39](https://github.com/aceobservability/ace/commit/1e10f39935091eb8da6f06904d99d2a7662ff623))
+* 267 clickhouse explore views and panel routing ([8a4803b](https://github.com/aceobservability/ace/commit/8a4803b0efaf8765d4bd43dc70cdf5bfa2aa6146))
+* add ClickHouse datasource tickets [#265](https://github.com/aceobservability/ace/issues/265), [#266](https://github.com/aceobservability/ace/issues/266), [#267](https://github.com/aceobservability/ace/issues/267) to PRD ([102aea5](https://github.com/aceobservability/ace/commit/102aea5e10f4638d3960ae443f38f1d823e6dd50))
+* LANDING-COMPARISON-001 add comparison table ([ae27477](https://github.com/aceobservability/ace/commit/ae27477149537798dd61014d89c6ae06b7715cb6))
+* LANDING-FEATURES-001 add landing feature cards ([3ca4ae5](https://github.com/aceobservability/ace/commit/3ca4ae5b3535866016fb96ef225a84700b570443))
+* LANDING-FOOTER-001 add landing footer CTA ([1bb0bf9](https://github.com/aceobservability/ace/commit/1bb0bf9b45d7fd0f9db6c4c2a497b7440185faa5))
+* LANDING-HERO-001 build landing hero section ([ac8cb1e](https://github.com/aceobservability/ace/commit/ac8cb1edc9fc67b89938909b3a7b061829bf5726))
+* LANDING-SCREENSHOTS-001 add landing screenshot gallery ([3c5cbc3](https://github.com/aceobservability/ace/commit/3c5cbc3429acf0c1adfbde9e0b445cc32bd8c8a3))
+* LANDING-SETUP-001 add landing route and SEO foundation ([92698c3](https://github.com/aceobservability/ace/commit/92698c331208fbafd79a9efb12b883ee8157b041))
+* POSTHOG-BACKEND-001 add backend PostHog analytics ([f80f912](https://github.com/aceobservability/ace/commit/f80f91268afb4c0b0885888e96e4cd3e2062c2fd))
+* POSTHOG-FRONTEND-001 add frontend analytics ([64590d6](https://github.com/aceobservability/ace/commit/64590d65149e216e9e20ceb5205b7d5f4777de95))
+* task-1 - frontend/src/views/Explore.spec.ts ([c1a67b0](https://github.com/aceobservability/ace/commit/c1a67b0499e67a886528c904b151ba8b824e4b29))
+* task-1 - frontend/src/views/Explore.spec.ts ([e58d36f](https://github.com/aceobservability/ace/commit/e58d36f4de4065cfbf29116234f56bf170391a65))
+* update Ralph workflow to use PRs for changelog tracking ([646f101](https://github.com/aceobservability/ace/commit/646f101044a6c30bc526b5a1f76c18dcd372c9d4))
 
 
 ### Bug Fixes
 
-* normalize trace search results and refine graph arrows ([8513820](https://github.com/janhoon/ace/commit/8513820742075f67c9b8c00532a16fba113d249f))
+* normalize trace search results and refine graph arrows ([8513820](https://github.com/aceobservability/ace/commit/8513820742075f67c9b8c00532a16fba113d249f))
 
 
 ### Documentation
 
-* Add PostHog backend and frontend integration tickets ([#249](https://github.com/janhoon/ace/issues/249), [#250](https://github.com/janhoon/ace/issues/250)) ([5143d75](https://github.com/janhoon/ace/commit/5143d75092d9a161aa856ae567a2e3a4db69af30))
-* Add PostHog EU region config and API keys ([2ff560b](https://github.com/janhoon/ace/commit/2ff560b76b2833b385292e28e95f122517fba293))
-* Remove PostHog API keys (moved to Speke) ([bdc1752](https://github.com/janhoon/ace/commit/bdc1752450fec3b61581d8b6b5904ec5bfd64ef3))
-* Update PostHog host to https://eu.i.posthog.com ([173c726](https://github.com/janhoon/ace/commit/173c7266436d2d969bfc2d63337fd08a231a391b))
+* Add PostHog backend and frontend integration tickets ([#249](https://github.com/aceobservability/ace/issues/249), [#250](https://github.com/aceobservability/ace/issues/250)) ([5143d75](https://github.com/aceobservability/ace/commit/5143d75092d9a161aa856ae567a2e3a4db69af30))
+* Add PostHog EU region config and API keys ([2ff560b](https://github.com/aceobservability/ace/commit/2ff560b76b2833b385292e28e95f122517fba293))
+* Remove PostHog API keys (moved to Speke) ([bdc1752](https://github.com/aceobservability/ace/commit/bdc1752450fec3b61581d8b6b5904ec5bfd64ef3))
+* Update PostHog host to https://eu.i.posthog.com ([173c726](https://github.com/aceobservability/ace/commit/173c7266436d2d969bfc2d63337fd08a231a391b))
 
-## [0.2.0](https://github.com/janhoon/dash/compare/v0.1.0...v0.2.0) (2026-02-10)
+## [0.2.0](https://github.com/aceobservability/ace/compare/v0.1.0...v0.2.0) (2026-02-10)
 
 
 ### Features
 
-* add inter-service topology to otel loadgen ([ff6a16b](https://github.com/janhoon/dash/commit/ff6a16b23e184fad5e488ccb259c798603daae37))
-* improve local trace testing and Tempo visibility ([e8511b1](https://github.com/janhoon/dash/commit/e8511b15afcf501f10aebbf405ecaf14c4e4862f))
-* TRACING-API-001 add tracing datasource APIs ([d5c45df](https://github.com/janhoon/dash/commit/d5c45dfde84e21a7c064b8fed55433c344245a13))
-* TRACING-AUTO-INSTRUMENT-001 add otel tracing pipeline ([de5a49e](https://github.com/janhoon/dash/commit/de5a49ecfb84e354682d65cd9e8375d0a9d9fbf8))
-* TRACING-DATASOURCE-001 add tracing datasource setup ([f2917dd](https://github.com/janhoon/dash/commit/f2917ddaf0f18790f8d68951c146f625b637deb8))
-* TRACING-INTEGRATION-001 add trace-to-logs and metrics context ([b01759f](https://github.com/janhoon/dash/commit/b01759f21617f96de54f086eb61c8189265000a1))
-* TRACING-PANELS-001 add trace list and heatmap panels ([5cae6dd](https://github.com/janhoon/dash/commit/5cae6ddc1983ef8e1e6353ea8fbfa7af22aa4d98))
-* TRACING-SERVICE-GRAPH-001 add trace service dependency graph ([8eb3947](https://github.com/janhoon/dash/commit/8eb394726fa4abc5a67ab62b3c9fe09059f26710))
-* TRACING-SPAN-DETAILS-001 span details panel ([2d82b33](https://github.com/janhoon/dash/commit/2d82b33c6c64d3f605afa77cb7d6beaeacaadbe8))
-* TRACING-TIMELINE-001 trace timeline waterfall ([1d2f8b9](https://github.com/janhoon/dash/commit/1d2f8b9070984dcce03c9a7c92c354f95832fce9))
+* add inter-service topology to otel loadgen ([ff6a16b](https://github.com/aceobservability/ace/commit/ff6a16b23e184fad5e488ccb259c798603daae37))
+* improve local trace testing and Tempo visibility ([e8511b1](https://github.com/aceobservability/ace/commit/e8511b15afcf501f10aebbf405ecaf14c4e4862f))
+* TRACING-API-001 add tracing datasource APIs ([d5c45df](https://github.com/aceobservability/ace/commit/d5c45dfde84e21a7c064b8fed55433c344245a13))
+* TRACING-AUTO-INSTRUMENT-001 add otel tracing pipeline ([de5a49e](https://github.com/aceobservability/ace/commit/de5a49ecfb84e354682d65cd9e8375d0a9d9fbf8))
+* TRACING-DATASOURCE-001 add tracing datasource setup ([f2917dd](https://github.com/aceobservability/ace/commit/f2917ddaf0f18790f8d68951c146f625b637deb8))
+* TRACING-INTEGRATION-001 add trace-to-logs and metrics context ([b01759f](https://github.com/aceobservability/ace/commit/b01759f21617f96de54f086eb61c8189265000a1))
+* TRACING-PANELS-001 add trace list and heatmap panels ([5cae6dd](https://github.com/aceobservability/ace/commit/5cae6ddc1983ef8e1e6353ea8fbfa7af22aa4d98))
+* TRACING-SERVICE-GRAPH-001 add trace service dependency graph ([8eb3947](https://github.com/aceobservability/ace/commit/8eb394726fa4abc5a67ab62b3c9fe09059f26710))
+* TRACING-SPAN-DETAILS-001 span details panel ([2d82b33](https://github.com/aceobservability/ace/commit/2d82b33c6c64d3f605afa77cb7d6beaeacaadbe8))
+* TRACING-TIMELINE-001 trace timeline waterfall ([1d2f8b9](https://github.com/aceobservability/ace/commit/1d2f8b9070984dcce03c9a7c92c354f95832fce9))
 
 
 ### Bug Fixes
 
-* expand collapsed sidebar on hover ([702d4fd](https://github.com/janhoon/dash/commit/702d4fd6896645df99b64e32a27932329d108a2e))
-* stabilize release workflow checks and rerun support ([136c41d](https://github.com/janhoon/dash/commit/136c41d6f086118fab4ebd241388df9a78dde0ec))
+* expand collapsed sidebar on hover ([702d4fd](https://github.com/aceobservability/ace/commit/702d4fd6896645df99b64e32a27932329d108a2e))
+* stabilize release workflow checks and rerun support ([136c41d](https://github.com/aceobservability/ace/commit/136c41d6f086118fab4ebd241388df9a78dde0ec))
 
 
 ### CI
 
-* update coverage badge [skip ci] ([9f139c6](https://github.com/janhoon/dash/commit/9f139c60253ca727fa18e50ca322b5cbc0a9b2e9))
-* update coverage badge [skip ci] ([c2b5305](https://github.com/janhoon/dash/commit/c2b5305881a2d8065f0734364373eed2008c5778))
-* update coverage badge [skip ci] ([6b9d245](https://github.com/janhoon/dash/commit/6b9d2453512f5fe479f63442f13c598a3e58b26f))
-* update coverage badge [skip ci] ([79e3e08](https://github.com/janhoon/dash/commit/79e3e08da8c36d33111bcd571a279c7481a2f53e))
-* update coverage badge [skip ci] ([390807e](https://github.com/janhoon/dash/commit/390807ebf73e3934f41e0cc99854eef1d9a8ad03))
-* update coverage badge [skip ci] ([94856f8](https://github.com/janhoon/dash/commit/94856f8151ecf26ae88eea6919938ba2d2d56562))
-* update coverage badge [skip ci] ([b2104e2](https://github.com/janhoon/dash/commit/b2104e269c411006dc4fd2520848b1d251879591))
-* update coverage badge [skip ci] ([3ae3e4f](https://github.com/janhoon/dash/commit/3ae3e4fb8807c0e4cda74e3bec2f3ee43f341b80))
-* update coverage badge [skip ci] ([0833767](https://github.com/janhoon/dash/commit/0833767315aaedf3df554bf4da317c431c99eebf))
-* update coverage badge [skip ci] ([1a0d947](https://github.com/janhoon/dash/commit/1a0d947c69b95dd747540b2eb8482860a23367b1))
+* update coverage badge [skip ci] ([9f139c6](https://github.com/aceobservability/ace/commit/9f139c60253ca727fa18e50ca322b5cbc0a9b2e9))
+* update coverage badge [skip ci] ([c2b5305](https://github.com/aceobservability/ace/commit/c2b5305881a2d8065f0734364373eed2008c5778))
+* update coverage badge [skip ci] ([6b9d245](https://github.com/aceobservability/ace/commit/6b9d2453512f5fe479f63442f13c598a3e58b26f))
+* update coverage badge [skip ci] ([79e3e08](https://github.com/aceobservability/ace/commit/79e3e08da8c36d33111bcd571a279c7481a2f53e))
+* update coverage badge [skip ci] ([390807e](https://github.com/aceobservability/ace/commit/390807ebf73e3934f41e0cc99854eef1d9a8ad03))
+* update coverage badge [skip ci] ([94856f8](https://github.com/aceobservability/ace/commit/94856f8151ecf26ae88eea6919938ba2d2d56562))
+* update coverage badge [skip ci] ([b2104e2](https://github.com/aceobservability/ace/commit/b2104e269c411006dc4fd2520848b1d251879591))
+* update coverage badge [skip ci] ([3ae3e4f](https://github.com/aceobservability/ace/commit/3ae3e4fb8807c0e4cda74e3bec2f3ee43f341b80))
+* update coverage badge [skip ci] ([0833767](https://github.com/aceobservability/ace/commit/0833767315aaedf3df554bf4da317c431c99eebf))
+* update coverage badge [skip ci] ([1a0d947](https://github.com/aceobservability/ace/commit/1a0d947c69b95dd747540b2eb8482860a23367b1))
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ace - Monitoring Dashboard
 
-[![CodeQL](https://github.com/janhoon/dash/actions/workflows/security.yml/badge.svg?branch=master)](https://github.com/janhoon/dash/actions/workflows/security.yml)
-[![Lint](https://github.com/janhoon/dash/actions/workflows/lint.yml/badge.svg?branch=master)](https://github.com/janhoon/dash/actions/workflows/lint.yml)
-[![Security](https://github.com/janhoon/dash/actions/workflows/security.yml/badge.svg?branch=master)](https://github.com/janhoon/dash/actions/workflows/security.yml)
+[![CodeQL](https://github.com/aceobservability/ace/actions/workflows/security.yml/badge.svg?branch=master)](https://github.com/aceobservability/ace/actions/workflows/security.yml)
+[![Lint](https://github.com/aceobservability/ace/actions/workflows/lint.yml/badge.svg?branch=master)](https://github.com/aceobservability/ace/actions/workflows/lint.yml)
+[![Security](https://github.com/aceobservability/ace/actions/workflows/security.yml/badge.svg?branch=master)](https://github.com/aceobservability/ace/actions/workflows/security.yml)
 
 A Grafana-like monitoring dashboard built with Vue.js, Go, and Prometheus.
 
@@ -18,14 +18,14 @@ A Grafana-like monitoring dashboard built with Vue.js, Go, and Prometheus.
 
 Public multi-arch images are published to GHCR on every release:
 
-- `ghcr.io/janhoon/dash-backend`
-- `ghcr.io/janhoon/dash-frontend`
+- `ghcr.io/aceobservability/ace-backend`
+- `ghcr.io/aceobservability/ace-frontend`
 
 Example pulls:
 
 ```bash
-docker pull ghcr.io/janhoon/dash-backend:v0.1.0
-docker pull ghcr.io/janhoon/dash-frontend:v0.1.0
+docker pull ghcr.io/aceobservability/ace-backend:v0.1.0
+docker pull ghcr.io/aceobservability/ace-frontend:v0.1.0
 ```
 
 When building the frontend image yourself, set `VITE_API_URL` at build time:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,8 +46,8 @@ Use Conventional Commit messages for all merge commits/PR titles to keep release
 
 ### Container images (public GHCR)
 
-- `ghcr.io/janhoon/dash-backend`
-- `ghcr.io/janhoon/dash-frontend`
+- `ghcr.io/aceobservability/ace-backend`
+- `ghcr.io/aceobservability/ace-frontend`
 
 Image tags published per release:
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,12 +9,12 @@ COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 
 COPY backend/ ./
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /out/dash-api ./cmd/api
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /out/ace-api ./cmd/api
 
 FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /out/dash-api /usr/local/bin/dash-api
+COPY --from=builder /out/ace-api /usr/local/bin/ace-api
 
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/local/bin/dash-api"]
+ENTRYPOINT ["/usr/local/bin/ace-api"]

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -9,14 +9,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/analytics"
-	"github.com/janhoon/dash/backend/internal/audit"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/db"
-	"github.com/janhoon/dash/backend/internal/handlers"
-	"github.com/janhoon/dash/backend/internal/httplog"
-	"github.com/janhoon/dash/backend/internal/telemetry"
-	"github.com/janhoon/dash/backend/internal/valkey"
+	"github.com/aceobservability/ace/backend/internal/analytics"
+	"github.com/aceobservability/ace/backend/internal/audit"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/db"
+	"github.com/aceobservability/ace/backend/internal/handlers"
+	"github.com/aceobservability/ace/backend/internal/httplog"
+	"github.com/aceobservability/ace/backend/internal/telemetry"
+	"github.com/aceobservability/ace/backend/internal/valkey"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
@@ -45,7 +45,7 @@ func main() {
 	// Get database URL from environment
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://dash:dash@localhost:5432/dash?sslmode=disable"
+		dbURL = "postgres://ace:ace@localhost:5432/ace?sslmode=disable"
 	}
 
 	// Get Prometheus URL from environment

--- a/backend/cmd/converter/main.go
+++ b/backend/cmd/converter/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/janhoon/dash/backend/internal/converter"
+	"github.com/aceobservability/ace/backend/internal/converter"
 )
 
 func main() {

--- a/backend/cmd/seed-dashboards/main.go
+++ b/backend/cmd/seed-dashboards/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/db"
+	"github.com/aceobservability/ace/backend/internal/db"
 )
 
 // panel describes a single panel to create inside a dashboard.
@@ -269,7 +269,7 @@ func main() {
 
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://dash:dash@localhost:5432/dash?sslmode=disable"
+		dbURL = "postgres://ace:ace@localhost:5432/ace?sslmode=disable"
 	}
 
 	ctx := context.Background()

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/db"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/db"
 )
 
 type datasource struct {
@@ -92,7 +92,7 @@ func main() {
 
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://dash:dash@localhost:5432/dash?sslmode=disable"
+		dbURL = "postgres://ace:ace@localhost:5432/ace?sslmode=disable"
 	}
 
 	ctx := context.Background()

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module github.com/janhoon/dash/backend
+module github.com/aceobservability/ace/backend
 
 go 1.25.8
 
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.64.1
+	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -44,7 +45,6 @@ require (
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect

--- a/backend/internal/audit/logger.go
+++ b/backend/internal/audit/logger.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/auth"
 	"go.uber.org/zap"
 )
 

--- a/backend/internal/audit/logger_test.go
+++ b/backend/internal/audit/logger_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/db"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/db"
 )
 
 var testPool *pgxpool.Pool
@@ -19,7 +19,7 @@ var testPool *pgxpool.Pool
 func TestMain(m *testing.M) {
 	dbURL := os.Getenv("TEST_DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://dash:dash@localhost:5432/dash_test?sslmode=disable"
+		dbURL = "postgres://ace:ace@localhost:5432/ace_test?sslmode=disable"
 	}
 
 	ctx := context.Background()

--- a/backend/internal/authz/service.go
+++ b/backend/internal/authz/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 type ResourceType string

--- a/backend/internal/authz/service_test.go
+++ b/backend/internal/authz/service_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/db"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/db"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 var testPool *pgxpool.Pool
@@ -17,7 +17,7 @@ var testPool *pgxpool.Pool
 func TestMain(m *testing.M) {
 	dbURL := os.Getenv("TEST_DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://dash:dash@localhost:5432/dash_test?sslmode=disable"
+		dbURL = "postgres://ace:ace@localhost:5432/ace_test?sslmode=disable"
 	}
 
 	ctx := context.Background()

--- a/backend/internal/crypto/crypto_test.go
+++ b/backend/internal/crypto/crypto_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/janhoon/dash/backend/internal/crypto"
+	"github.com/aceobservability/ace/backend/internal/crypto"
 )
 
 // TestEncryptDecryptRoundTrip verifies that a plaintext can be encrypted and

--- a/backend/internal/datasource/alertmanager.go
+++ b/backend/internal/datasource/alertmanager.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // AlertManagerClient wraps HTTP calls to AlertManager's v2 API.

--- a/backend/internal/datasource/auth.go
+++ b/backend/internal/datasource/auth.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 type datasourceAuthConfig struct {

--- a/backend/internal/datasource/auth_test.go
+++ b/backend/internal/datasource/auth_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestApplyDataSourceAuth_Basic(t *testing.T) {

--- a/backend/internal/datasource/clickhouse.go
+++ b/backend/internal/datasource/clickhouse.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 const (

--- a/backend/internal/datasource/clickhouse_test.go
+++ b/backend/internal/datasource/clickhouse_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestNormaliseToLogs(t *testing.T) {

--- a/backend/internal/datasource/client.go
+++ b/backend/internal/datasource/client.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // QueryRequest represents a query request body

--- a/backend/internal/datasource/client_test.go
+++ b/backend/internal/datasource/client_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestNewClient_Prometheus(t *testing.T) {

--- a/backend/internal/datasource/cloudwatch.go
+++ b/backend/internal/datasource/cloudwatch.go
@@ -16,7 +16,7 @@ import (
 	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 const (

--- a/backend/internal/datasource/elasticsearch.go
+++ b/backend/internal/datasource/elasticsearch.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 const (

--- a/backend/internal/datasource/elasticsearch_test.go
+++ b/backend/internal/datasource/elasticsearch_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestElasticsearchClient_QueryWithSignal_Logs(t *testing.T) {

--- a/backend/internal/datasource/prometheus.go
+++ b/backend/internal/datasource/prometheus.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	promclient "github.com/janhoon/dash/backend/pkg/prometheus"
+	promclient "github.com/aceobservability/ace/backend/pkg/prometheus"
 )
 
 type PrometheusClient struct {

--- a/backend/internal/datasource/tempo.go
+++ b/backend/internal/datasource/tempo.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // TempoClient is used for trace datasource connectivity checks.

--- a/backend/internal/datasource/tracing.go
+++ b/backend/internal/datasource/tracing.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // TracingClient is the interface for trace-specific datasource operations.

--- a/backend/internal/datasource/tracing_test.go
+++ b/backend/internal/datasource/tracing_test.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestParseTrace_JaegerDataFormat(t *testing.T) {

--- a/backend/internal/datasource/victoriatraces.go
+++ b/backend/internal/datasource/victoriatraces.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // VictoriaTracesClient is used for trace datasource connectivity checks.

--- a/backend/internal/datasource/vmalert.go
+++ b/backend/internal/datasource/vmalert.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // VMAlertClient wraps HTTP calls to VMAlert's API.

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/telemetry"
+	"github.com/aceobservability/ace/backend/internal/telemetry"
 )
 
 func Connect(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {

--- a/backend/internal/db/migrations_test.go
+++ b/backend/internal/db/migrations_test.go
@@ -12,7 +12,7 @@ import (
 // This test requires a running PostgreSQL database
 func TestRunMigrations(t *testing.T) {
 	// Skip if no database URL is provided
-	databaseURL := "postgres://dash:dash@localhost:5432/dash_test?sslmode=disable"
+	databaseURL := "postgres://ace:ace@localhost:5432/ace_test?sslmode=disable"
 
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, databaseURL)
@@ -434,7 +434,7 @@ func TestRunMigrations(t *testing.T) {
 // TestDownMigration tests that migrations can be reversed
 func TestDownMigration(t *testing.T) {
 	// Skip if no database URL is provided
-	databaseURL := "postgres://dash:dash@localhost:5432/dash_test?sslmode=disable"
+	databaseURL := "postgres://ace:ace@localhost:5432/ace_test?sslmode=disable"
 
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, databaseURL)

--- a/backend/internal/handlers/ai_handler.go
+++ b/backend/internal/handlers/ai_handler.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/crypto"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/crypto"
 	"go.uber.org/zap"
 )
 

--- a/backend/internal/handlers/ai_handler_test.go
+++ b/backend/internal/handlers/ai_handler_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/auth"
 )
 
 // --- helpers ----------------------------------------------------------------

--- a/backend/internal/handlers/ai_provider.go
+++ b/backend/internal/handlers/ai_provider.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/crypto"
+	"github.com/aceobservability/ace/backend/internal/crypto"
 )
 
 // hashToken returns a hex-encoded SHA-256 hash of the given token,

--- a/backend/internal/handlers/ai_provider_test.go
+++ b/backend/internal/handlers/ai_provider_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/janhoon/dash/backend/internal/crypto"
+	"github.com/aceobservability/ace/backend/internal/crypto"
 )
 
 func TestOpenAICompatibleProvider_ListModels(t *testing.T) {

--- a/backend/internal/handlers/alertmanager.go
+++ b/backend/internal/handlers/alertmanager.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/datasource"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/datasource"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // AlertManagerHandler proxies requests to an AlertManager datasource.

--- a/backend/internal/handlers/audit.go
+++ b/backend/internal/handlers/audit.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // AuditHandler serves audit log endpoints.

--- a/backend/internal/handlers/audit_test.go
+++ b/backend/internal/handlers/audit_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // auditTestSetup creates an org and up to 4 members with different roles,

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/analytics"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/analytics"
+	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/db"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/db"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	// Setup test database
 	dbURL := os.Getenv("TEST_DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://dash:dash@localhost:5432/dash_test?sslmode=disable"
+		dbURL = "postgres://ace:ace@localhost:5432/ace_test?sslmode=disable"
 	}
 
 	ctx := context.Background()

--- a/backend/internal/handlers/dashboard_cac.go
+++ b/backend/internal/handlers/dashboard_cac.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/authz"
-	"github.com/janhoon/dash/backend/internal/converter"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/authz"
+	"github.com/aceobservability/ace/backend/internal/converter"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func (h *DashboardHandler) Export(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handlers/dashboard_cac_test.go
+++ b/backend/internal/handlers/dashboard_cac_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/auth"
 )
 
 func TestDashboardHandler_Export_InvalidFormat(t *testing.T) {

--- a/backend/internal/handlers/dashboards.go
+++ b/backend/internal/handlers/dashboards.go
@@ -9,10 +9,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/analytics"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/authz"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/analytics"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/authz"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 type DashboardHandler struct {

--- a/backend/internal/handlers/dashboards_test.go
+++ b/backend/internal/handlers/dashboards_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestDashboardHandler_Create_MissingTitle(t *testing.T) {

--- a/backend/internal/handlers/datasource.go
+++ b/backend/internal/handlers/datasource.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/analytics"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/datasource"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/analytics"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/datasource"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // validateDatasourceURL validates a datasource URL to prevent SSRF attacks.

--- a/backend/internal/handlers/datasource_test.go
+++ b/backend/internal/handlers/datasource_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestDataSourceHandler_Create_MissingName(t *testing.T) {

--- a/backend/internal/handlers/folders.go
+++ b/backend/internal/handlers/folders.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/authz"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/authz"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 type FolderHandler struct {

--- a/backend/internal/handlers/github_copilot.go
+++ b/backend/internal/handlers/github_copilot.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/crypto"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/crypto"
 	"go.uber.org/zap"
 )
 

--- a/backend/internal/handlers/grafana_converter.go
+++ b/backend/internal/handlers/grafana_converter.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/janhoon/dash/backend/internal/converter"
+	"github.com/aceobservability/ace/backend/internal/converter"
 )
 
 type GrafanaConverterHandler struct{}

--- a/backend/internal/handlers/groups.go
+++ b/backend/internal/handlers/groups.go
@@ -12,8 +12,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 type GroupHandler struct {

--- a/backend/internal/handlers/groups_test.go
+++ b/backend/internal/handlers/groups_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func createTestOrganization(t *testing.T, orgHandler *OrganizationHandler, accessToken string, namePrefix string) models.Organization {

--- a/backend/internal/handlers/organization.go
+++ b/backend/internal/handlers/organization.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/backend/internal/handlers/organization_test.go
+++ b/backend/internal/handlers/organization_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/backend/internal/handlers/panels.go
+++ b/backend/internal/handlers/panels.go
@@ -9,9 +9,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/authz"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/authz"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 type PanelHandler struct {

--- a/backend/internal/handlers/panels_test.go
+++ b/backend/internal/handlers/panels_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func TestPanelHandler_Create_InvalidDashboardID(t *testing.T) {

--- a/backend/internal/handlers/permissions.go
+++ b/backend/internal/handlers/permissions.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/authz"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/authz"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 type PermissionHandler struct {

--- a/backend/internal/handlers/permissions_test.go
+++ b/backend/internal/handlers/permissions_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/authz"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/authz"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 func createTestFolderForPermissions(t *testing.T, folderHandler *FolderHandler, accessToken string, orgID uuid.UUID, name string) models.Folder {

--- a/backend/internal/handlers/prometheus.go
+++ b/backend/internal/handlers/prometheus.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/janhoon/dash/backend/pkg/prometheus"
+	"github.com/aceobservability/ace/backend/pkg/prometheus"
 )
 
 // CacheEntry holds cached data with expiration

--- a/backend/internal/handlers/sso_google.go
+++ b/backend/internal/handlers/sso_google.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"

--- a/backend/internal/handlers/sso_google_test.go
+++ b/backend/internal/handlers/sso_google_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/backend/internal/handlers/sso_microsoft.go
+++ b/backend/internal/handlers/sso_microsoft.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/oauth2"
 )

--- a/backend/internal/handlers/sso_microsoft_test.go
+++ b/backend/internal/handlers/sso_microsoft_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/backend/internal/handlers/sso_okta.go
+++ b/backend/internal/handlers/sso_okta.go
@@ -16,9 +16,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/audit"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/audit"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/oauth2"
 )

--- a/backend/internal/handlers/sso_okta_test.go
+++ b/backend/internal/handlers/sso_okta_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/handlers/sso_role_mappings.go
+++ b/backend/internal/handlers/sso_role_mappings.go
@@ -11,9 +11,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/audit"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/audit"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // SSORoleMappingHandler serves CRUD endpoints for SSO group-to-role mappings.

--- a/backend/internal/handlers/sso_role_mappings_test.go
+++ b/backend/internal/handlers/sso_role_mappings_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // ssoRoleMappingTestSetup creates an org, an SSO config for the given provider,

--- a/backend/internal/handlers/vmalert.go
+++ b/backend/internal/handlers/vmalert.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/datasource"
-	"github.com/janhoon/dash/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/datasource"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // VMAlertHandler proxies requests to a VMAlert datasource.

--- a/charts/ace/Chart.yaml
+++ b/charts/ace/Chart.yaml
@@ -11,10 +11,10 @@ keywords:
   - logs
   - traces
   - victoriametrics
-home: https://github.com/janhoon/ace
+home: https://github.com/aceobservability/ace
 maintainers:
   - name: Jan Hoon
-    url: https://github.com/janhoon
+    url: https://github.com/aceobservability
 
 dependencies:
   # -- PostgreSQL database (togglable — disable when using an external DB)

--- a/charts/ace/README.md
+++ b/charts/ace/README.md
@@ -118,7 +118,7 @@ helm install ace charts/ace --dry-run -f charts/ace/values-dev.yaml -n ace
 | Key | Description | Default |
 |-----|-------------|---------|
 | `backend.replicaCount` | Replicas (when HPA disabled) | `2` |
-| `backend.image.repository` | Backend image | `ghcr.io/janhoon/ace-backend` |
+| `backend.image.repository` | Backend image | `ghcr.io/aceobservability/ace-backend` |
 | `backend.image.tag` | Image tag | `Chart.appVersion` |
 | `backend.autoscaling.enabled` | Enable HPA | `true` |
 | `backend.autoscaling.minReplicas` | HPA min | `2` |
@@ -144,7 +144,7 @@ helm install ace charts/ace --dry-run -f charts/ace/values-dev.yaml -n ace
 | Key | Description | Default |
 |-----|-------------|---------|
 | `frontend.replicaCount` | Replicas (when HPA disabled) | `2` |
-| `frontend.image.repository` | Frontend image | `ghcr.io/janhoon/ace-frontend` |
+| `frontend.image.repository` | Frontend image | `ghcr.io/aceobservability/ace-frontend` |
 | `frontend.autoscaling.enabled` | Enable HPA | `true` |
 | `frontend.nginxConfigOverride` | Use ConfigMap nginx.conf | `false` |
 | `frontend.resources` | Resource requests/limits | See values.yaml |

--- a/charts/ace/values.yaml
+++ b/charts/ace/values.yaml
@@ -53,7 +53,7 @@ backend:
   replicaCount: 2
 
   image:
-    repository: ghcr.io/janhoon/ace-backend
+    repository: ghcr.io/aceobservability/ace-backend
     pullPolicy: IfNotPresent
     # -- Overrides the image tag (default: Chart.appVersion)
     tag: ""
@@ -158,7 +158,7 @@ frontend:
   replicaCount: 2
 
   image:
-    repository: ghcr.io/janhoon/ace-frontend
+    repository: ghcr.io/aceobservability/ace-frontend
     pullPolicy: IfNotPresent
     tag: ""
 

--- a/deploy/charts/ace-local-infra/values.yaml
+++ b/deploy/charts/ace-local-infra/values.yaml
@@ -1,9 +1,9 @@
 postgres:
   enabled: false
   image: postgres:16-alpine
-  database: dash
-  username: dash
-  password: dash
+  database: ace
+  username: ace
+  password: ace
   persistence:
     enabled: false
     size: 5Gi
@@ -18,7 +18,7 @@ valkey:
 backend:
   enabled: false
   image: ace-backend
-  databaseURL: postgres://dash:dash@postgres:5432/dash?sslmode=disable
+  databaseURL: postgres://ace:ace@postgres:5432/ace?sslmode=disable
   valkeyURL: redis://valkey:6379
   otlpEndpoint: tempo:4318
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-name: dash
+name: ace
 
 # ─── Core services (always started) ──────────────────────────────────────────
 
@@ -8,13 +8,13 @@ services:
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-dash}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dash}
-      POSTGRES_DB: ${POSTGRES_DB:-dash}
+      POSTGRES_USER: ${POSTGRES_USER:-ace}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ace}
+      POSTGRES_DB: ${POSTGRES_DB:-ace}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dash}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ace}"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docs/plans/2026-02-25-seed-system.md
+++ b/docs/plans/2026-02-25-seed-system.md
@@ -33,8 +33,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/janhoon/dash/backend/internal/auth"
-	"github.com/janhoon/dash/backend/internal/db"
+	"github.com/aceobservability/ace/backend/internal/auth"
+	"github.com/aceobservability/ace/backend/internal/db"
 )
 
 type datasource struct {
@@ -113,7 +113,7 @@ func main() {
 
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://dash:dash@localhost:5432/dash?sslmode=disable"
+		dbURL = "postgres://ace:ace@localhost:5432/ace?sslmode=disable"
 	}
 
 	ctx := context.Background()

--- a/docs/plans/2026-02-27-copilot-mcp-tools.md
+++ b/docs/plans/2026-02-27-copilot-mcp-tools.md
@@ -312,7 +312,7 @@ In `backend/cmd/api/main.go`, add the metric-names route after the existing labe
 
 **Step 5: Verify it compiles**
 
-Run: `cd /home/janhoon/projects/ace/backend && go build ./...`
+Run: `cd ./backend && go build ./...`
 Expected: No errors
 
 **Step 6: Commit**
@@ -425,7 +425,7 @@ export async function fetchDataSourceLabelValues(
 
 **Step 4: Verify it compiles**
 
-Run: `cd /home/janhoon/projects/ace/frontend && npx biome check src/api/datasources.ts`
+Run: `cd ./frontend && npx biome check src/api/datasources.ts`
 Expected: No errors
 
 **Step 5: Commit**
@@ -497,7 +497,7 @@ export function useQueryEditor() {
 
 **Step 2: Verify lint passes**
 
-Run: `cd /home/janhoon/projects/ace/frontend && npx biome check src/composables/useQueryEditor.ts`
+Run: `cd ./frontend && npx biome check src/composables/useQueryEditor.ts`
 Expected: No errors
 
 **Step 3: Commit**
@@ -548,7 +548,7 @@ queryEditor.unregister()
 
 **Step 3: Verify lint passes**
 
-Run: `cd /home/janhoon/projects/ace/frontend && npx biome check src/views/Explore.vue`
+Run: `cd ./frontend && npx biome check src/views/Explore.vue`
 Expected: No errors
 
 **Step 4: Commit**
@@ -692,7 +692,7 @@ Add `sendChatRequest` to the return object of `useCopilot()`.
 
 **Step 4: Verify lint passes**
 
-Run: `cd /home/janhoon/projects/ace/frontend && npx biome check src/composables/useCopilot.ts`
+Run: `cd ./frontend && npx biome check src/composables/useCopilot.ts`
 Expected: No errors
 
 **Step 5: Commit**
@@ -773,7 +773,7 @@ After the Copilot API call, check if the response is streaming or JSON. If non-s
 
 **Step 4: Verify it compiles**
 
-Run: `cd /home/janhoon/projects/ace/backend && go build ./...`
+Run: `cd ./backend && go build ./...`
 Expected: No errors
 
 **Step 5: Commit**
@@ -965,7 +965,7 @@ export function useCopilotToolExecutor(datasourceId: () => string) {
 
 **Step 2: Verify lint passes**
 
-Run: `cd /home/janhoon/projects/ace/frontend && npx biome check src/composables/useCopilotTools.ts`
+Run: `cd ./frontend && npx biome check src/composables/useCopilotTools.ts`
 Expected: No errors
 
 **Step 3: Commit**
@@ -1127,7 +1127,7 @@ These are no longer needed — the `write_query` tool handles query insertion. R
 
 **Step 5: Verify lint passes**
 
-Run: `cd /home/janhoon/projects/ace/frontend && npx biome check src/components/CopilotPanel.vue`
+Run: `cd ./frontend && npx biome check src/components/CopilotPanel.vue`
 Expected: No errors
 
 **Step 6: Commit**
@@ -1230,7 +1230,7 @@ In `Explore.vue`:
 
 **Step 4: Verify lint passes**
 
-Run: `cd /home/janhoon/projects/ace/frontend && npx biome check src/App.vue src/views/Explore.vue`
+Run: `cd ./frontend && npx biome check src/App.vue src/views/Explore.vue`
 Expected: No errors
 
 **Step 5: Commit**
@@ -1246,7 +1246,7 @@ git commit -m "feat: move copilot panel to app-level layout for global visibilit
 
 **Step 1: Start the dev environment**
 
-Run: `cd /home/janhoon/projects/ace && make dev` (or however the local dev environment starts)
+Run: `cd . && make dev` (or however the local dev environment starts)
 
 **Step 2: Verify copilot panel visibility**
 


### PR DESCRIPTION
## Summary
- Renames Go module from `github.com/janhoon/dash/backend` to `github.com/aceobservability/ace/backend` (62 Go files)
- Updates all database defaults from `dash` to `ace` (Docker Compose, Helm values, hardcoded URLs in code and tests)
- Renames binary from `dash-api` to `ace-api` (Dockerfile, release workflow)
- Updates container image references from `ghcr.io/janhoon/dash-*` to `ghcr.io/aceobservability/ace-*`
- Replaces all remaining `janhoon` GitHub URLs with `aceobservability` (CHANGELOG, charts, plan docs)

76 files changed, zero new test failures (backend all green, frontend 23 pre-existing failures identical to master).

## Test plan
- [x] `go build ./...` — compiles clean
- [x] `go test ./...` — all packages pass
- [x] `npm run test` — 1164 passed, 23 failed (same as master)
- [x] Verified zero remaining `janhoon` or project-name `dash` references via grep
- [ ] Verify Tilt/Docker Compose local dev still works with new `ace` database name (requires DB reset)
- [ ] Verify release workflow produces `ace-api` / `ace-backend` artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)