### PR TITLE
feat: implement all P2 TODOs

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,6 +21,7 @@ import (
 	"github.com/aceobservability/ace/backend/internal/db"
 	"github.com/aceobservability/ace/backend/internal/handlers"
 	"github.com/aceobservability/ace/backend/internal/httplog"
+	"github.com/aceobservability/ace/backend/internal/ratelimit"
 	"github.com/aceobservability/ace/backend/internal/telemetry"
 	"github.com/aceobservability/ace/backend/internal/valkey"
 )
@@ -67,6 +70,17 @@ func main() {
 		logger.Fatal("failed to run migrations", zap.Error(err))
 	}
 
+	// Separate audit DB pool (INSERT-only role for compliance hardening)
+	auditPool := pool // default: use main pool
+	if auditDBURL := os.Getenv("AUDIT_DATABASE_URL"); auditDBURL != "" {
+		auditPool, err = db.Connect(context.Background(), auditDBURL)
+		if err != nil {
+			logger.Fatal("failed to connect audit database", zap.Error(err))
+		}
+		defer auditPool.Close()
+		logger.Info("audit database pool connected (INSERT-only role)")
+	}
+
 	// Initialize JWT manager
 	jwtManager, err := auth.NewJWTManager()
 	if err != nil {
@@ -108,6 +122,21 @@ func main() {
 			logger.Warn("PostHog shutdown failed", zap.Error(closeErr))
 		}
 	}()
+
+	// Configure trusted proxies for IP logging
+	if tp := os.Getenv("TRUSTED_PROXIES"); tp != "" {
+		var proxies []net.IPNet
+		for _, cidr := range strings.Split(tp, ",") {
+			cidr = strings.TrimSpace(cidr)
+			_, network, err := net.ParseCIDR(cidr)
+			if err != nil {
+				logger.Fatal("invalid TRUSTED_PROXIES CIDR", zap.String("cidr", cidr), zap.Error(err))
+			}
+			proxies = append(proxies, *network)
+		}
+		auth.SetTrustedProxies(proxies)
+		logger.Info("trusted proxies configured", zap.Int("count", len(proxies)))
+	}
 
 	// Setup router
 	mux := http.NewServeMux()
@@ -159,7 +188,7 @@ func main() {
 	mux.HandleFunc("PUT /api/orgs/{id}/branding", auth.RequireAuth(jwtManager, orgHandler.UpdateBranding))
 
 	// Audit log routes
-	auditLogger := audit.NewLogger(pool)
+	auditLogger := audit.NewLogger(auditPool)
 	auditHandler := handlers.NewAuditHandler(pool)
 	mux.HandleFunc("GET /api/orgs/{id}/audit-log", auth.RequireAuth(jwtManager, auditHandler.ListAuditLog))
 	mux.HandleFunc("GET /api/orgs/{id}/audit-log/export", auth.RequireAuth(jwtManager, auditHandler.ExportAuditLog))
@@ -275,7 +304,9 @@ func main() {
 	mux.HandleFunc("DELETE /api/auth/github/connection", auth.RequireAuth(jwtManager, githubCopilotHandler.Disconnect))
 
 	// AI provider routes (org-scoped)
-	aiHandler := handlers.NewAIHandler(pool)
+	aiLimiter := ratelimit.New()
+	defer aiLimiter.Stop()
+	aiHandler := handlers.NewAIHandler(pool, aiLimiter)
 	mux.HandleFunc("GET /api/orgs/{id}/ai/providers", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.ListProviders)))
 	mux.HandleFunc("GET /api/orgs/{id}/ai/models", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.ListModels)))
 	mux.HandleFunc("POST /api/orgs/{id}/ai/chat", auth.RequireAuth(jwtManager, auth.RequireOrgMember(pool, aiHandler.Chat)))

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -2,11 +2,42 @@ package auth
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
 )
+
+// trustedProxies holds the list of trusted proxy CIDRs.
+// When non-empty, X-Forwarded-For is only trusted from these IPs.
+var trustedProxies []net.IPNet
+
+// SetTrustedProxies configures the trusted proxy CIDRs.
+// Call once at startup before registering routes.
+func SetTrustedProxies(proxies []net.IPNet) {
+	trustedProxies = proxies
+}
+
+func isTrustedProxy(remoteAddr string) bool {
+	if len(trustedProxies) == 0 {
+		return true // no config = trust all (backward compat)
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, network := range trustedProxies {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
 
 // Context keys for user information
 type contextKey string
@@ -54,7 +85,7 @@ func AuthMiddleware(jwtManager *JWTManager) func(http.Handler) http.Handler {
 			ctx = context.WithValue(ctx, UserNameKey, claims.Name)
 
 			ip := r.RemoteAddr
-			if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+			if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" && isTrustedProxy(r.RemoteAddr) {
 				ip = strings.Split(fwd, ",")[0]
 			}
 			ctx = context.WithValue(ctx, IPAddressKey, strings.TrimSpace(ip))

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -1,0 +1,155 @@
+package auth
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIPExtraction_NoTrustedProxies(t *testing.T) {
+	// When no trusted proxies are configured, X-Forwarded-For is trusted (backward compat)
+	SetTrustedProxies(nil)
+
+	handler := AuthMiddleware(&JWTManager{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := GetIPAddress(r.Context())
+		if ip != "203.0.113.50" {
+			t.Errorf("expected 203.0.113.50, got %s", ip)
+		}
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.50, 10.0.0.1")
+	req.Header.Set("Authorization", "Bearer test")
+
+	// We need a valid token, so test isTrustedProxy directly instead
+	_ = handler // handler needs a valid JWT — test the helper directly
+
+	if !isTrustedProxy("10.0.0.1:1234") {
+		t.Error("expected isTrustedProxy to return true when no proxies configured")
+	}
+}
+
+func TestIsTrustedProxy_TrustedIP(t *testing.T) {
+	_, network, _ := net.ParseCIDR("10.0.0.0/8")
+	SetTrustedProxies([]net.IPNet{*network})
+	defer SetTrustedProxies(nil)
+
+	if !isTrustedProxy("10.0.0.1:1234") {
+		t.Error("expected 10.0.0.1 to be trusted")
+	}
+}
+
+func TestIsTrustedProxy_UntrustedIP(t *testing.T) {
+	_, network, _ := net.ParseCIDR("10.0.0.0/8")
+	SetTrustedProxies([]net.IPNet{*network})
+	defer SetTrustedProxies(nil)
+
+	if isTrustedProxy("203.0.113.50:1234") {
+		t.Error("expected 203.0.113.50 to be untrusted")
+	}
+}
+
+func TestIsTrustedProxy_NoPort(t *testing.T) {
+	_, network, _ := net.ParseCIDR("10.0.0.0/8")
+	SetTrustedProxies([]net.IPNet{*network})
+	defer SetTrustedProxies(nil)
+
+	if !isTrustedProxy("10.0.0.1") {
+		t.Error("expected 10.0.0.1 without port to be trusted")
+	}
+}
+
+func TestIsTrustedProxy_InvalidIP(t *testing.T) {
+	_, network, _ := net.ParseCIDR("10.0.0.0/8")
+	SetTrustedProxies([]net.IPNet{*network})
+	defer SetTrustedProxies(nil)
+
+	if isTrustedProxy("not-an-ip") {
+		t.Error("expected invalid IP to be untrusted")
+	}
+}
+
+func TestIPExtraction_Integration(t *testing.T) {
+	// Integration test: verify the full middleware respects trusted proxies.
+	// We create a minimal JWTManager and skip the auth part by testing
+	// the IP extraction logic directly.
+	_, network, _ := net.ParseCIDR("10.0.0.0/8")
+	SetTrustedProxies([]net.IPNet{*network})
+	defer SetTrustedProxies(nil)
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		wantIP     string
+	}{
+		{
+			name:       "trusted proxy with XFF",
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "203.0.113.50, 10.0.0.1",
+			wantIP:     "203.0.113.50",
+		},
+		{
+			name:       "untrusted source with XFF",
+			remoteAddr: "203.0.113.99:1234",
+			xff:        "1.2.3.4",
+			wantIP:     "203.0.113.99:1234",
+		},
+		{
+			name:       "trusted proxy without XFF",
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "",
+			wantIP:     "10.0.0.1:1234",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the IP extraction logic from AuthMiddleware
+			ip := tt.remoteAddr
+			if fwd := tt.xff; fwd != "" && isTrustedProxy(tt.remoteAddr) {
+				parts := splitFirst(fwd, ",")
+				ip = trimSpace(parts)
+			}
+			if ip != tt.wantIP {
+				t.Errorf("got %q, want %q", ip, tt.wantIP)
+			}
+		})
+	}
+}
+
+// helpers to mirror middleware logic without importing strings
+func splitFirst(s, sep string) string {
+	for i := 0; i < len(s); i++ {
+		if string(s[i]) == sep {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func trimSpace(s string) string {
+	start, end := 0, len(s)
+	for start < end && s[start] == ' ' {
+		start++
+	}
+	for end > start && s[end-1] == ' ' {
+		end--
+	}
+	return s[start:end]
+}
+
+// Ensure context key types work correctly
+func TestContextHelpers(t *testing.T) {
+	ctx := context.WithValue(context.Background(), IPAddressKey, "1.2.3.4")
+	if ip := GetIPAddress(ctx); ip != "1.2.3.4" {
+		t.Errorf("GetIPAddress: got %q, want 1.2.3.4", ip)
+	}
+
+	if ip := GetIPAddress(context.Background()); ip != "" {
+		t.Errorf("GetIPAddress empty ctx: got %q, want empty", ip)
+	}
+}

--- a/backend/internal/db/migrations.go
+++ b/backend/internal/db/migrations.go
@@ -330,6 +330,10 @@ $$ LANGUAGE plpgsql`,
 			UNIQUE(dashboard_id, name)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_dashboard_variables_dashboard_id ON dashboard_variables(dashboard_id)`,
+
+		// Per-user rate limiting for org AI providers
+		`ALTER TABLE ai_providers ADD COLUMN IF NOT EXISTS rate_limit_per_user INTEGER DEFAULT 0`,
+		`ALTER TABLE ai_providers ADD COLUMN IF NOT EXISTS rate_limit_window_seconds INTEGER DEFAULT 3600`,
 	}
 
 	for _, migration := range migrations {

--- a/backend/internal/db/migrations/011_audit_role_setup.sql
+++ b/backend/internal/db/migrations/011_audit_role_setup.sql
@@ -1,0 +1,29 @@
+-- Audit role setup (run as PostgreSQL superuser BEFORE deploying with AUDIT_DATABASE_URL)
+--
+-- This script is NOT run by the application's auto-migration system.
+-- It creates a restricted role for audit log writes that can only INSERT,
+-- providing true immutability guarantees for compliance audits (SOC 2, ISO 27001).
+--
+-- Usage:
+--   psql -U postgres -d ace -f 011_audit_role_setup.sql
+--
+-- Then set AUDIT_DATABASE_URL in the app environment:
+--   AUDIT_DATABASE_URL=postgres://ace_audit:<password>@localhost:5432/ace?sslmode=require
+
+-- Create the restricted audit role
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ace_audit') THEN
+        CREATE ROLE ace_audit WITH LOGIN PASSWORD 'changeme';
+    END IF;
+END
+$$;
+
+-- Grant minimal privileges
+GRANT CONNECT ON DATABASE ace TO ace_audit;
+GRANT USAGE ON SCHEMA public TO ace_audit;
+GRANT INSERT ON TABLE audit_log TO ace_audit;
+
+-- Explicitly revoke dangerous operations
+REVOKE UPDATE, DELETE, TRUNCATE ON TABLE audit_log FROM ace_audit;
+REVOKE CREATE ON SCHEMA public FROM ace_audit;

--- a/backend/internal/handlers/ai_handler.go
+++ b/backend/internal/handlers/ai_handler.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/aceobservability/ace/backend/internal/crypto"
+	"github.com/aceobservability/ace/backend/internal/ratelimit"
 )
 
 // jsonError writes a JSON error response with proper encoding, preventing JSON injection.
@@ -120,38 +121,43 @@ func (bw *bytesWrittenResponseWriter) Flush() {
 
 // AIHandler orchestrates all AI endpoints: provider CRUD, model listing, and chat.
 type AIHandler struct {
-	pool *pgxpool.Pool
+	pool    *pgxpool.Pool
+	limiter *ratelimit.Limiter
 
 	// testProvider allows tests to inject a mock AIProvider, bypassing DB resolution.
 	testProvider AIProvider
 }
 
 // NewAIHandler creates a new AI handler.
-func NewAIHandler(pool *pgxpool.Pool) *AIHandler {
-	return &AIHandler{pool: pool}
+func NewAIHandler(pool *pgxpool.Pool, limiter *ratelimit.Limiter) *AIHandler {
+	return &AIHandler{pool: pool, limiter: limiter}
 }
 
 // providerRow represents a row from the ai_providers table.
 type providerRow struct {
-	ID             uuid.UUID
-	ProviderType   string
-	DisplayName    string
-	BaseURL        string
-	APIKey         *string // nullable
-	Enabled        bool
-	ModelsOverride json.RawMessage // nullable JSONB
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID                     uuid.UUID
+	ProviderType           string
+	DisplayName            string
+	BaseURL                string
+	APIKey                 *string // nullable
+	Enabled                bool
+	ModelsOverride         json.RawMessage // nullable JSONB
+	RateLimitPerUser       int
+	RateLimitWindowSeconds int
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
 }
 
 // providerJSON is the safe JSON representation of a provider (no api_key).
 type providerJSON struct {
-	ID             uuid.UUID        `json:"id"`
-	ProviderType   string           `json:"provider_type"`
-	DisplayName    string           `json:"display_name"`
-	BaseURL        string           `json:"base_url"`
-	Enabled        bool             `json:"enabled"`
-	ModelsOverride *json.RawMessage `json:"models_override,omitempty"`
+	ID                     uuid.UUID        `json:"id"`
+	ProviderType           string           `json:"provider_type"`
+	DisplayName            string           `json:"display_name"`
+	BaseURL                string           `json:"base_url"`
+	Enabled                bool             `json:"enabled"`
+	ModelsOverride         *json.RawMessage `json:"models_override,omitempty"`
+	RateLimitPerUser       int              `json:"rate_limit_per_user"`
+	RateLimitWindowSeconds int              `json:"rate_limit_window_seconds"`
 }
 
 // providerToJSON converts a providerRow to a safe JSON representation,
@@ -162,12 +168,14 @@ func providerToJSON(p providerRow) providerJSON {
 		mo = &p.ModelsOverride
 	}
 	return providerJSON{
-		ID:             p.ID,
-		ProviderType:   p.ProviderType,
-		DisplayName:    p.DisplayName,
-		BaseURL:        p.BaseURL,
-		Enabled:        p.Enabled,
-		ModelsOverride: mo,
+		ID:                     p.ID,
+		ProviderType:           p.ProviderType,
+		DisplayName:            p.DisplayName,
+		BaseURL:                p.BaseURL,
+		Enabled:                p.Enabled,
+		ModelsOverride:         mo,
+		RateLimitPerUser:       p.RateLimitPerUser,
+		RateLimitWindowSeconds: p.RateLimitWindowSeconds,
 	}
 }
 
@@ -184,22 +192,26 @@ type chatRequestBody struct {
 
 // createProviderRequest is the JSON body for creating a provider.
 type createProviderRequest struct {
-	ProviderType   string           `json:"provider_type"`
-	DisplayName    string           `json:"display_name"`
-	BaseURL        string           `json:"base_url"`
-	APIKey         string           `json:"api_key"`
-	Enabled        *bool            `json:"enabled"`
-	ModelsOverride *json.RawMessage `json:"models_override,omitempty"`
+	ProviderType           string           `json:"provider_type"`
+	DisplayName            string           `json:"display_name"`
+	BaseURL                string           `json:"base_url"`
+	APIKey                 string           `json:"api_key"`
+	Enabled                *bool            `json:"enabled"`
+	ModelsOverride         *json.RawMessage `json:"models_override,omitempty"`
+	RateLimitPerUser       *int             `json:"rate_limit_per_user,omitempty"`
+	RateLimitWindowSeconds *int             `json:"rate_limit_window_seconds,omitempty"`
 }
 
 // updateProviderRequest is the JSON body for updating a provider.
 type updateProviderRequest struct {
-	ProviderType   *string          `json:"provider_type,omitempty"`
-	DisplayName    *string          `json:"display_name,omitempty"`
-	BaseURL        *string          `json:"base_url,omitempty"`
-	APIKey         *string          `json:"api_key,omitempty"`
-	Enabled        *bool            `json:"enabled,omitempty"`
-	ModelsOverride *json.RawMessage `json:"models_override,omitempty"`
+	ProviderType           *string          `json:"provider_type,omitempty"`
+	DisplayName            *string          `json:"display_name,omitempty"`
+	BaseURL                *string          `json:"base_url,omitempty"`
+	APIKey                 *string          `json:"api_key,omitempty"`
+	Enabled                *bool            `json:"enabled,omitempty"`
+	ModelsOverride         *json.RawMessage `json:"models_override,omitempty"`
+	RateLimitPerUser       *int             `json:"rate_limit_per_user,omitempty"`
+	RateLimitWindowSeconds *int             `json:"rate_limit_window_seconds,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -229,20 +241,21 @@ func (h *AIHandler) requireAdmin(ctx context.Context, w http.ResponseWriter, use
 // Helper: resolve provider from provider_id
 // ---------------------------------------------------------------------------
 
-func (h *AIHandler) resolveProvider(ctx context.Context, providerID string, userID, orgID uuid.UUID) (AIProvider, error) {
+func (h *AIHandler) resolveProvider(ctx context.Context, providerID string, userID, orgID uuid.UUID) (AIProvider, providerQuota, error) {
 	// Test bypass
 	if h.testProvider != nil {
-		return h.testProvider, nil
+		return h.testProvider, providerQuota{}, nil
 	}
 
 	if providerID == "copilot" {
-		return h.buildCopilotProvider(ctx, userID)
+		p, err := h.buildCopilotProvider(ctx, userID)
+		return p, providerQuota{}, err
 	}
 
 	// Try to parse as UUID — it's a DB provider
 	pid, err := uuid.Parse(providerID)
 	if err != nil {
-		return nil, fmt.Errorf("unknown provider: %s", providerID)
+		return nil, providerQuota{}, fmt.Errorf("unknown provider: %s", providerID)
 	}
 
 	return h.buildDBProvider(ctx, pid, orgID)
@@ -269,31 +282,46 @@ func (h *AIHandler) buildCopilotProvider(ctx context.Context, userID uuid.UUID) 
 	return &CopilotProvider{EncryptedGHToken: encryptedToken}, nil
 }
 
-func (h *AIHandler) buildDBProvider(ctx context.Context, providerID, orgID uuid.UUID) (*OpenAICompatibleProvider, error) {
+// providerQuota holds the per-user rate limit config for a provider.
+type providerQuota struct {
+	ProviderID uuid.UUID
+	Limit      int
+	WindowSecs int
+}
+
+func (h *AIHandler) buildDBProvider(ctx context.Context, providerID, orgID uuid.UUID) (*OpenAICompatibleProvider, providerQuota, error) {
 	if h.pool == nil {
-		return nil, fmt.Errorf("failed to load provider")
+		return nil, providerQuota{}, fmt.Errorf("failed to load provider")
 	}
 
 	var p providerRow
 	err := h.pool.QueryRow(ctx,
-		`SELECT id, provider_type, display_name, base_url, api_key, enabled, models_override
+		`SELECT id, provider_type, display_name, base_url, api_key, enabled, models_override,
+		        rate_limit_per_user, rate_limit_window_seconds
 		 FROM ai_providers WHERE id = $1 AND organization_id = $2`,
 		providerID, orgID,
-	).Scan(&p.ID, &p.ProviderType, &p.DisplayName, &p.BaseURL, &p.APIKey, &p.Enabled, &p.ModelsOverride)
+	).Scan(&p.ID, &p.ProviderType, &p.DisplayName, &p.BaseURL, &p.APIKey, &p.Enabled, &p.ModelsOverride,
+		&p.RateLimitPerUser, &p.RateLimitWindowSeconds)
 	if err != nil {
-		return nil, fmt.Errorf("provider not found")
+		return nil, providerQuota{}, fmt.Errorf("provider not found")
 	}
 
 	apiKey := ""
 	if p.APIKey != nil && *p.APIKey != "" {
 		decrypted, err := crypto.DecryptToken(*p.APIKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt provider API key: %w", err)
+			return nil, providerQuota{}, fmt.Errorf("failed to decrypt provider API key: %w", err)
 		}
 		apiKey = decrypted
 	}
 
-	return NewOpenAICompatibleProvider(p.BaseURL, apiKey, p.DisplayName), nil
+	quota := providerQuota{
+		ProviderID: p.ID,
+		Limit:      p.RateLimitPerUser,
+		WindowSecs: p.RateLimitWindowSeconds,
+	}
+
+	return NewOpenAICompatibleProvider(p.BaseURL, apiKey, p.DisplayName), quota, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -319,7 +347,8 @@ func (h *AIHandler) ListProviders(w http.ResponseWriter, r *http.Request) {
 	var providers []providerJSON
 	if h.pool != nil {
 		rows, err := h.pool.Query(ctx,
-			`SELECT id, provider_type, display_name, base_url, enabled, models_override
+			`SELECT id, provider_type, display_name, base_url, enabled, models_override,
+			        rate_limit_per_user, rate_limit_window_seconds
 			 FROM ai_providers WHERE organization_id = $1 AND enabled = true`,
 			orgID,
 		)
@@ -329,7 +358,7 @@ func (h *AIHandler) ListProviders(w http.ResponseWriter, r *http.Request) {
 			defer rows.Close()
 			for rows.Next() {
 				var p providerRow
-				if err := rows.Scan(&p.ID, &p.ProviderType, &p.DisplayName, &p.BaseURL, &p.Enabled, &p.ModelsOverride); err != nil {
+				if err := rows.Scan(&p.ID, &p.ProviderType, &p.DisplayName, &p.BaseURL, &p.Enabled, &p.ModelsOverride, &p.RateLimitPerUser, &p.RateLimitWindowSeconds); err != nil {
 					zap.L().Error("list providers row scan failed", zap.Error(err))
 					continue
 				}
@@ -410,7 +439,7 @@ func (h *AIHandler) ListModels(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
-	provider, err := h.resolveProvider(ctx, providerID, userID, orgID)
+	provider, _, err := h.resolveProvider(ctx, providerID, userID, orgID)
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
@@ -503,10 +532,32 @@ func (h *AIHandler) Chat(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Resolve provider
-	provider, err := h.resolveProvider(ctx, reqBody.ProviderID, userID, orgID)
+	provider, quota, err := h.resolveProvider(ctx, reqBody.ProviderID, userID, orgID)
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
+	}
+
+	// Per-user rate limiting
+	if h.limiter != nil && quota.Limit > 0 {
+		allowed, remaining, resetAt := h.limiter.Allow(userID, quota.ProviderID, quota.Limit, quota.WindowSecs)
+		if !allowed {
+			retryAfter := int(time.Until(resetAt).Seconds()) + 1
+			w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+			w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%d", quota.Limit))
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", resetAt.Unix()))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error":               "rate limit exceeded",
+				"retry_after_seconds": retryAfter,
+			})
+			return
+		}
+		w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%d", quota.Limit))
+		w.Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", remaining))
+		w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", resetAt.Unix()))
 	}
 
 	// System prompt injection
@@ -617,13 +668,22 @@ func (h *AIHandler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 		enabled = *reqBody.Enabled
 	}
 
+	rateLimitPerUser := 0
+	if reqBody.RateLimitPerUser != nil {
+		rateLimitPerUser = *reqBody.RateLimitPerUser
+	}
+	rateLimitWindowSeconds := 3600
+	if reqBody.RateLimitWindowSeconds != nil {
+		rateLimitWindowSeconds = *reqBody.RateLimitWindowSeconds
+	}
+
 	var p providerRow
 	err := h.pool.QueryRow(ctx,
-		`INSERT INTO ai_providers (organization_id, provider_type, display_name, base_url, api_key, enabled, models_override)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)
-		 RETURNING id, provider_type, display_name, base_url, enabled, models_override, created_at, updated_at`,
-		orgID, reqBody.ProviderType, reqBody.DisplayName, reqBody.BaseURL, encryptedKey, enabled, reqBody.ModelsOverride,
-	).Scan(&p.ID, &p.ProviderType, &p.DisplayName, &p.BaseURL, &p.Enabled, &p.ModelsOverride, &p.CreatedAt, &p.UpdatedAt)
+		`INSERT INTO ai_providers (organization_id, provider_type, display_name, base_url, api_key, enabled, models_override, rate_limit_per_user, rate_limit_window_seconds)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 RETURNING id, provider_type, display_name, base_url, enabled, models_override, rate_limit_per_user, rate_limit_window_seconds, created_at, updated_at`,
+		orgID, reqBody.ProviderType, reqBody.DisplayName, reqBody.BaseURL, encryptedKey, enabled, reqBody.ModelsOverride, rateLimitPerUser, rateLimitWindowSeconds,
+	).Scan(&p.ID, &p.ProviderType, &p.DisplayName, &p.BaseURL, &p.Enabled, &p.ModelsOverride, &p.RateLimitPerUser, &p.RateLimitWindowSeconds, &p.CreatedAt, &p.UpdatedAt)
 	if err != nil {
 		zap.L().Error("failed to create provider", zap.Error(err))
 		jsonError(w, "failed to create provider", http.StatusInternalServerError)
@@ -676,10 +736,12 @@ func (h *AIHandler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 	// Load existing provider
 	var existing providerRow
 	err = h.pool.QueryRow(ctx,
-		`SELECT id, provider_type, display_name, base_url, api_key, enabled, models_override
+		`SELECT id, provider_type, display_name, base_url, api_key, enabled, models_override,
+		        rate_limit_per_user, rate_limit_window_seconds
 		 FROM ai_providers WHERE id = $1 AND organization_id = $2`,
 		pid, orgID,
-	).Scan(&existing.ID, &existing.ProviderType, &existing.DisplayName, &existing.BaseURL, &existing.APIKey, &existing.Enabled, &existing.ModelsOverride)
+	).Scan(&existing.ID, &existing.ProviderType, &existing.DisplayName, &existing.BaseURL, &existing.APIKey, &existing.Enabled, &existing.ModelsOverride,
+		&existing.RateLimitPerUser, &existing.RateLimitWindowSeconds)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			jsonError(w, "provider not found", http.StatusNotFound)
@@ -705,6 +767,12 @@ func (h *AIHandler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 	if reqBody.ModelsOverride != nil {
 		existing.ModelsOverride = *reqBody.ModelsOverride
 	}
+	if reqBody.RateLimitPerUser != nil {
+		existing.RateLimitPerUser = *reqBody.RateLimitPerUser
+	}
+	if reqBody.RateLimitWindowSeconds != nil {
+		existing.RateLimitWindowSeconds = *reqBody.RateLimitWindowSeconds
+	}
 
 	// Fix #1: SSRF validation on base_url (validate the final URL after applying updates)
 	if err := validateBaseURL(existing.BaseURL); err != nil {
@@ -728,12 +796,14 @@ func (h *AIHandler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 	var updated providerRow
 	err = h.pool.QueryRow(ctx,
 		`UPDATE ai_providers
-		 SET provider_type = $1, display_name = $2, base_url = $3, api_key = $4, enabled = $5, models_override = $6, updated_at = NOW()
-		 WHERE id = $7 AND organization_id = $8
-		 RETURNING id, provider_type, display_name, base_url, enabled, models_override, created_at, updated_at`,
+		 SET provider_type = $1, display_name = $2, base_url = $3, api_key = $4, enabled = $5, models_override = $6,
+		     rate_limit_per_user = $7, rate_limit_window_seconds = $8, updated_at = NOW()
+		 WHERE id = $9 AND organization_id = $10
+		 RETURNING id, provider_type, display_name, base_url, enabled, models_override, rate_limit_per_user, rate_limit_window_seconds, created_at, updated_at`,
 		existing.ProviderType, existing.DisplayName, existing.BaseURL, encryptedKey, existing.Enabled, existing.ModelsOverride,
-		pid, orgID,
-	).Scan(&updated.ID, &updated.ProviderType, &updated.DisplayName, &updated.BaseURL, &updated.Enabled, &updated.ModelsOverride, &updated.CreatedAt, &updated.UpdatedAt)
+		existing.RateLimitPerUser, existing.RateLimitWindowSeconds, pid, orgID,
+	).Scan(&updated.ID, &updated.ProviderType, &updated.DisplayName, &updated.BaseURL, &updated.Enabled, &updated.ModelsOverride,
+		&updated.RateLimitPerUser, &updated.RateLimitWindowSeconds, &updated.CreatedAt, &updated.UpdatedAt)
 	if err != nil {
 		zap.L().Error("failed to update provider", zap.Error(err))
 		jsonError(w, "failed to update provider", http.StatusInternalServerError)
@@ -819,7 +889,7 @@ func (h *AIHandler) TestProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Load provider from DB
-	provider, err := h.buildDBProvider(ctx, pid, orgID)
+	provider, _, err := h.buildDBProvider(ctx, pid, orgID)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/backend/internal/handlers/ai_handler_test.go
+++ b/backend/internal/handlers/ai_handler_test.go
@@ -62,7 +62,7 @@ func (m *mockAIProvider) Chat(_ context.Context, req ChatRequest, w http.Respons
 func TestListProviders_EmptyArray_WhenNoProviders(t *testing.T) {
 	// With a nil pool we cannot query DB; the handler should gracefully
 	// return an empty array when both DB paths fail.
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -88,7 +88,7 @@ func TestListProviders_EmptyArray_WhenNoProviders(t *testing.T) {
 // === ListModels tests =======================================================
 
 func TestListModels_UnknownProvider_Returns404(t *testing.T) {
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -104,7 +104,7 @@ func TestListModels_UnknownProvider_Returns404(t *testing.T) {
 }
 
 func TestListModels_MissingProviderID_Returns400(t *testing.T) {
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -124,7 +124,7 @@ func TestListModels_MissingProviderID_Returns400(t *testing.T) {
 func TestChat_SystemPromptPrepended_ForKnownDatasource(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret-for-ai-handler-tests")
 
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	mock := &mockAIProvider{}
 	// Inject the mock via the testProvider bypass.
@@ -181,7 +181,7 @@ func TestChat_SystemPromptPrepended_ForKnownDatasource(t *testing.T) {
 func TestChat_DefaultSystemPrompt_WhenDatasourceUnknown(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret-for-ai-handler-tests")
 
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 	mock := &mockAIProvider{}
 	h.testProvider = mock
 
@@ -222,7 +222,7 @@ func TestChat_CopilotProvider_RoutesByProviderID(t *testing.T) {
 	// When provider_id is "copilot" and there's no DB, we get an error
 	// about not being able to load the copilot connection. This verifies
 	// the routing logic tries the copilot path.
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -254,7 +254,7 @@ func TestChat_CopilotProvider_RoutesByProviderID(t *testing.T) {
 func TestChat_UUIDProvider_RoutesByProviderID(t *testing.T) {
 	// When provider_id is a UUID and there's no DB, we get an error about
 	// not being able to load the provider. This verifies UUID routing.
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -282,7 +282,7 @@ func TestChat_UUIDProvider_RoutesByProviderID(t *testing.T) {
 }
 
 func TestChat_InvalidBody_Returns400(t *testing.T) {
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -300,7 +300,7 @@ func TestChat_InvalidBody_Returns400(t *testing.T) {
 }
 
 func TestChat_EmptyMessages_Returns400(t *testing.T) {
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -329,7 +329,7 @@ func TestChat_EmptyMessages_Returns400(t *testing.T) {
 
 func TestCreateProvider_NonAdmin_Returns403(t *testing.T) {
 	// With nil pool, the admin check query will fail, which should be 403.
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -356,7 +356,7 @@ func TestCreateProvider_NonAdmin_Returns403(t *testing.T) {
 }
 
 func TestUpdateProvider_NonAdmin_Returns403(t *testing.T) {
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -381,7 +381,7 @@ func TestUpdateProvider_NonAdmin_Returns403(t *testing.T) {
 }
 
 func TestDeleteProvider_NonAdmin_Returns403(t *testing.T) {
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -400,7 +400,7 @@ func TestDeleteProvider_NonAdmin_Returns403(t *testing.T) {
 }
 
 func TestTestProvider_NonAdmin_Returns403(t *testing.T) {
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	userID := uuid.New()
 	orgID := uuid.New()
@@ -423,7 +423,7 @@ func TestTestProvider_NonAdmin_Returns403(t *testing.T) {
 func TestChat_ToolDegradation_RetriesWithoutTools(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret-for-ai-handler-tests")
 
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	callCount := 0
 	mock := &mockToolDegradationProvider{
@@ -476,7 +476,7 @@ func TestChat_ToolDegradation_RetriesWithoutTools(t *testing.T) {
 func TestChat_ToolDegradation_NonToolError_NotRetried(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret-for-ai-handler-tests")
 
-	h := NewAIHandler(nil)
+	h := NewAIHandler(nil, nil)
 
 	callCount := 0
 	mock := &mockToolDegradationProvider{

--- a/backend/internal/handlers/system_prompts.go
+++ b/backend/internal/handlers/system_prompts.go
@@ -48,7 +48,9 @@ Panel type selection:
 - Value as percentage of max → gauge
 - Value over time → line_chart
 - Comparison across categories → bar_chart
-- Distribution → pie`,
+- Distribution → pie
+
+When the user asks to modify an existing dashboard (the current spec will be in the conversation), call generate_dashboard with the complete updated spec. Keep panels the user did not ask to change.`,
 
 	"tempo": `You are an expert in distributed tracing and Grafana Tempo. Help with trace queries and analysis.
 Tempo uses TraceQL: {.http.status_code=500 && duration>200ms}

--- a/backend/internal/ratelimit/limiter.go
+++ b/backend/internal/ratelimit/limiter.go
@@ -1,0 +1,97 @@
+package ratelimit
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type key struct {
+	UserID     uuid.UUID
+	ProviderID uuid.UUID
+}
+
+type window struct {
+	count     int
+	expiresAt time.Time
+}
+
+// Limiter implements a simple fixed-window rate limiter keyed by (user, provider).
+type Limiter struct {
+	mu      sync.Mutex
+	windows map[key]*window
+	done    chan struct{}
+}
+
+// New creates a Limiter and starts a background goroutine that
+// sweeps expired entries every 5 minutes.
+func New() *Limiter {
+	l := &Limiter{
+		windows: make(map[key]*window),
+		done:    make(chan struct{}),
+	}
+	go l.cleanup()
+	return l
+}
+
+// Allow checks whether the user may make a request to the given provider.
+// limit is the max requests allowed in the window; windowSecs is the window duration.
+// Returns whether the request is allowed, the remaining quota, and when the window resets.
+func (l *Limiter) Allow(userID, providerID uuid.UUID, limit, windowSecs int) (allowed bool, remaining int, resetAt time.Time) {
+	if limit <= 0 {
+		return true, 0, time.Time{}
+	}
+
+	k := key{UserID: userID, ProviderID: providerID}
+	now := time.Now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	w, exists := l.windows[k]
+	if !exists || now.After(w.expiresAt) {
+		w = &window{
+			count:     0,
+			expiresAt: now.Add(time.Duration(windowSecs) * time.Second),
+		}
+		l.windows[k] = w
+	}
+
+	if w.count >= limit {
+		return false, 0, w.expiresAt
+	}
+
+	w.count++
+	return true, limit - w.count, w.expiresAt
+}
+
+// Stop terminates the background cleanup goroutine.
+func (l *Limiter) Stop() {
+	close(l.done)
+}
+
+func (l *Limiter) cleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-l.done:
+			return
+		case <-ticker.C:
+			l.sweep()
+		}
+	}
+}
+
+func (l *Limiter) sweep() {
+	now := time.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for k, w := range l.windows {
+		if now.After(w.expiresAt) {
+			delete(l.windows, k)
+		}
+	}
+}

--- a/backend/internal/ratelimit/limiter_test.go
+++ b/backend/internal/ratelimit/limiter_test.go
@@ -1,0 +1,154 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestAllow_UnlimitedWhenZero(t *testing.T) {
+	l := New()
+	defer l.Stop()
+
+	uid := uuid.New()
+	pid := uuid.New()
+
+	allowed, _, _ := l.Allow(uid, pid, 0, 3600)
+	if !allowed {
+		t.Error("expected unlimited when limit=0")
+	}
+}
+
+func TestAllow_WithinLimit(t *testing.T) {
+	l := New()
+	defer l.Stop()
+
+	uid := uuid.New()
+	pid := uuid.New()
+
+	for i := 0; i < 3; i++ {
+		allowed, remaining, _ := l.Allow(uid, pid, 3, 3600)
+		if !allowed {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+		if remaining != 3-i-1 {
+			t.Errorf("request %d: expected remaining %d, got %d", i+1, 3-i-1, remaining)
+		}
+	}
+}
+
+func TestAllow_ExceedsLimit(t *testing.T) {
+	l := New()
+	defer l.Stop()
+
+	uid := uuid.New()
+	pid := uuid.New()
+
+	for i := 0; i < 3; i++ {
+		l.Allow(uid, pid, 3, 3600)
+	}
+
+	allowed, remaining, resetAt := l.Allow(uid, pid, 3, 3600)
+	if allowed {
+		t.Error("4th request should be denied")
+	}
+	if remaining != 0 {
+		t.Errorf("expected remaining 0, got %d", remaining)
+	}
+	if resetAt.IsZero() {
+		t.Error("expected non-zero resetAt")
+	}
+}
+
+func TestAllow_SeparateUsers(t *testing.T) {
+	l := New()
+	defer l.Stop()
+
+	uid1 := uuid.New()
+	uid2 := uuid.New()
+	pid := uuid.New()
+
+	// Exhaust user1
+	for i := 0; i < 2; i++ {
+		l.Allow(uid1, pid, 2, 3600)
+	}
+
+	// user2 should still be allowed
+	allowed, _, _ := l.Allow(uid2, pid, 2, 3600)
+	if !allowed {
+		t.Error("user2 should be allowed independently of user1")
+	}
+}
+
+func TestAllow_SeparateProviders(t *testing.T) {
+	l := New()
+	defer l.Stop()
+
+	uid := uuid.New()
+	pid1 := uuid.New()
+	pid2 := uuid.New()
+
+	// Exhaust provider1
+	for i := 0; i < 2; i++ {
+		l.Allow(uid, pid1, 2, 3600)
+	}
+
+	// provider2 should still be allowed
+	allowed, _, _ := l.Allow(uid, pid2, 2, 3600)
+	if !allowed {
+		t.Error("provider2 should be allowed independently of provider1")
+	}
+}
+
+func TestSweep_RemovesExpired(t *testing.T) {
+	l := New()
+	defer l.Stop()
+
+	uid := uuid.New()
+	pid := uuid.New()
+
+	// Create a window with 1-second duration
+	l.Allow(uid, pid, 10, 1)
+
+	// Wait for it to expire
+	time.Sleep(1100 * time.Millisecond)
+
+	l.sweep()
+
+	l.mu.Lock()
+	_, exists := l.windows[key{UserID: uid, ProviderID: pid}]
+	l.mu.Unlock()
+
+	if exists {
+		t.Error("expected expired window to be swept")
+	}
+}
+
+func TestAllow_WindowReset(t *testing.T) {
+	l := New()
+	defer l.Stop()
+
+	uid := uuid.New()
+	pid := uuid.New()
+
+	// Exhaust with 1-second window
+	for i := 0; i < 2; i++ {
+		l.Allow(uid, pid, 2, 1)
+	}
+	allowed, _, _ := l.Allow(uid, pid, 2, 1)
+	if allowed {
+		t.Error("should be denied within window")
+	}
+
+	// Wait for window to expire
+	time.Sleep(1100 * time.Millisecond)
+
+	allowed, remaining, _ := l.Allow(uid, pid, 2, 1)
+	if !allowed {
+		t.Error("should be allowed after window expires")
+	}
+	if remaining != 1 {
+		t.Errorf("expected remaining 1, got %d", remaining)
+	}
+}

--- a/frontend/src/api/aiProviders.ts
+++ b/frontend/src/api/aiProviders.ts
@@ -24,6 +24,8 @@ export interface AIProviderInfo {
   base_url: string
   enabled: boolean
   models_override?: Array<{ id: string; name: string }>
+  rate_limit_per_user: number
+  rate_limit_window_seconds: number
   created_at: string
   updated_at: string
 }
@@ -35,6 +37,8 @@ export interface CreateProviderRequest {
   api_key?: string
   enabled?: boolean
   models_override?: Array<{ id: string; name: string }>
+  rate_limit_per_user?: number
+  rate_limit_window_seconds?: number
 }
 
 export interface UpdateProviderRequest {
@@ -43,6 +47,8 @@ export interface UpdateProviderRequest {
   api_key?: string
   enabled?: boolean
   models_override?: Array<{ id: string; name: string }>
+  rate_limit_per_user?: number
+  rate_limit_window_seconds?: number
 }
 
 interface AIModel {

--- a/frontend/src/components/AIProviderSettings.vue
+++ b/frontend/src/components/AIProviderSettings.vue
@@ -42,6 +42,8 @@ const formDisplayName = ref('')
 const formBaseUrl = ref('')
 const formApiKey = ref('')
 const formEnabled = ref(true)
+const formRateLimitPerUser = ref(0)
+const formRateLimitWindowSeconds = ref(3600)
 const formLoading = ref(false)
 const formError = ref<string | null>(null)
 
@@ -119,6 +121,8 @@ function openAddForm() {
   formBaseUrl.value = urlHints.openai
   formApiKey.value = ''
   formEnabled.value = true
+  formRateLimitPerUser.value = 0
+  formRateLimitWindowSeconds.value = 3600
   formError.value = null
   showForm.value = true
 }
@@ -130,6 +134,8 @@ function openEditForm(provider: AIProviderInfo) {
   formBaseUrl.value = provider.base_url
   formApiKey.value = ''
   formEnabled.value = provider.enabled
+  formRateLimitPerUser.value = provider.rate_limit_per_user ?? 0
+  formRateLimitWindowSeconds.value = provider.rate_limit_window_seconds ?? 3600
   formError.value = null
   showForm.value = true
   openMenuId.value = null
@@ -157,6 +163,8 @@ async function submitForm() {
         display_name: formDisplayName.value,
         base_url: formBaseUrl.value,
         enabled: formEnabled.value,
+        rate_limit_per_user: formRateLimitPerUser.value,
+        rate_limit_window_seconds: formRateLimitWindowSeconds.value,
       }
       if (formApiKey.value) data.api_key = formApiKey.value
       await updateAIProvider(props.orgId, editingId.value, data)
@@ -166,6 +174,8 @@ async function submitForm() {
         display_name: formDisplayName.value,
         base_url: formBaseUrl.value,
         enabled: formEnabled.value,
+        rate_limit_per_user: formRateLimitPerUser.value,
+        rate_limit_window_seconds: formRateLimitWindowSeconds.value,
       }
       if (formApiKey.value) data.api_key = formApiKey.value
       await createAIProvider(props.orgId, data)
@@ -292,6 +302,18 @@ function cancelDelete() {
               }"
             >
               {{ modelCount(provider) }} models
+            </span>
+
+            <!-- Rate limit badge -->
+            <span
+              v-if="provider.rate_limit_per_user > 0"
+              class="inline-flex px-2 py-0.5 rounded-sm text-xs font-medium font-mono"
+              :style="{
+                backgroundColor: 'color-mix(in srgb, var(--color-tertiary) 10%, transparent)',
+                color: 'var(--color-tertiary)',
+              }"
+            >
+              {{ provider.rate_limit_per_user }}/{{ provider.rate_limit_window_seconds >= 3600 ? `${provider.rate_limit_window_seconds / 3600}hr` : `${provider.rate_limit_window_seconds / 60}min` }}
             </span>
 
             <!-- Enabled/Disabled badge -->
@@ -455,6 +477,30 @@ function cancelDelete() {
           <input v-model="formEnabled" type="checkbox" class="w-auto m-0" />
           Enabled
         </label>
+
+        <!-- Rate limit -->
+        <div class="flex gap-3">
+          <label class="flex flex-col gap-1 text-xs font-medium flex-1" :style="{ color: 'var(--color-on-surface-variant)' }">
+            Rate limit per user (0 = unlimited)
+            <input
+              v-model.number="formRateLimitPerUser"
+              type="number"
+              min="0"
+              class="px-3 py-2 rounded-sm text-sm focus:outline-none"
+              :style="{ backgroundColor: 'var(--color-surface-container-high)', color: 'var(--color-on-surface)', border: '1px solid var(--color-outline-variant)' }"
+            />
+          </label>
+          <label class="flex flex-col gap-1 text-xs font-medium flex-1" :style="{ color: 'var(--color-on-surface-variant)' }">
+            Window (seconds)
+            <input
+              v-model.number="formRateLimitWindowSeconds"
+              type="number"
+              min="60"
+              class="px-3 py-2 rounded-sm text-sm focus:outline-none"
+              :style="{ backgroundColor: 'var(--color-surface-container-high)', color: 'var(--color-on-surface)', border: '1px solid var(--color-outline-variant)' }"
+            />
+          </label>
+        </div>
 
         <!-- Form error -->
         <div v-if="formError" class="text-xs" :style="{ color: 'var(--color-error)' }">{{ formError }}</div>

--- a/frontend/src/components/AiSidebar.vue
+++ b/frontend/src/components/AiSidebar.vue
@@ -67,7 +67,16 @@ async function handleSend(userMessage: string) {
   const dsType = currentContext.value?.datasourceType ?? ''
   const dsName = currentContext.value?.datasourceName ?? ''
   const tools = getToolsForDatasourceType(dsType)
-  dashboardSpec.value = null
+
+  // Inject current spec so the AI can refine it
+  if (dashboardSpec.value) {
+    requestMessages.push({
+      role: 'system',
+      content: `Current dashboard spec to refine:\n${JSON.stringify(dashboardSpec.value, null, 2)}\nModify and call generate_dashboard with the full updated spec.`,
+    })
+  }
+
+  const isRefinement = !!dashboardSpec.value
 
   const result = await generate(requestMessages, tools, dsName, {
     onContent(text) {
@@ -77,7 +86,9 @@ async function handleSend(userMessage: string) {
       dashboardSpec.value = spec
       chatMessages.value.push({
         role: 'assistant',
-        content: 'Dashboard generated. See the preview below.',
+        content: isRefinement
+          ? 'Dashboard updated. See the revised preview below.'
+          : 'Dashboard generated. See the preview below.',
         dashboardSpec: spec,
       })
     },

--- a/frontend/src/components/AppSidebar.spec.ts
+++ b/frontend/src/components/AppSidebar.spec.ts
@@ -47,6 +47,8 @@ vi.mock('../composables/useFavorites', () => ({
     toggleFavorite: vi.fn(),
     isFavorite: () => false,
     addRecent: vi.fn(),
+    favoriteRoute: () => '/app',
+    favoritesForType: () => [],
   }),
 }))
 

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -27,7 +27,7 @@ const route = useRoute()
 const { user } = useAuth()
 const { organizations, currentOrg, selectOrganization } = useOrganization()
 const { expandedSection, isPinned, currentRouteSection, toggleSection, togglePin } = useSidebar()
-const { favorites, recentDashboards } = useFavorites()
+const { favorites, recentDashboards, favoriteRoute, favoritesForType } = useFavorites()
 const { isOpen: aiSidebarOpen, toggle: toggleAiSidebar } = useAiSidebar()
 
 const userMenuOpen = ref(false)
@@ -133,6 +133,18 @@ const dashboardRecents = computed(() => {
   return recentDashboards.value.slice(0, 5)
 })
 
+const sectionTypeMap: Record<string, 'dashboard' | 'service' | 'alert' | 'explore'> = {
+  services: 'service',
+  alerts: 'alert',
+  explore: 'explore',
+}
+
+const sectionFavorites = computed(() => {
+  const section = expandedSection.value
+  if (!section || !sectionTypeMap[section]) return []
+  return favoritesForType(sectionTypeMap[section]!).slice(0, 5)
+})
+
 // Search filtering
 const filteredSubNav = computed(() => {
   if (!searchQuery.value.trim()) return currentSubNav.value
@@ -148,6 +160,12 @@ const filteredFavorites = computed(() => {
   )
 })
 
+const filteredSectionFavorites = computed(() => {
+  if (!searchQuery.value.trim()) return sectionFavorites.value
+  const q = searchQuery.value.toLowerCase()
+  return sectionFavorites.value.filter((f) => f.title.toLowerCase().includes(q))
+})
+
 const filteredRecents = computed(() => {
   if (!searchQuery.value.trim()) return dashboardRecents.value
   const q = searchQuery.value.toLowerCase()
@@ -158,7 +176,7 @@ const hasAnyResults = computed(() => {
   if (expandedSection.value === 'dashboards') {
     return filteredFavorites.value.length > 0 || filteredRecents.value.length > 0 || !searchQuery.value.trim()
   }
-  return filteredSubNav.value.length > 0
+  return filteredSubNav.value.length > 0 || filteredSectionFavorites.value.length > 0
 })
 
 const allNavigableItems = computed<{ path: string }[]>(() => {
@@ -172,6 +190,9 @@ const allNavigableItems = computed<{ path: string }[]>(() => {
     }
     items.push({ path: '/app/dashboards' })
   } else {
+    for (const f of filteredSectionFavorites.value) {
+      items.push({ path: favoriteRoute(f) })
+    }
     for (const item of filteredSubNav.value) {
       items.push({ path: item.path })
     }
@@ -207,8 +228,12 @@ function handleOrgClick() {
 }
 
 function handleSelectOrg(orgId: string) {
+  const previousOrgId = currentOrg.value?.id
   selectOrganization(orgId)
   orgMenuOpen.value = false
+  if (orgId !== previousOrgId) {
+    router.push('/app')
+  }
 }
 
 function handleAvatarClick() {
@@ -517,15 +542,45 @@ onUnmounted(() => {
           </div>
         </template>
 
-        <!-- Non-dashboard sections: static sub-nav -->
+        <!-- Non-dashboard sections: favorites + static sub-nav -->
         <template v-else>
+          <!-- Section favorites -->
+          <template v-if="sectionTypeMap[expandedSection!]">
+            <div v-if="filteredSectionFavorites.length > 0" role="group" aria-labelledby="sidebar-section-favorites-label">
+              <div
+                id="sidebar-section-favorites-label"
+                :style="{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '11px',
+                  fontWeight: '600',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                  color: 'var(--color-outline)',
+                  padding: '6px 10px 4px',
+                }"
+              >Favorites</div>
+              <button
+                v-for="(fav, idx) in filteredSectionFavorites"
+                :key="fav.id"
+                :data-testid="`sidebar-fav-${fav.id}`"
+                class="sidebar-subnav-item"
+                :class="{ highlighted: highlightedIndex === idx }"
+                @click="handleSubNavNavigate(favoriteRoute(fav))"
+              >
+                <Star :size="14" fill="currentColor" :style="{ color: 'var(--color-primary)', flexShrink: 0 }" />
+                <span class="flex-1 truncate">{{ fav.title }}</span>
+              </button>
+              <div :style="{ height: '1px', backgroundColor: 'var(--color-stroke-subtle)', margin: '4px 10px' }" />
+            </div>
+          </template>
+
           <button
             v-for="(item, idx) in filteredSubNav"
             :key="item.id"
             :data-testid="`sidebar-subnav-${item.id}`"
             :aria-current="isSubNavActive(item) ? 'page' : undefined"
             class="sidebar-subnav-item"
-            :class="{ highlighted: highlightedIndex === idx }"
+            :class="{ highlighted: highlightedIndex === filteredSectionFavorites.length + idx }"
             :style="{
               fontWeight: isSubNavActive(item) ? '500' : '400',
               color: isSubNavActive(item) ? 'var(--color-primary)' : 'var(--color-on-surface-variant)',
@@ -536,7 +591,7 @@ onUnmounted(() => {
           >{{ item.label }}</button>
 
           <!-- No search results -->
-          <div v-if="searchQuery.trim() && filteredSubNav.length === 0" data-testid="sidebar-no-results" class="sidebar-empty-hint">
+          <div v-if="searchQuery.trim() && !hasAnyResults" data-testid="sidebar-no-results" class="sidebar-empty-hint">
             <span>No matches</span>
           </div>
         </template>

--- a/frontend/src/components/DashboardSpecPreview.vue
+++ b/frontend/src/components/DashboardSpecPreview.vue
@@ -13,7 +13,7 @@ import {
   Table,
   TrendingUp,
 } from 'lucide-vue-next'
-import { computed, onMounted, ref, type Component } from 'vue'
+import { computed, onMounted, ref, watch, type Component } from 'vue'
 import { RouterLink } from 'vue-router'
 import { queryDataSource } from '../api/datasources'
 import { useDatasource } from '../composables/useDatasource'
@@ -134,6 +134,14 @@ async function runDryRuns() {
 onMounted(() => {
   runDryRuns()
 })
+
+watch(() => props.spec, () => {
+  savedDashboardId.value = null
+  saveSuccess.value = false
+  saveError.value = null
+  validationErrors.value = []
+  runDryRuns()
+}, { deep: true })
 
 // --- Save ---
 

--- a/frontend/src/composables/useDashboardGeneration.spec.ts
+++ b/frontend/src/composables/useDashboardGeneration.spec.ts
@@ -180,8 +180,8 @@ describe('useDashboardGeneration', () => {
         'MyDS',
       )
 
-      // Should set error because no generate_dashboard was called
-      expect(error.value).toBe('Could not generate a dashboard. Try a more specific prompt.')
+      // Content-only response (no spec) is valid (e.g. during refinement), so no error
+      expect(error.value).toBeNull()
     })
 
     it('sets error when max iterations exhausted without generate_dashboard', async () => {

--- a/frontend/src/composables/useDashboardGeneration.ts
+++ b/frontend/src/composables/useDashboardGeneration.ts
@@ -103,7 +103,11 @@ export function useDashboardGeneration(
 
             resultSpec = spec
             callbacks?.onDashboardSpec?.(spec)
-            return { spec: resultSpec, content: lastContent }
+            requestMessages.push(
+              { role: 'assistant', content: null, tool_calls: [tc] },
+              { role: 'tool', tool_call_id: tc.id, content: JSON.stringify(spec) },
+            )
+            break
           }
 
           const statusEntry: ToolStatus = { name: tc.function.name, status: 'running' }
@@ -125,9 +129,11 @@ export function useDashboardGeneration(
             { role: 'tool', tool_call_id: tc.id, content: result },
           )
         }
+
+        if (resultSpec) break
       }
 
-      if (!resultSpec) {
+      if (!resultSpec && !lastContent) {
         error.value = 'Could not generate a dashboard. Try a more specific prompt.'
       }
     } catch (e) {

--- a/frontend/src/composables/useFavorites.ts
+++ b/frontend/src/composables/useFavorites.ts
@@ -88,6 +88,28 @@ function addRecent(dashboard: RecentDashboard): void {
   persistRecents()
 }
 
+function favoriteRoute(item: FavoriteItem): string {
+  switch (item.type) {
+    case 'dashboard':
+      return `/app/dashboards/${item.id}`
+    case 'service':
+      return '/app/services'
+    case 'alert':
+      return '/app/alerts'
+    case 'explore': {
+      const [, exploreType, ...queryParts] = item.id.split('::')
+      const query = queryParts.join('::')
+      return `/app/explore/${exploreType || 'metrics'}?q=${encodeURIComponent(query || '')}`
+    }
+    default:
+      return '/app'
+  }
+}
+
+function favoritesForType(type: FavoriteItem['type']): FavoriteItem[] {
+  return favorites.value.filter((f) => f.type === type)
+}
+
 /** Re-read from localStorage. Exposed for testing. */
 function _reset(): void {
   favorites.value = readFavorites()
@@ -101,6 +123,8 @@ export function useFavorites() {
     toggleFavorite,
     isFavorite,
     addRecent,
+    favoriteRoute,
+    favoritesForType,
     _reset,
   }
 }

--- a/frontend/src/views/AlertsView.vue
+++ b/frontend/src/views/AlertsView.vue
@@ -10,6 +10,7 @@ import {
   Plus,
   Radio,
   RefreshCw,
+  Star,
   Trash2,
   X,
 } from 'lucide-vue-next'
@@ -24,6 +25,7 @@ import {
 import { useAuth } from '../composables/useAuth'
 import { useCommandContext } from '../composables/useCommandContext'
 import { useDatasource } from '../composables/useDatasource'
+import { useFavorites } from '../composables/useFavorites'
 import { useOrganization } from '../composables/useOrganization'
 import { fetchAlerts, fetchGroups } from '../composables/useVMAlert'
 import AiAlertTriage from '../components/AiAlertTriage.vue'
@@ -43,6 +45,7 @@ const { currentOrg } = useOrganization()
 const { user } = useAuth()
 const { alertingDatasources, fetchDatasources } = useDatasource()
 const { registerContext, deregisterContext } = useCommandContext()
+const { toggleFavorite, isFavorite } = useFavorites()
 
 const selectedDatasourceId = ref('')
 const activeTab = ref<'alerts' | 'groups' | 'am-alerts' | 'am-silences' | 'am-receivers'>('alerts')
@@ -629,7 +632,20 @@ onUnmounted(() => {
                   />
                 </td>
                 <td class="px-4 py-3">
-                  <span class="text-sm font-semibold" :style="{ color: 'var(--color-on-surface)' }">{{ alert.name }}</span>
+                  <div class="flex items-center gap-2">
+                    <span class="text-sm font-semibold" :style="{ color: 'var(--color-on-surface)' }">{{ alert.name }}</span>
+                    <button
+                      class="shrink-0 bg-transparent border-none cursor-pointer p-0.5"
+                      :title="isFavorite(`alert::${selectedDatasourceId}::${alert.name}`) ? 'Remove from favorites' : 'Add to favorites'"
+                      @click.stop="toggleFavorite({ id: `alert::${selectedDatasourceId}::${alert.name}`, title: alert.name, type: 'alert' })"
+                    >
+                      <Star
+                        :size="12"
+                        :fill="isFavorite(`alert::${selectedDatasourceId}::${alert.name}`) ? 'currentColor' : 'none'"
+                        :style="{ color: isFavorite(`alert::${selectedDatasourceId}::${alert.name}`) ? 'var(--color-primary)' : 'var(--color-outline)' }"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td class="px-4 py-3">
                   <div class="flex flex-wrap gap-1.5" v-if="alert.labels && Object.keys(alert.labels).length > 0">
@@ -949,7 +965,21 @@ onUnmounted(() => {
                 />
               </td>
               <td class="px-4 py-3">
-                <span class="text-sm font-semibold" :style="{ color: 'var(--color-on-surface)' }">{{ alert.labels?.alertname || '--' }}</span>
+                <div class="flex items-center gap-2">
+                  <span class="text-sm font-semibold" :style="{ color: 'var(--color-on-surface)' }">{{ alert.labels?.alertname || '--' }}</span>
+                  <button
+                    v-if="alert.fingerprint"
+                    class="shrink-0 bg-transparent border-none cursor-pointer p-0.5"
+                    :title="isFavorite(`alert::${selectedDatasourceId}::${alert.fingerprint}`) ? 'Remove from favorites' : 'Add to favorites'"
+                    @click.stop="toggleFavorite({ id: `alert::${selectedDatasourceId}::${alert.fingerprint}`, title: alert.labels?.alertname || 'Alert', type: 'alert' })"
+                  >
+                    <Star
+                      :size="12"
+                      :fill="isFavorite(`alert::${selectedDatasourceId}::${alert.fingerprint}`) ? 'currentColor' : 'none'"
+                      :style="{ color: isFavorite(`alert::${selectedDatasourceId}::${alert.fingerprint}`) ? 'var(--color-primary)' : 'var(--color-outline)' }"
+                    />
+                  </button>
+                </div>
               </td>
               <td class="px-4 py-3">
                 <span class="text-xs font-mono" :style="{ color: 'var(--color-on-surface-variant)' }">{{ alert.labels?.severity || 'none' }}</span>

--- a/frontend/src/views/LogsExploreTab.vue
+++ b/frontend/src/views/LogsExploreTab.vue
@@ -9,9 +9,11 @@ import {
   History,
   Loader2,
   Play,
+  Star,
   X,
 } from 'lucide-vue-next'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { fetchDataSourceLabels, queryDataSource, streamDataSourceLogs } from '../api/datasources'
 import ClickHouseSQLEditor from '../components/ClickHouseSQLEditor.vue'
 import CloudWatchQueryEditor from '../components/CloudWatchQueryEditor.vue'
@@ -30,9 +32,14 @@ const emit = defineEmits<{
   'datasource-changed': [payload: { id: string; name: string; type: string }]
 }>()
 
+const route = useRoute()
 const { timeRange, onRefresh, setCustomRange } = useTimeRange()
 const { currentOrg } = useOrganization()
 const { logsDatasources, fetchDatasources } = useDatasource()
+
+// Favorites
+import { useFavorites } from '../composables/useFavorites'
+const { toggleFavorite, isFavorite } = useFavorites()
 
 type DatasourceHealthStatus = 'unknown' | 'checking' | 'healthy' | 'unhealthy'
 
@@ -192,6 +199,11 @@ function applyTraceLogsNavigationContext(type_: DataSourceType) {
 }
 
 onMounted(() => {
+  // Populate query from URL param (e.g., from explore favorites)
+  if (route.query.q && typeof route.query.q === 'string') {
+    query.value = route.query.q
+  }
+
   consumeTraceLogsNavigationContext()
 
   if (activeDatasource.value) {
@@ -1058,6 +1070,22 @@ watch(
             <span>{{ isLive ? 'Stop Live' : 'Start Live' }}</span>
           </button>
 
+          <button
+            v-if="query.trim()"
+            class="inline-flex items-center gap-1.5 rounded-sm px-3 py-2.5 text-sm transition border cursor-pointer"
+            :style="{
+              backgroundColor: isFavorite(`explore::logs::${query}`) ? 'var(--color-primary-muted)' : 'var(--color-surface-container-high)',
+              borderColor: isFavorite(`explore::logs::${query}`) ? 'var(--color-primary)' : 'var(--color-stroke-subtle)',
+              color: isFavorite(`explore::logs::${query}`) ? 'var(--color-primary)' : 'var(--color-on-surface-variant)',
+            }"
+            :title="isFavorite(`explore::logs::${query}`) ? 'Remove from favorites' : 'Save to favorites'"
+            @click="toggleFavorite({ id: `explore::logs::${query}`, title: query.length > 40 ? query.slice(0, 40) + '...' : query, type: 'explore' })"
+          >
+            <Star
+              :size="14"
+              :fill="isFavorite(`explore::logs::${query}`) ? 'currentColor' : 'none'"
+            />
+          </button>
           <span class="text-xs text-[var(--color-outline)]">Ctrl+Enter to run</span>
 
           <span

--- a/frontend/src/views/MetricsExploreTab.vue
+++ b/frontend/src/views/MetricsExploreTab.vue
@@ -9,9 +9,11 @@ import {
   History,
   Loader2,
   Play,
+  Star,
   X,
 } from 'lucide-vue-next'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { queryDataSource } from '../api/datasources'
 import ClickHouseSQLEditor from '../components/ClickHouseSQLEditor.vue'
 import CloudWatchQueryEditor from '../components/CloudWatchQueryEditor.vue'
@@ -21,6 +23,7 @@ import LineChart from '../components/LineChart.vue'
 import QueryBuilder from '../components/QueryBuilder.vue'
 import TimeRangePicker from '../components/TimeRangePicker.vue'
 import { useDatasource } from '../composables/useDatasource'
+import { useFavorites } from '../composables/useFavorites'
 import { useOrganization } from '../composables/useOrganization'
 import {
   type PrometheusQueryData,
@@ -37,9 +40,11 @@ const emit = defineEmits<{
   'datasource-changed': [payload: { id: string; name: string; type: string }]
 }>()
 
+const route = useRoute()
 const { timeRange, onRefresh, setCustomRange } = useTimeRange()
 const { currentOrg } = useOrganization()
 const { metricsDatasources, fetchDatasources } = useDatasource()
+const { toggleFavorite, isFavorite } = useFavorites()
 const queryEditor = useQueryEditor()
 
 type DatasourceHealthStatus = 'unknown' | 'checking' | 'healthy' | 'unhealthy'
@@ -201,6 +206,11 @@ function applyTraceMetricsNavigationContext() {
 
 // Load history from session storage
 onMounted(() => {
+  // Populate query from URL param (e.g., from explore favorites)
+  if (route.query.q && typeof route.query.q === 'string') {
+    query.value = route.query.q
+  }
+
   consumeTraceMetricsNavigationContext()
 
   if (activeDatasource.value) {
@@ -629,6 +639,22 @@ watch(selectedDatasourceId, (newId) => {
         >
           <Play :size="16" />
           <span>{{ loading ? 'Running...' : 'Run Query' }}</span>
+        </button>
+        <button
+          v-if="query.trim()"
+          class="inline-flex items-center gap-1.5 rounded-sm px-3 py-2.5 text-sm transition border cursor-pointer"
+          :style="{
+            backgroundColor: isFavorite(`explore::metrics::${query}`) ? 'var(--color-primary-muted)' : 'var(--color-surface-container-high)',
+            borderColor: isFavorite(`explore::metrics::${query}`) ? 'var(--color-primary)' : 'var(--color-stroke-subtle)',
+            color: isFavorite(`explore::metrics::${query}`) ? 'var(--color-primary)' : 'var(--color-on-surface-variant)',
+          }"
+          :title="isFavorite(`explore::metrics::${query}`) ? 'Remove from favorites' : 'Save to favorites'"
+          @click="toggleFavorite({ id: `explore::metrics::${query}`, title: query.length > 40 ? query.slice(0, 40) + '...' : query, type: 'explore' })"
+        >
+          <Star
+            :size="14"
+            :fill="isFavorite(`explore::metrics::${query}`) ? 'currentColor' : 'none'"
+          />
         </button>
         <span class="text-xs" :style="{ color: 'var(--color-outline)' }">Ctrl+Enter to run</span>
       </div>

--- a/frontend/src/views/ServicesView.vue
+++ b/frontend/src/views/ServicesView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { Activity } from 'lucide-vue-next'
+import { Activity, Star } from 'lucide-vue-next'
 import { onMounted, onUnmounted, ref } from 'vue'
 import EmptyState from '../components/EmptyState.vue'
 import StatusDot from '../components/StatusDot.vue'
 import { useCommandContext } from '../composables/useCommandContext'
+import { useFavorites } from '../composables/useFavorites'
 
 const { registerContext, deregisterContext } = useCommandContext()
+const { toggleFavorite, isFavorite } = useFavorites()
 
 interface ServiceMetrics {
   latencyMs: number
@@ -123,11 +125,23 @@ onUnmounted(() => {
           <StatusDot :status="service.status" :size="8" />
           <h3
             data-testid="service-name"
-            class="font-display text-base font-semibold"
+            class="font-display text-base font-semibold flex-1"
             :style="{ color: 'var(--color-on-surface)' }"
           >
             {{ service.name }}
           </h3>
+          <button
+            class="shrink-0 bg-transparent border-none cursor-pointer p-1"
+            :data-testid="`favorite-svc-${service.name}`"
+            :title="isFavorite(`svc::${service.name}`) ? 'Remove from favorites' : 'Add to favorites'"
+            @click.stop="toggleFavorite({ id: `svc::${service.name}`, title: service.name, type: 'service' })"
+          >
+            <Star
+              :size="14"
+              :fill="isFavorite(`svc::${service.name}`) ? 'currentColor' : 'none'"
+              :style="{ color: isFavorite(`svc::${service.name}`) ? 'var(--color-primary)' : 'var(--color-outline)' }"
+            />
+          </button>
         </div>
 
         <div class="flex flex-col gap-2">

--- a/frontend/src/views/TracesExploreTab.vue
+++ b/frontend/src/views/TracesExploreTab.vue
@@ -8,6 +8,7 @@ import {
   HeartPulse,
   Loader2,
   Search,
+  Star,
   Waypoints,
 } from 'lucide-vue-next'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -74,6 +75,9 @@ const router = useRouter()
 const { timeRange, isCustomRange, onRefresh } = useTimeRange()
 const { currentOrg } = useOrganization()
 const { tracingDatasources, fetchDatasources } = useDatasource()
+
+import { useFavorites } from '../composables/useFavorites'
+const { toggleFavorite, isFavorite } = useFavorites()
 
 type DatasourceHealthStatus = 'unknown' | 'checking' | 'healthy' | 'unhealthy'
 
@@ -731,6 +735,11 @@ async function handleOpenTraceFromList(traceId: string) {
 }
 
 onMounted(() => {
+  // Populate query from URL param (e.g., from explore favorites)
+  if (route.query.q && typeof route.query.q === 'string') {
+    query.value = route.query.q
+  }
+
   const queryTraceId = route.query.traceId
   const queryDatasourceId = route.query.datasourceId
   if (queryTraceId && typeof queryTraceId === 'string') {
@@ -913,6 +922,22 @@ onUnmounted(() => {
             <Loader2 v-if="loadingSearch" :size="16" class="animate-spin" />
             <Search v-else :size="16" />
             <span>{{ loadingSearch ? 'Searching...' : (isClickHouseDatasource ? 'Run Query' : 'Search Traces') }}</span>
+          </button>
+          <button
+            v-if="isClickHouseDatasource && query.trim()"
+            class="inline-flex items-center gap-1.5 rounded-sm px-3 py-2.5 text-sm transition border cursor-pointer"
+            :style="{
+              backgroundColor: isFavorite(`explore::traces::${query}`) ? 'var(--color-primary-muted)' : 'var(--color-surface-container-high)',
+              borderColor: isFavorite(`explore::traces::${query}`) ? 'var(--color-primary)' : 'var(--color-stroke-subtle)',
+              color: isFavorite(`explore::traces::${query}`) ? 'var(--color-primary)' : 'var(--color-on-surface-variant)',
+            }"
+            :title="isFavorite(`explore::traces::${query}`) ? 'Remove from favorites' : 'Save to favorites'"
+            @click="toggleFavorite({ id: `explore::traces::${query}`, title: query.length > 40 ? query.slice(0, 40) + '...' : query, type: 'explore' })"
+          >
+            <Star
+              :size="14"
+              :fill="isFavorite(`explore::traces::${query}`) ? 'currentColor' : 'none'"
+            />
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

- **Trusted proxy model** — `TRUSTED_PROXIES` env var (comma-separated CIDRs) controls X-Forwarded-For trust for audit log IP accuracy. Backward compatible.
- **Separate audit DB role** — `AUDIT_DATABASE_URL` env var enables an INSERT-only PostgreSQL role for audit writes, hardening immutability for compliance audits. Ops setup script included.
- **Iterative spec refinement** — copilot chat now preserves conversation context after dashboard generation, allowing follow-up messages like "add a panel for error rates" to refine the spec in-place.
- **Extend useFavorites** — star buttons on services, alerts, and explore queries. Sidebar flyouts show favorites for all sections, not just dashboards.
- **Per-user rate limiting** — in-memory fixed-window counter per (user, provider) with admin-configurable quotas. Returns 429 + Retry-After when exceeded. Badge shown on provider cards.

## Test plan

- [ ] Set `TRUSTED_PROXIES=10.0.0.0/8`, verify spoofed XFF from untrusted IP is ignored in audit log
- [ ] Set `AUDIT_DATABASE_URL` with `ace_audit` role, verify audit writes succeed and UPDATE/DELETE are denied
- [ ] Generate a dashboard via copilot, then send "add a panel for error rates" — preview should update
- [ ] Star a service in Services view, verify it appears in sidebar Services flyout
- [ ] Star an explore query, click it in sidebar, verify query populates
- [ ] Set rate limit to 3/hour on a provider, send 4 requests — 4th returns 429
- [ ] `cd backend && go test ./...` — all pass
- [ ] `cd frontend && bun run test` — all 1182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)