### PR TITLE
fix: prevent org switcher popup from immediately closing

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -344,7 +344,7 @@ onUnmounted(() => {
           fontFamily: 'var(--font-display)',
         }"
         :title="currentOrg?.name || 'Select organization'"
-        @click="handleOrgClick"
+        @click.stop="handleOrgClick"
       >
         <span class="shrink-0">{{ orgInitial }}</span>
         <span v-if="isExpanded" class="flex-1 truncate text-left text-xs" :style="{ color: 'var(--color-on-surface)' }">


### PR DESCRIPTION
## Summary
- Fix org switcher popup closing immediately after opening due to Vue 3 microtask timing race
- Added `.stop` modifier to org selector button click to prevent the event from bubbling to the document-level click-outside handler

## Root cause
Vue 3 flushes DOM updates via microtask (between event listener callbacks). When clicking the org selector button, the popup rendered mid-bubbling, causing `handleOrgMenuClickOutside` to see the popup as already present and immediately close it.

## Test plan
- [ ] Click org selector button — popup should open and stay open
- [ ] Click an org in the popup — org should switch and popup should close
- [ ] Click outside the popup — popup should close
- [ ] Click org button again while popup is open — popup should toggle closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)