### PR TITLE
fix: restyle traces view to match Kinetic v2 design system

### DIFF
--- a/frontend/src/components/TraceListPanel.vue
+++ b/frontend/src/components/TraceListPanel.vue
@@ -84,27 +84,27 @@ function sortIndicator(field: TraceSortField): string {
     <table class="w-full border-collapse text-sm">
       <thead class="sticky top-0 z-10 bg-[var(--color-surface-container-high)]">
         <tr>
-          <th class="border-b  px-4 py-3 text-left align-middle">
+          <th class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 text-left align-middle">
             <button type="button" class="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)]" @click="toggleSort('traceId')">
               Trace {{ sortIndicator('traceId') }}
             </button>
           </th>
-          <th class="border-b  px-4 py-3 text-left align-middle">
+          <th class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 text-left align-middle">
             <button type="button" class="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)]" @click="toggleSort('startTimeUnixNano')">
               Start {{ sortIndicator('startTimeUnixNano') }}
             </button>
           </th>
-          <th class="border-b  px-4 py-3 text-left align-middle">
+          <th class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 text-left align-middle">
             <button type="button" class="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)]" @click="toggleSort('durationNano')">
               Duration {{ sortIndicator('durationNano') }}
             </button>
           </th>
-          <th class="border-b  px-4 py-3 text-left align-middle">
+          <th class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 text-left align-middle">
             <button type="button" class="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)]" @click="toggleSort('spanCount')">
               Spans {{ sortIndicator('spanCount') }}
             </button>
           </th>
-          <th class="border-b  px-4 py-3 text-left align-middle">
+          <th class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 text-left align-middle">
             <button type="button" class="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)]" @click="toggleSort('errorSpanCount')">
               Errors {{ sortIndicator('errorSpanCount') }}
             </button>
@@ -113,15 +113,15 @@ function sortIndicator(field: TraceSortField): string {
       </thead>
       <tbody>
         <tr v-for="trace in sortedTraces" :key="trace.traceId" class="transition hover:bg-[var(--color-surface-container-high)]">
-          <td class="max-w-[220px] px-4 py-3 align-middle">
+          <td class="max-w-[220px] border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle">
             <button type="button" class="inline-block w-full cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap border-none bg-transparent p-0 text-left font-mono text-xs text-[var(--color-primary)] transition hover:text-[var(--color-primary)] hover:underline" @click="openTrace(trace.traceId)">
               {{ trace.traceId }}
             </button>
           </td>
-          <td class="border-b  px-4 py-3 align-middle text-sm text-[var(--color-on-surface-variant)]">{{ formatStart(trace.startTimeUnixNano) }}</td>
-          <td class="border-b  px-4 py-3 align-middle font-mono text-xs text-[var(--color-outline)]">{{ formatDuration(trace.durationNano) }}</td>
-          <td class="border-b  px-4 py-3 align-middle text-sm text-[var(--color-on-surface-variant)]">{{ trace.spanCount }}</td>
-          <td class="border-b  px-4 py-3 align-middle">
+          <td class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle text-sm text-[var(--color-on-surface-variant)]">{{ formatStart(trace.startTimeUnixNano) }}</td>
+          <td class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle font-mono text-xs text-[var(--color-outline)]">{{ formatDuration(trace.durationNano) }}</td>
+          <td class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle text-sm text-[var(--color-on-surface-variant)]">{{ trace.spanCount }}</td>
+          <td class="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle">
             <span :class="trace.errorSpanCount > 0 ? 'font-semibold text-[var(--color-error)]' : 'text-[var(--color-on-surface-variant)]'">
               {{ trace.errorSpanCount }}
             </span>

--- a/frontend/src/components/TraceServiceGraph.vue
+++ b/frontend/src/components/TraceServiceGraph.vue
@@ -299,7 +299,7 @@ function handleSelectEdge(edge: PositionedEdge) {
               stroke: edgeColor(edge),
               strokeWidth: edgeWidth(edge),
               strokeOpacity: selectedEdgeKey === edge.key ? 1 : 0.84,
-              filter: selectedEdgeKey === edge.key ? 'drop-shadow(0 0 4px rgba(201, 150, 15, 0.3))' : 'none',
+              filter: selectedEdgeKey === edge.key ? 'drop-shadow(0 0 4px color-mix(in srgb, var(--color-primary) 30%, transparent))' : 'none',
             }"
             marker-end="url(#service-graph-arrow)"
             @click="handleSelectEdge(edge)"

--- a/frontend/src/components/TraceServiceGraph.vue
+++ b/frontend/src/components/TraceServiceGraph.vue
@@ -180,12 +180,12 @@ function edgeWidth(edge: TraceServiceGraphEdge): number {
 
 function edgeColor(edge: TraceServiceGraphEdge): string {
   if (edge.errorRate >= 0.4) {
-    return '#fb7185'
+    return 'var(--color-error)'
   }
   if (edge.errorRate >= 0.15) {
-    return '#f59e0b'
+    return 'var(--color-tertiary)'
   }
-  return '#34d399'
+  return 'var(--color-secondary)'
 }
 
 function nodeRadius(node: TraceServiceGraphNode): number {
@@ -194,14 +194,16 @@ function nodeRadius(node: TraceServiceGraphNode): number {
 }
 
 function nodeColor(node: TraceServiceGraphNode): string {
-  return node.errorRate >= 0.25 ? '#e11d48' : '#10b981'
+  return node.errorRate >= 0.25 ? 'var(--color-error)' : 'var(--color-secondary)'
 }
 
 function nodeStroke(node: TraceServiceGraphNode, isSelected: boolean): string {
   if (isSelected) {
-    return '#059669'
+    return 'var(--color-primary)'
   }
-  return node.errorRate >= 0.25 ? '#fda4af' : '#a7f3d0'
+  return node.errorRate >= 0.25
+    ? 'color-mix(in srgb, var(--color-error) 50%, white)'
+    : 'color-mix(in srgb, var(--color-secondary) 50%, white)'
 }
 
 function nodeStrokeWidth(isSelected: boolean): number {
@@ -282,7 +284,7 @@ function handleSelectEdge(edge: PositionedEdge) {
             refY="2.5"
             orient="auto"
           >
-            <path d="M0,0 L5,2.5 L0,5 z" fill="#64748b" />
+            <path d="M0,0 L5,2.5 L0,5 z" fill="var(--color-outline)" />
           </marker>
         </defs>
 
@@ -297,7 +299,7 @@ function handleSelectEdge(edge: PositionedEdge) {
               stroke: edgeColor(edge),
               strokeWidth: edgeWidth(edge),
               strokeOpacity: selectedEdgeKey === edge.key ? 1 : 0.84,
-              filter: selectedEdgeKey === edge.key ? 'drop-shadow(0 0 4px rgba(16, 185, 129, 0.4))' : 'none',
+              filter: selectedEdgeKey === edge.key ? 'drop-shadow(0 0 4px rgba(201, 150, 15, 0.3))' : 'none',
             }"
             marker-end="url(#service-graph-arrow)"
             @click="handleSelectEdge(edge)"
@@ -322,7 +324,7 @@ function handleSelectEdge(edge: PositionedEdge) {
       </svg>
     </div>
 
-    <div class="border-t  pt-2 text-xs text-[var(--color-outline)]">
+    <div class="border-t border-[var(--color-stroke-subtle)] pt-2 text-xs text-[var(--color-outline)]">
       <p v-if="selectedService" class="m-0 flex flex-wrap gap-1.5">
         <strong class="text-[var(--color-on-surface)]">{{ selectedService }}</strong>
         <span>

--- a/frontend/src/components/TraceSpanDetailsPanel.vue
+++ b/frontend/src/components/TraceSpanDetailsPanel.vue
@@ -307,16 +307,16 @@ function exportSpanJson() {
       <table v-if="sortedTags.length > 0" class="w-full border-collapse text-sm">
         <thead>
           <tr>
-            <th class="border-b  pb-1.5 text-left text-xs text-[var(--color-outline)]">Key</th>
-            <th class="border-b  pb-1.5 text-left text-xs text-[var(--color-outline)]">Value</th>
+            <th class="border-b border-[var(--color-stroke-subtle)] pb-1.5 text-left text-xs text-[var(--color-outline)]">Key</th>
+            <th class="border-b border-[var(--color-stroke-subtle)] pb-1.5 text-left text-xs text-[var(--color-outline)]">Value</th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="([key, value]) in sortedTags" :key="key">
-            <td class="border-b  py-1.5 align-top">
+            <td class="border-b border-[var(--color-stroke-subtle)] py-1.5 align-top">
               <code class="rounded-sm bg-[var(--color-surface-container-high)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-outline)]">{{ key }}</code>
             </td>
-            <td class="border-b  py-1.5 align-top">
+            <td class="border-b border-[var(--color-stroke-subtle)] py-1.5 align-top">
               <code class="rounded-sm bg-[var(--color-surface-container-high)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface)]">{{ value }}</code>
             </td>
           </tr>

--- a/frontend/src/components/TraceTimeline.vue
+++ b/frontend/src/components/TraceTimeline.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { Trace, TraceSpan } from '../types/datasource'
+import { chartPalette, thresholdColors } from '../utils/chartTheme'
 
 interface SpanRow {
   span: TraceSpan
@@ -152,18 +153,7 @@ const svgHeight = computed(
 )
 const svgWidth = labelWidth + barsWidth + 12
 
-const serviceColorPalette = [
-  '#059669',
-  '#10b981',
-  '#f59e0b',
-  '#f97316',
-  '#ef4444',
-  '#14b8a6',
-  '#6366f1',
-  '#ec4899',
-  '#84cc16',
-  '#eab308',
-]
+const serviceColorPalette = chartPalette
 
 const serviceColorMap = computed(() => {
   const services = [
@@ -177,7 +167,7 @@ const serviceColorMap = computed(() => {
 })
 
 function getServiceColor(serviceName: string): string {
-  return serviceColorMap.value.get(serviceName || 'unknown') || '#94a3b8'
+  return serviceColorMap.value.get(serviceName || 'unknown') || chartPalette[7]
 }
 
 function clamped(value: number, min: number, max: number): number {
@@ -301,9 +291,9 @@ const criticalPathSpanIds = computed(() => {
 })
 
 function spanBarStroke(span: TraceSpan): string {
-  if (span.status === 'error') return '#f87171'
-  if (criticalPathSpanIds.value.has(span.spanId)) return '#f59e0b'
-  if (span.spanId === props.selectedSpanId) return '#334155'
+  if (span.status === 'error') return thresholdColors.critical
+  if (criticalPathSpanIds.value.has(span.spanId)) return thresholdColors.warning
+  if (span.spanId === props.selectedSpanId) return 'var(--color-outline-variant)'
   return 'transparent'
 }
 
@@ -319,7 +309,7 @@ function spanBarOpacity(span: TraceSpan): number {
 }
 
 function rowBgFill(rowIndex: number): string {
-  return rowIndex % 2 === 0 ? '#f8fafc' : '#ffffff'
+  return rowIndex % 2 === 0 ? 'var(--color-surface-container-low)' : 'var(--color-surface-container-high)'
 }
 </script>
 
@@ -374,7 +364,7 @@ function rowBgFill(rowIndex: number): string {
             y1="0"
             :x2="marker.x"
             :y2="svgHeight"
-            stroke="#e2e8f0"
+            stroke="var(--color-stroke-subtle)"
             stroke-width="1"
           />
           <text
@@ -383,16 +373,16 @@ function rowBgFill(rowIndex: number): string {
             :x="marker.x"
             y="14"
             text-anchor="middle"
-            fill="#94a3b8"
+            fill="var(--color-outline)"
             font-size="10"
-            font-family="IBM Plex Mono, monospace"
+            font-family="JetBrains Mono, monospace"
           >
             {{ marker.label }}
           </text>
         </g>
 
         <g>
-          <line :x1="labelWidth" y1="0" :x2="labelWidth" :y2="svgHeight" stroke="#cbd5e1" stroke-width="1" />
+          <line :x1="labelWidth" y1="0" :x2="labelWidth" :y2="svgHeight" stroke="var(--color-stroke-strong)" stroke-width="1" />
         </g>
 
         <g v-for="(row, rowIndex) in visibleRows" :key="row.span.spanId">
@@ -407,7 +397,7 @@ function rowBgFill(rowIndex: number): string {
           <text
             :x="12 + row.depth * 14"
             :y="rowY(rowIndex) + 19"
-            fill="#0f172a"
+            fill="var(--color-on-surface)"
             font-size="11"
             class="select-none"
             :title="`${row.span.operationName} (${row.span.serviceName})`"
@@ -434,9 +424,9 @@ function rowBgFill(rowIndex: number): string {
           <text
             :x="spanStartToX(row.span.startTimeUnixNano) + spanWidth(row.span.durationNano, row.span.startTimeUnixNano) + 6"
             :y="rowY(rowIndex) + 19"
-            fill="#64748b"
+            fill="var(--color-on-surface-variant)"
             font-size="10"
-            font-family="IBM Plex Mono, monospace"
+            font-family="JetBrains Mono, monospace"
           >
             {{ formatDurationNano(row.span.durationNano) }}
           </text>

--- a/frontend/src/views/TracesExploreTab.vue
+++ b/frontend/src/views/TracesExploreTab.vue
@@ -892,6 +892,7 @@ onUnmounted(() => {
                 data-testid="explore-traces-service-select"
                 :disabled="loadingServices || services.length === 0"
                 class="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] disabled:opacity-50 disabled:cursor-not-allowed"
+                :style="{ border: '1px solid var(--color-outline-variant)' }"
               >
                 <option value="">All services</option>
                 <option v-for="service in services" :key="service" :value="service">{{ service }}</option>
@@ -904,6 +905,7 @@ onUnmounted(() => {
                 v-model.number="limit"
                 data-testid="explore-traces-limit-select"
                 class="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)]"
+                :style="{ border: '1px solid var(--color-outline-variant)' }"
               >
                 <option :value="10">10</option>
                 <option :value="20">20</option>
@@ -931,6 +933,7 @@ onUnmounted(() => {
             data-testid="explore-traces-search-input"
             type="text"
             class="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] placeholder:text-[var(--color-outline)]"
+            :style="{ border: '1px solid var(--color-outline-variant)' }"
             placeholder="service.name=api error=true"
           />
         </div>
@@ -976,6 +979,7 @@ onUnmounted(() => {
               type="text"
               placeholder="Paste trace id"
               class="flex-1 rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] placeholder:text-[var(--color-outline)]"
+              :style="{ border: '1px solid var(--color-outline-variant)' }"
             />
             <button
               data-testid="explore-traces-open-btn"
@@ -991,7 +995,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Error -->
-        <div v-if="error" class="flex items-center gap-2 rounded border border-rose-500/25 bg-[var(--color-error)]/10 p-4 text-sm text-[var(--color-error)]">
+        <div v-if="error" class="flex items-center gap-2 rounded border border-[var(--color-error)]/25 bg-[var(--color-error)]/10 p-4 text-sm text-[var(--color-error)]">
           <AlertCircle :size="16" />
           <span>{{ error }}</span>
         </div>
@@ -1025,7 +1029,7 @@ onUnmounted(() => {
         <!-- Standard trace layout: list + detail -->
         <div v-else class="grid grid-cols-[320px_minmax(0,1fr)] min-h-[460px] flex-1 max-lg:grid-cols-1">
           <!-- Trace results sidebar -->
-          <aside class="flex flex-col max-lg:border-r-0 max-lg:border-b max-lg:max-h-[320px]">
+          <aside class="flex flex-col max-lg:border-r-0 max-lg:border-b max-lg:border-[var(--color-stroke-subtle)] max-lg:max-h-[320px]">
             <div class="flex items-center justify-between px-4 py-3 bg-[var(--color-surface-container-high)]">
               <h2 class="m-0 text-xs font-semibold uppercase tracking-wide text-[var(--color-on-surface-variant)]">Matching traces</h2>
               <span class="text-xs text-[var(--color-outline)]">{{ traceSummaries.length }} result{{ traceSummaries.length === 1 ? '' : 's' }}</span>
@@ -1043,7 +1047,7 @@ onUnmounted(() => {
                 class="flex flex-col gap-1 text-left p-3 rounded-sm border cursor-pointer transition"
                 :class="selectedTraceId === summary.traceId
                   ? 'border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10'
-                  : ' bg-[var(--color-surface-container-low)]  hover:bg-[var(--color-surface-container-high)]'"
+                  : 'border-[var(--color-stroke-subtle)] bg-[var(--color-surface-container-low)] hover:bg-[var(--color-surface-container-high)]'"
                 @click="loadTrace(summary.traceId)"
               >
                 <code class="text-xs font-mono text-[var(--color-primary)] break-all">{{ summary.traceId }}</code>
@@ -1094,7 +1098,7 @@ onUnmounted(() => {
                   <span class="text-sm">Loading service graph...</span>
                 </div>
 
-                <div v-else-if="serviceGraphError" class="flex items-center gap-2 rounded-sm border border-rose-500/25 bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
+                <div v-else-if="serviceGraphError" class="flex items-center gap-2 rounded-sm border border-[var(--color-error)]/25 bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
                   <AlertCircle :size="14" />
                   <span>{{ serviceGraphError }}</span>
                 </div>


### PR DESCRIPTION
## Summary
- Replace hardcoded light-mode colors and ad-hoc Tailwind palette values in the traces view with Kinetic v2 design system tokens
- Swap white SVG row backgrounds for dark surface tokens, fix font from IBM Plex Mono to JetBrains Mono, use `chartPalette` from `chartTheme.ts` for service colors
- Use semantic color tokens (`--color-secondary`, `--color-error`, `--color-tertiary`) and `color-mix()` for node stroke rings in the service dependency graph
- Add explicit border color tokens to all bare `border-b` classes across trace components

## Test plan
- [ ] Navigate to Explore → Traces and verify waterfall timeline has dark row backgrounds (no white patches)
- [ ] Confirm service colors in timeline legend match the data viz palette (Steel Blue first)
- [ ] Confirm axis labels and duration text use JetBrains Mono
- [ ] Verify service dependency graph uses brass/green/red semantic colors with lighter stroke rings
- [ ] Verify selected edge glow is brass-tinted
- [ ] Confirm all input/select fields have visible borders
- [ ] Run `bun run build` — passes
- [ ] Run `bun run lint:fix` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)