### PR TITLE
feat: dashboard export/import v2 YAML overhaul + themed range sliders

### DIFF
--- a/backend/internal/converter/dashboard_cac.go
+++ b/backend/internal/converter/dashboard_cac.go
@@ -6,48 +6,95 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"go.yaml.in/yaml/v2"
 )
 
-const CurrentSchemaVersion = 1
+const CurrentSchemaVersion = 2
 
-type DashboardDocument struct {
-	SchemaVersion int               `json:"schema_version" yaml:"schema_version"`
-	Dashboard     DashboardResource `json:"dashboard" yaml:"dashboard"`
+// Valid panel types recognized by the frontend renderer.
+var validPanelTypes = map[string]bool{
+	"line_chart":    true,
+	"bar_chart":     true,
+	"gauge":         true,
+	"stat":          true,
+	"table":         true,
+	"pie":           true,
+	"logs":          true,
+	"trace_list":    true,
+	"trace_heatmap": true,
+	"bar_gauge":     true,
+	"heatmap":       true,
+	"histogram":     true,
+	"canvas":        true,
 }
 
-type DashboardResource struct {
-	ID              *uuid.UUID         `json:"id,omitempty" yaml:"id,omitempty"`
-	Title           string             `json:"title" yaml:"title"`
-	Description     *string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Panels          []PanelResource    `json:"panels" yaml:"panels"`
-	Variables       []VariableResource `json:"variables,omitempty" yaml:"variables,omitempty"`
-	TimeRange       *TimeRangeResource `json:"time_range,omitempty" yaml:"time_range,omitempty"`
-	RefreshInterval *string            `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty"`
+// ---------- Document types ----------
+
+// DashboardDocument is the root of the v2 YAML/JSON export format.
+type DashboardDocument struct {
+	Version     int             `json:"version" yaml:"version"`
+	Title       string          `json:"title" yaml:"title"`
+	Description string          `json:"description,omitempty" yaml:"description,omitempty"`
+	Panels      []PanelResource `json:"panels" yaml:"panels"`
 }
 
 type PanelResource struct {
-	Title        string          `json:"title" yaml:"title"`
-	Type         string          `json:"type" yaml:"type"`
-	GridPos      map[string]int  `json:"grid_pos" yaml:"grid_pos"`
-	Query        json.RawMessage `json:"query,omitempty" yaml:"query,omitempty"`
-	DataSourceID *uuid.UUID      `json:"datasource_id,omitempty" yaml:"datasource_id,omitempty"`
+	Title      string           `json:"title" yaml:"title"`
+	Type       string           `json:"type" yaml:"type"`
+	Position   GridPosition     `json:"position" yaml:"position,flow"`
+	Datasource *DatasourceRef   `json:"datasource,omitempty" yaml:"datasource,omitempty"`
+	Query      *QueryResource   `json:"query,omitempty" yaml:"query,omitempty"`
+	Display    *DisplayResource `json:"display,omitempty" yaml:"display,omitempty"`
 }
 
-type VariableResource struct {
-	Name       string `json:"name" yaml:"name"`
-	Type       string `json:"type" yaml:"type"`
-	Label      string `json:"label,omitempty" yaml:"label,omitempty"`
-	Query      string `json:"query,omitempty" yaml:"query,omitempty"`
-	Multi      bool   `json:"multi,omitempty" yaml:"multi,omitempty"`
-	IncludeAll bool   `json:"include_all,omitempty" yaml:"include_all,omitempty"`
+type GridPosition struct {
+	X int `json:"x" yaml:"x"`
+	Y int `json:"y" yaml:"y"`
+	W int `json:"w" yaml:"w"`
+	H int `json:"h" yaml:"h"`
 }
 
-type TimeRangeResource struct {
-	From string `json:"from" yaml:"from"`
-	To   string `json:"to" yaml:"to"`
+// DatasourceRef identifies a datasource by human-readable name + type for portability.
+type DatasourceRef struct {
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	Type string `json:"type" yaml:"type"`
 }
+
+// QueryResource holds structured data-fetching parameters.
+type QueryResource struct {
+	Expr    string         `json:"expr" yaml:"expr"`
+	Signal  string         `json:"signal,omitempty" yaml:"signal,omitempty"`
+	Legend  string         `json:"legend,omitempty" yaml:"legend,omitempty"`
+	Limit   *int           `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Service string         `json:"service,omitempty" yaml:"service,omitempty"`
+	RawData string         `json:"raw_data,omitempty" yaml:"raw_data,omitempty"`
+	Extra   map[string]any `json:"extra,omitempty" yaml:"extra,omitempty"`
+}
+
+// DisplayResource holds optional visualization parameters.
+//
+// Pointer types are used for fields where false/0 are meaningful values
+// (e.g., sparkline: false, min: 0). With omitempty, nil pointers are omitted
+// but pointers to zero values (&false, &0.0) are preserved.
+type DisplayResource struct {
+	Min        *float64            `json:"min,omitempty" yaml:"min,omitempty"`
+	Max        *float64            `json:"max,omitempty" yaml:"max,omitempty"`
+	Unit       string              `json:"unit,omitempty" yaml:"unit,omitempty"`
+	Decimals   *int                `json:"decimals,omitempty" yaml:"decimals,omitempty"`
+	Thresholds []ThresholdResource `json:"thresholds,omitempty" yaml:"thresholds,omitempty"`
+	Sparkline  *bool               `json:"sparkline,omitempty" yaml:"sparkline,omitempty"`
+	Trend      *bool               `json:"trend,omitempty" yaml:"trend,omitempty"`
+	Style      string              `json:"style,omitempty" yaml:"style,omitempty"`
+	Legend     *bool               `json:"legend,omitempty" yaml:"legend,omitempty"`
+	Labels     *bool               `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+type ThresholdResource struct {
+	Value float64 `json:"value" yaml:"value"`
+	Color string  `json:"color" yaml:"color"`
+}
+
+// ---------- Format helpers ----------
 
 func NormalizeFormat(format string) string {
 	normalized := strings.TrimSpace(strings.ToLower(format))
@@ -60,6 +107,8 @@ func NormalizeFormat(format string) string {
 		return ""
 	}
 }
+
+// ---------- Encode / Decode ----------
 
 func DecodeDashboardDocument(data []byte, format string) (DashboardDocument, error) {
 	normalized := NormalizeFormat(format)
@@ -78,8 +127,8 @@ func DecodeDashboardDocument(data []byte, format string) (DashboardDocument, err
 		return DashboardDocument{}, err
 	}
 
-	if doc.SchemaVersion == 0 {
-		doc.SchemaVersion = CurrentSchemaVersion
+	if doc.Version == 0 {
+		doc.Version = CurrentSchemaVersion
 	}
 
 	if err := ValidateDashboardDocument(doc); err != nil {
@@ -106,34 +155,291 @@ func EncodeDashboardDocument(doc DashboardDocument, format string) ([]byte, erro
 	return json.MarshalIndent(doc, "", "  ")
 }
 
+// ---------- Validation ----------
+
 func ValidateDashboardDocument(doc DashboardDocument) error {
-	if doc.SchemaVersion != CurrentSchemaVersion {
-		return fmt.Errorf("unsupported schema_version %d", doc.SchemaVersion)
+	if doc.Version != CurrentSchemaVersion {
+		return fmt.Errorf("unsupported version %d", doc.Version)
 	}
 
-	if strings.TrimSpace(doc.Dashboard.Title) == "" {
-		return errors.New("dashboard.title is required")
+	if strings.TrimSpace(doc.Title) == "" {
+		return errors.New("title is required")
 	}
 
-	for i, panel := range doc.Dashboard.Panels {
+	for i, panel := range doc.Panels {
 		if strings.TrimSpace(panel.Title) == "" {
-			return fmt.Errorf("dashboard.panels[%d].title is required", i)
+			return fmt.Errorf("panels[%d].title is required", i)
 		}
 		if strings.TrimSpace(panel.Type) == "" {
-			return fmt.Errorf("dashboard.panels[%d].type is required", i)
+			return fmt.Errorf("panels[%d].type is required", i)
 		}
-		if panel.GridPos == nil {
-			return fmt.Errorf("dashboard.panels[%d].grid_pos is required", i)
+		if !validPanelTypes[panel.Type] {
+			return fmt.Errorf("panels[%d].type %q is not a recognized panel type", i, panel.Type)
 		}
-		for _, key := range []string{"x", "y", "w", "h"} {
-			if _, ok := panel.GridPos[key]; !ok {
-				return fmt.Errorf("dashboard.panels[%d].grid_pos.%s is required", i, key)
-			}
+		pos := panel.Position
+		if pos.W <= 0 || pos.H <= 0 {
+			return fmt.Errorf("panels[%d].position width/height must be > 0", i)
 		}
-		if panel.GridPos["w"] <= 0 || panel.GridPos["h"] <= 0 {
-			return fmt.Errorf("dashboard.panels[%d].grid_pos width/height must be > 0", i)
+		if pos.X < 0 || pos.Y < 0 {
+			return fmt.Errorf("panels[%d].position x/y must be >= 0", i)
+		}
+		if pos.X+pos.W > 12 {
+			return fmt.Errorf("panels[%d].position x + w must be <= 12", i)
 		}
 	}
 
 	return nil
+}
+
+// ---------- Query blob decomposition ----------
+
+// Known keys in the DB query JSONB blob that map to QueryResource fields.
+var queryKeys = map[string]bool{
+	"expr": true, "promql": true, "signal": true, "legend_format": true,
+	"limit": true, "service": true, "datasource_id": true, "canvasData": true,
+}
+
+// Known keys in the DB query JSONB blob that map to DisplayResource fields.
+var displayKeys = map[string]bool{
+	"min": true, "max": true, "unit": true, "decimals": true, "thresholds": true,
+	"showSparkline": true, "showTrend": true, "displayAs": true,
+	"showLegend": true, "showLabels": true,
+}
+
+// QueryBlobToResources decomposes a DB query JSONB blob into structured
+// QueryResource and DisplayResource. The datasource_id is stripped (caller
+// handles it separately via the resolver).
+func QueryBlobToResources(raw json.RawMessage) (*QueryResource, *DisplayResource) {
+	if len(raw) == 0 || string(raw) == "{}" || string(raw) == "null" {
+		return nil, nil
+	}
+
+	var blob map[string]any
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		return nil, nil
+	}
+
+	q := &QueryResource{}
+	var d *DisplayResource
+
+	// Query fields
+	if v, ok := blob["expr"].(string); ok {
+		q.Expr = v
+	} else if v, ok := blob["promql"].(string); ok {
+		q.Expr = v
+	}
+	if v, ok := blob["signal"].(string); ok {
+		q.Signal = v
+	}
+	if v, ok := blob["legend_format"].(string); ok {
+		q.Legend = v
+	}
+	if v, ok := blob["service"].(string); ok {
+		q.Service = v
+	}
+	if v, ok := blob["limit"]; ok {
+		if f, ok := v.(float64); ok {
+			n := int(f)
+			q.Limit = &n
+		}
+	}
+
+	// Canvas data -> raw_data (JSON string to preserve fidelity)
+	if v, ok := blob["canvasData"]; ok {
+		if raw, err := json.Marshal(v); err == nil {
+			q.RawData = string(raw)
+		}
+	}
+
+	// Display fields
+	if hasAnyDisplayKey(blob) {
+		d = &DisplayResource{}
+
+		if v, ok := blob["min"]; ok {
+			if f, ok := v.(float64); ok {
+				d.Min = &f
+			}
+		}
+		if v, ok := blob["max"]; ok {
+			if f, ok := v.(float64); ok {
+				d.Max = &f
+			}
+		}
+		if v, ok := blob["unit"].(string); ok {
+			d.Unit = v
+		}
+		if v, ok := blob["decimals"]; ok {
+			if f, ok := v.(float64); ok {
+				n := int(f)
+				d.Decimals = &n
+			}
+		}
+		if v, ok := blob["thresholds"]; ok {
+			d.Thresholds = parseThresholds(v)
+		}
+		if v, ok := blob["showSparkline"]; ok {
+			if b, ok := v.(bool); ok {
+				d.Sparkline = &b
+			}
+		}
+		if v, ok := blob["showTrend"]; ok {
+			if b, ok := v.(bool); ok {
+				d.Trend = &b
+			}
+		}
+		if v, ok := blob["displayAs"].(string); ok {
+			d.Style = v
+		}
+		if v, ok := blob["showLegend"]; ok {
+			if b, ok := v.(bool); ok {
+				d.Legend = &b
+			}
+		}
+		if v, ok := blob["showLabels"]; ok {
+			if b, ok := v.(bool); ok {
+				d.Labels = &b
+			}
+		}
+	}
+
+	// Unknown keys -> Extra
+	for k, v := range blob {
+		if queryKeys[k] || displayKeys[k] {
+			continue
+		}
+		if q.Extra == nil {
+			q.Extra = make(map[string]any)
+		}
+		q.Extra[k] = v
+	}
+
+	return q, d
+}
+
+func hasAnyDisplayKey(blob map[string]any) bool {
+	for k := range blob {
+		if displayKeys[k] {
+			return true
+		}
+	}
+	return false
+}
+
+func parseThresholds(v any) []ThresholdResource {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	var result []ThresholdResource
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		t := ThresholdResource{}
+		if val, ok := m["value"].(float64); ok {
+			t.Value = val
+		}
+		if col, ok := m["color"].(string); ok {
+			t.Color = col
+		}
+		result = append(result, t)
+	}
+	return result
+}
+
+// ResourcesToQueryBlob re-assembles structured QueryResource + DisplayResource
+// back into the flat JSONB blob that the DB panels.query column expects.
+// The dsID is injected as datasource_id into the blob.
+func ResourcesToQueryBlob(q *QueryResource, d *DisplayResource, dsID *string) json.RawMessage {
+	blob := make(map[string]any)
+
+	if q != nil {
+		if q.Expr != "" {
+			blob["expr"] = q.Expr
+		}
+		if q.Signal != "" {
+			blob["signal"] = q.Signal
+		}
+		if q.Legend != "" {
+			blob["legend_format"] = q.Legend // reverse rename
+		}
+		if q.Limit != nil {
+			blob["limit"] = *q.Limit
+		}
+		if q.Service != "" {
+			blob["service"] = q.Service
+		}
+		if q.RawData != "" {
+			var canvasData any
+			if err := json.Unmarshal([]byte(q.RawData), &canvasData); err == nil {
+				blob["canvasData"] = canvasData
+			}
+		}
+		for k, v := range q.Extra {
+			blob[k] = v
+		}
+	}
+
+	if d != nil {
+		if d.Min != nil {
+			blob["min"] = *d.Min
+		}
+		if d.Max != nil {
+			blob["max"] = *d.Max
+		}
+		if d.Unit != "" {
+			blob["unit"] = d.Unit
+		}
+		if d.Decimals != nil {
+			blob["decimals"] = *d.Decimals
+		}
+		if d.Thresholds != nil {
+			var arr []map[string]any
+			for _, t := range d.Thresholds {
+				arr = append(arr, map[string]any{"value": t.Value, "color": t.Color})
+			}
+			blob["thresholds"] = arr
+		}
+		if d.Sparkline != nil {
+			blob["showSparkline"] = *d.Sparkline // reverse rename
+		}
+		if d.Trend != nil {
+			blob["showTrend"] = *d.Trend
+		}
+		if d.Style != "" {
+			blob["displayAs"] = d.Style
+		}
+		if d.Legend != nil {
+			blob["showLegend"] = *d.Legend
+		}
+		if d.Labels != nil {
+			blob["showLabels"] = *d.Labels
+		}
+	}
+
+	if dsID != nil {
+		blob["datasource_id"] = *dsID
+	}
+
+	raw, err := json.Marshal(blob)
+	if err != nil {
+		return json.RawMessage("{}")
+	}
+	return raw
+}
+
+// ExtractDatasourceID pulls datasource_id from a raw query JSONB blob.
+func ExtractDatasourceID(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var blob map[string]any
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		return ""
+	}
+	if v, ok := blob["datasource_id"].(string); ok {
+		return v
+	}
+	return ""
 }

--- a/backend/internal/converter/dashboard_cac_test.go
+++ b/backend/internal/converter/dashboard_cac_test.go
@@ -1,24 +1,19 @@
 package converter
 
 import (
+	"encoding/json"
 	"testing"
-
-	"github.com/google/uuid"
 )
 
 func TestEncodeDecodeDashboardDocumentJSON(t *testing.T) {
-	id := uuid.New()
 	doc := DashboardDocument{
-		SchemaVersion: CurrentSchemaVersion,
-		Dashboard: DashboardResource{
-			ID:    &id,
-			Title: "Service Health",
-			Panels: []PanelResource{
-				{
-					Title:   "CPU",
-					Type:    "line_chart",
-					GridPos: map[string]int{"x": 0, "y": 0, "w": 12, "h": 8},
-				},
+		Version: CurrentSchemaVersion,
+		Title:   "Service Health",
+		Panels: []PanelResource{
+			{
+				Title:    "CPU",
+				Type:     "line_chart",
+				Position: GridPosition{X: 0, Y: 0, W: 12, H: 8},
 			},
 		},
 	}
@@ -33,26 +28,21 @@ func TestEncodeDecodeDashboardDocumentJSON(t *testing.T) {
 		t.Fatalf("expected JSON decode to succeed: %v", err)
 	}
 
-	if decoded.Dashboard.Title != doc.Dashboard.Title {
-		t.Fatalf("expected dashboard title %q, got %q", doc.Dashboard.Title, decoded.Dashboard.Title)
+	if decoded.Title != doc.Title {
+		t.Fatalf("expected title %q, got %q", doc.Title, decoded.Title)
 	}
-	if len(decoded.Dashboard.Panels) != 1 {
-		t.Fatalf("expected 1 panel, got %d", len(decoded.Dashboard.Panels))
+	if len(decoded.Panels) != 1 {
+		t.Fatalf("expected 1 panel, got %d", len(decoded.Panels))
 	}
 }
 
 func TestDecodeDashboardDocumentYAML(t *testing.T) {
-	payload := []byte(`schema_version: 1
-dashboard:
-  title: API Overview
-  panels:
-    - title: Requests
-      type: line_chart
-      grid_pos:
-        x: 0
-        y: 0
-        w: 8
-        h: 6
+	payload := []byte(`version: 2
+title: API Overview
+panels:
+  - title: Requests
+    type: line_chart
+    position: {x: 0, y: 0, w: 8, h: 6}
 `)
 
 	decoded, err := DecodeDashboardDocument(payload, "yaml")
@@ -60,16 +50,325 @@ dashboard:
 		t.Fatalf("expected YAML decode to succeed: %v", err)
 	}
 
-	if decoded.Dashboard.Title != "API Overview" {
-		t.Fatalf("expected dashboard title %q, got %q", "API Overview", decoded.Dashboard.Title)
+	if decoded.Title != "API Overview" {
+		t.Fatalf("expected title %q, got %q", "API Overview", decoded.Title)
+	}
+	p := decoded.Panels[0]
+	if p.Position.X != 0 || p.Position.Y != 0 || p.Position.W != 8 || p.Position.H != 6 {
+		t.Fatalf("unexpected position: %+v", p.Position)
 	}
 }
 
 func TestDecodeDashboardDocumentValidationError(t *testing.T) {
-	payload := []byte(`{"schema_version":1,"dashboard":{"title":"","panels":[]}}`)
+	payload := []byte(`{"version":2,"title":"","panels":[]}`)
 
 	_, err := DecodeDashboardDocument(payload, "json")
 	if err == nil {
-		t.Fatal("expected decode to fail for missing dashboard title")
+		t.Fatal("expected decode to fail for missing title")
+	}
+}
+
+func TestValidateDashboardDocumentV2(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     DashboardDocument
+		wantErr string
+	}{
+		{
+			name:    "wrong version",
+			doc:     DashboardDocument{Version: 1, Title: "T", Panels: []PanelResource{{Title: "P", Type: "stat", Position: GridPosition{W: 4, H: 4}}}},
+			wantErr: "unsupported version 1",
+		},
+		{
+			name:    "empty title",
+			doc:     DashboardDocument{Version: 2, Title: "", Panels: []PanelResource{{Title: "P", Type: "stat", Position: GridPosition{W: 4, H: 4}}}},
+			wantErr: "title is required",
+		},
+		{
+			name:    "panel missing title",
+			doc:     DashboardDocument{Version: 2, Title: "T", Panels: []PanelResource{{Title: "", Type: "stat", Position: GridPosition{W: 4, H: 4}}}},
+			wantErr: "panels[0].title is required",
+		},
+		{
+			name:    "panel missing type",
+			doc:     DashboardDocument{Version: 2, Title: "T", Panels: []PanelResource{{Title: "P", Type: "", Position: GridPosition{W: 4, H: 4}}}},
+			wantErr: "panels[0].type is required",
+		},
+		{
+			name:    "invalid panel type",
+			doc:     DashboardDocument{Version: 2, Title: "T", Panels: []PanelResource{{Title: "P", Type: "unknown", Position: GridPosition{W: 4, H: 4}}}},
+			wantErr: "not a recognized panel type",
+		},
+		{
+			name:    "position width zero",
+			doc:     DashboardDocument{Version: 2, Title: "T", Panels: []PanelResource{{Title: "P", Type: "stat", Position: GridPosition{W: 0, H: 4}}}},
+			wantErr: "width/height must be > 0",
+		},
+		{
+			name:    "position x+w exceeds 12",
+			doc:     DashboardDocument{Version: 2, Title: "T", Panels: []PanelResource{{Title: "P", Type: "stat", Position: GridPosition{X: 8, W: 6, H: 4}}}},
+			wantErr: "x + w must be <= 12",
+		},
+		{
+			name:    "negative x",
+			doc:     DashboardDocument{Version: 2, Title: "T", Panels: []PanelResource{{Title: "P", Type: "stat", Position: GridPosition{X: -1, W: 4, H: 4}}}},
+			wantErr: "x/y must be >= 0",
+		},
+		{
+			name: "valid document",
+			doc: DashboardDocument{
+				Version: 2, Title: "T",
+				Panels: []PanelResource{{Title: "P", Type: "stat", Position: GridPosition{X: 0, Y: 0, W: 4, H: 4}}},
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDashboardDocument(tt.doc)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+			if !containsSubstring(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestQueryBlobToResources(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+	floatPtr := func(v float64) *float64 { return &v }
+	intPtr := func(v int) *int { return &v }
+
+	tests := []struct {
+		name        string
+		blob        string
+		wantQuery   *QueryResource
+		wantDisplay *DisplayResource
+	}{
+		{name: "empty blob", blob: `{}`, wantQuery: nil, wantDisplay: nil},
+		{
+			name: "metrics panel", blob: `{"expr":"rate(up[5m])","signal":"metrics","legend_format":"{{instance}}","datasource_id":"abc-123"}`,
+			wantQuery: &QueryResource{Expr: "rate(up[5m])", Signal: "metrics", Legend: "{{instance}}"}, wantDisplay: nil,
+		},
+		{
+			name: "promql alias", blob: `{"promql":"up","signal":"metrics"}`,
+			wantQuery: &QueryResource{Expr: "up", Signal: "metrics"}, wantDisplay: nil,
+		},
+		{
+			name: "gauge panel", blob: `{"expr":"mem_used","signal":"metrics","min":0,"max":100,"unit":"bytes","thresholds":[{"value":80,"color":"#f00"}]}`,
+			wantQuery:   &QueryResource{Expr: "mem_used", Signal: "metrics"},
+			wantDisplay: &DisplayResource{Min: floatPtr(0), Max: floatPtr(100), Unit: "bytes", Thresholds: []ThresholdResource{{Value: 80, Color: "#f00"}}},
+		},
+		{
+			name: "stat panel", blob: `{"expr":"up","signal":"metrics","showSparkline":false,"showTrend":true,"unit":"","decimals":0}`,
+			wantQuery:   &QueryResource{Expr: "up", Signal: "metrics"},
+			wantDisplay: &DisplayResource{Sparkline: boolPtr(false), Trend: boolPtr(true), Decimals: intPtr(0)},
+		},
+		{
+			name: "pie panel", blob: `{"expr":"sum(up)","signal":"metrics","displayAs":"donut","showLegend":true,"showLabels":false}`,
+			wantQuery:   &QueryResource{Expr: "sum(up)", Signal: "metrics"},
+			wantDisplay: &DisplayResource{Style: "donut", Legend: boolPtr(true), Labels: boolPtr(false)},
+		},
+		{
+			name: "trace panel", blob: `{"expr":"{}","limit":50,"service":"api"}`,
+			wantQuery: &QueryResource{Expr: "{}", Limit: intPtr(50), Service: "api"}, wantDisplay: nil,
+		},
+		{
+			name: "unknown keys go to extra", blob: `{"expr":"up","ref_id":"A","custom_field":"value"}`,
+			wantQuery: &QueryResource{Expr: "up", Extra: map[string]any{"ref_id": "A", "custom_field": "value"}}, wantDisplay: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, d := QueryBlobToResources(json.RawMessage(tt.blob))
+
+			if tt.wantQuery == nil {
+				if q != nil {
+					t.Fatalf("expected nil query, got %+v", q)
+				}
+			} else {
+				if q == nil {
+					t.Fatal("expected non-nil query")
+				}
+				if q.Expr != tt.wantQuery.Expr {
+					t.Errorf("expr: got %q, want %q", q.Expr, tt.wantQuery.Expr)
+				}
+				if q.Signal != tt.wantQuery.Signal {
+					t.Errorf("signal: got %q, want %q", q.Signal, tt.wantQuery.Signal)
+				}
+				if q.Legend != tt.wantQuery.Legend {
+					t.Errorf("legend: got %q, want %q", q.Legend, tt.wantQuery.Legend)
+				}
+				if q.Service != tt.wantQuery.Service {
+					t.Errorf("service: got %q, want %q", q.Service, tt.wantQuery.Service)
+				}
+				if (q.Limit == nil) != (tt.wantQuery.Limit == nil) {
+					t.Errorf("limit nil mismatch: got %v, want %v", q.Limit, tt.wantQuery.Limit)
+				} else if q.Limit != nil && *q.Limit != *tt.wantQuery.Limit {
+					t.Errorf("limit: got %d, want %d", *q.Limit, *tt.wantQuery.Limit)
+				}
+				if tt.wantQuery.Extra != nil {
+					for k := range tt.wantQuery.Extra {
+						if _, ok := q.Extra[k]; !ok {
+							t.Errorf("missing extra key %q", k)
+						}
+					}
+				}
+			}
+
+			if tt.wantDisplay == nil {
+				if d != nil {
+					t.Fatalf("expected nil display, got %+v", d)
+				}
+			} else {
+				if d == nil {
+					t.Fatal("expected non-nil display")
+				}
+				comparePtrFloat(t, "min", d.Min, tt.wantDisplay.Min)
+				comparePtrFloat(t, "max", d.Max, tt.wantDisplay.Max)
+				if d.Unit != tt.wantDisplay.Unit {
+					t.Errorf("unit: got %q, want %q", d.Unit, tt.wantDisplay.Unit)
+				}
+				comparePtrBool(t, "sparkline", d.Sparkline, tt.wantDisplay.Sparkline)
+				comparePtrBool(t, "trend", d.Trend, tt.wantDisplay.Trend)
+				comparePtrBool(t, "legend", d.Legend, tt.wantDisplay.Legend)
+				comparePtrBool(t, "labels", d.Labels, tt.wantDisplay.Labels)
+				comparePtrInt(t, "decimals", d.Decimals, tt.wantDisplay.Decimals)
+				if d.Style != tt.wantDisplay.Style {
+					t.Errorf("style: got %q, want %q", d.Style, tt.wantDisplay.Style)
+				}
+				if len(d.Thresholds) != len(tt.wantDisplay.Thresholds) {
+					t.Errorf("thresholds count: got %d, want %d", len(d.Thresholds), len(tt.wantDisplay.Thresholds))
+				}
+			}
+		})
+	}
+}
+
+func TestResourcesToQueryBlob(t *testing.T) {
+	dsID := "ds-123"
+	q := &QueryResource{Expr: "rate(up[5m])", Signal: "metrics", Legend: "{{instance}}"}
+	f := false
+	d := &DisplayResource{Sparkline: &f}
+
+	raw := ResourcesToQueryBlob(q, d, &dsID)
+
+	var blob map[string]any
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		t.Fatalf("failed to unmarshal blob: %v", err)
+	}
+
+	if blob["legend_format"] != "{{instance}}" {
+		t.Errorf("expected legend_format, got %v", blob["legend_format"])
+	}
+	if _, ok := blob["legend"]; ok {
+		t.Error("should not have 'legend' key, should be 'legend_format'")
+	}
+	if blob["showSparkline"] != false {
+		t.Errorf("expected showSparkline=false, got %v", blob["showSparkline"])
+	}
+	if blob["datasource_id"] != "ds-123" {
+		t.Errorf("expected datasource_id, got %v", blob["datasource_id"])
+	}
+}
+
+func TestExtractDatasourceID(t *testing.T) {
+	raw := json.RawMessage(`{"expr":"up","datasource_id":"abc-123","signal":"metrics"}`)
+	id := ExtractDatasourceID(raw)
+	if id != "abc-123" {
+		t.Fatalf("expected abc-123, got %q", id)
+	}
+
+	empty := ExtractDatasourceID(json.RawMessage(`{"expr":"up"}`))
+	if empty != "" {
+		t.Fatalf("expected empty, got %q", empty)
+	}
+}
+
+func TestCanvasDataRoundTrip(t *testing.T) {
+	blob := `{"canvasData":{"elements":[{"type":"rect","x":10,"y":20}],"appState":{"zoom":1.5}}}`
+	q, _ := QueryBlobToResources(json.RawMessage(blob))
+	if q == nil || q.RawData == "" {
+		t.Fatal("expected canvasData to be captured in RawData")
+	}
+
+	raw := ResourcesToQueryBlob(q, nil, nil)
+	var result map[string]any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	cd, ok := result["canvasData"].(map[string]any)
+	if !ok {
+		t.Fatal("expected canvasData to be restored")
+	}
+	elems, ok := cd["elements"].([]any)
+	if !ok || len(elems) != 1 {
+		t.Fatalf("expected 1 element in canvasData, got %v", cd["elements"])
+	}
+}
+
+func TestGridPositionFlowYAML(t *testing.T) {
+	doc := DashboardDocument{
+		Version: 2,
+		Title:   "Test",
+		Panels: []PanelResource{
+			{Title: "P", Type: "stat", Position: GridPosition{X: 0, Y: 0, W: 6, H: 4}},
+		},
+	}
+
+	encoded, err := EncodeDashboardDocument(doc, "yaml")
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	yamlStr := string(encoded)
+	if !containsSubstring(yamlStr, "x:") || !containsSubstring(yamlStr, "w:") {
+		t.Errorf("expected flow-style position in YAML output:\n%s", yamlStr)
+	}
+}
+
+func comparePtrBool(t *testing.T, name string, got, want *bool) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Errorf("%s: got %v, want %v", name, got, want)
+	} else if got != nil && *got != *want {
+		t.Errorf("%s: got %v, want %v", name, *got, *want)
+	}
+}
+
+func comparePtrFloat(t *testing.T, name string, got, want *float64) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Errorf("%s: got %v, want %v", name, got, want)
+	} else if got != nil && *got != *want {
+		t.Errorf("%s: got %v, want %v", name, *got, *want)
+	}
+}
+
+func comparePtrInt(t *testing.T, name string, got, want *int) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Errorf("%s: got %v, want %v", name, got, want)
+	} else if got != nil && *got != *want {
+		t.Errorf("%s: got %v, want %v", name, *got, *want)
 	}
 }

--- a/backend/internal/converter/grafana.go
+++ b/backend/internal/converter/grafana.go
@@ -73,22 +73,9 @@ type ConversionReport struct {
 }
 
 func ConvertGrafanaDashboard(data []byte) (DashboardDocument, []string, error) {
-	var envelope grafanaEnvelope
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return DashboardDocument{}, nil, fmt.Errorf("invalid grafana JSON: %w", err)
-	}
-
-	dashboard := envelope.Dashboard
-	if dashboard == nil {
-		var raw grafanaDashboard
-		if err := json.Unmarshal(data, &raw); err != nil {
-			return DashboardDocument{}, nil, fmt.Errorf("invalid grafana dashboard: %w", err)
-		}
-		dashboard = &raw
-	}
-
-	if strings.TrimSpace(dashboard.Title) == "" {
-		return DashboardDocument{}, nil, fmt.Errorf("grafana dashboard title is required")
+	dashboard, err := parseGrafanaInput(data)
+	if err != nil {
+		return DashboardDocument{}, nil, err
 	}
 
 	warnings := make([]string, 0)
@@ -99,11 +86,12 @@ func ConvertGrafanaDashboard(data []byte) (DashboardDocument, []string, error) {
 			warnings = append(warnings, fmt.Sprintf("panel[%d] %s", idx, warning))
 		}
 
-		if panel.GridPos == nil {
-			panel.GridPos = map[string]int{"x": 0, "y": idx * 8, "w": 12, "h": 8}
+		gridPos := panel.GridPos
+		if gridPos == nil {
+			gridPos = map[string]int{"x": 0, "y": idx * 8, "w": 12, "h": 8}
 		}
 
-		query := map[string]string{}
+		var qr *QueryResource
 		if len(panel.Targets) > 0 {
 			target := panel.Targets[0]
 			expr := strings.TrimSpace(target.Expr)
@@ -111,20 +99,11 @@ func ConvertGrafanaDashboard(data []byte) (DashboardDocument, []string, error) {
 				expr = strings.TrimSpace(target.Query)
 			}
 			if expr != "" {
-				query["expr"] = expr
+				qr = &QueryResource{Expr: expr}
+				if target.RefID != "" {
+					qr.Extra = map[string]any{"ref_id": target.RefID}
+				}
 			}
-			if target.RefID != "" {
-				query["ref_id"] = target.RefID
-			}
-		}
-
-		queryRaw := json.RawMessage("{}")
-		if len(query) > 0 {
-			encodedQuery, err := json.Marshal(query)
-			if err != nil {
-				return DashboardDocument{}, nil, fmt.Errorf("failed to encode panel query: %w", err)
-			}
-			queryRaw = encodedQuery
 		}
 
 		panelTitle := strings.TrimSpace(panel.Title)
@@ -133,47 +112,21 @@ func ConvertGrafanaDashboard(data []byte) (DashboardDocument, []string, error) {
 		}
 
 		panels = append(panels, PanelResource{
-			Title:   panelTitle,
-			Type:    mappedType,
-			GridPos: panel.GridPos,
-			Query:   queryRaw,
+			Title: panelTitle,
+			Type:  mappedType,
+			Position: GridPosition{
+				X: gridPos["x"], Y: gridPos["y"],
+				W: gridPos["w"], H: gridPos["h"],
+			},
+			Query: qr,
 		})
-	}
-
-	variables := make([]VariableResource, 0, len(dashboard.Templating.List))
-	for _, variable := range dashboard.Templating.List {
-		query := strings.TrimSpace(variable.Query)
-		if query == "" {
-			query = strings.TrimSpace(variable.Definition)
-		}
-		variables = append(variables, VariableResource{
-			Name:       variable.Name,
-			Type:       variable.Type,
-			Label:      variable.Label,
-			Query:      query,
-			Multi:      variable.Multi,
-			IncludeAll: variable.IncludeAll,
-		})
-	}
-
-	var timeRange *TimeRangeResource
-	if dashboard.Time != nil {
-		timeRange = &TimeRangeResource{
-			From: dashboard.Time.From,
-			To:   dashboard.Time.To,
-		}
 	}
 
 	doc := DashboardDocument{
-		SchemaVersion: CurrentSchemaVersion,
-		Dashboard: DashboardResource{
-			Title:           dashboard.Title,
-			Description:     optionalString(dashboard.Description),
-			Panels:          panels,
-			Variables:       variables,
-			TimeRange:       timeRange,
-			RefreshInterval: optionalString(dashboard.Refresh),
-		},
+		Version:     CurrentSchemaVersion,
+		Title:       dashboard.Title,
+		Description: strings.TrimSpace(dashboard.Description),
+		Panels:      panels,
 	}
 
 	if err := ValidateDashboardDocument(doc); err != nil {
@@ -183,54 +136,13 @@ func ConvertGrafanaDashboard(data []byte) (DashboardDocument, []string, error) {
 	return doc, warnings, nil
 }
 
-func mapGrafanaPanelType(panelType string) (string, string) {
-	switch strings.ToLower(strings.TrimSpace(panelType)) {
-	case "graph", "timeseries":
-		return "line_chart", ""
-	case "gauge":
-		return "gauge", ""
-	case "stat":
-		return "stat", ""
-	case "piechart", "pie chart":
-		return "pie", ""
-	case "logs":
-		return "logs", ""
-	case "table":
-		return "table", ""
-	case "bargauge":
-		return "bar_gauge", ""
-	case "barchart":
-		return "bar_chart", ""
-	case "heatmap":
-		return "heatmap", ""
-	case "histogram":
-		return "histogram", ""
-	default:
-		return "line_chart", fmt.Sprintf("unsupported panel type %q mapped to line_chart", panelType)
-	}
-}
-
 // ConvertGrafanaDashboardWithReport returns the converted document plus a structured fidelity report.
 func ConvertGrafanaDashboardWithReport(data []byte) (DashboardDocument, ConversionReport, error) {
-	var envelope grafanaEnvelope
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return DashboardDocument{}, ConversionReport{}, fmt.Errorf("invalid grafana JSON: %w", err)
+	dashboard, err := parseGrafanaInput(data)
+	if err != nil {
+		return DashboardDocument{}, ConversionReport{}, err
 	}
 
-	dashboard := envelope.Dashboard
-	if dashboard == nil {
-		var raw grafanaDashboard
-		if err := json.Unmarshal(data, &raw); err != nil {
-			return DashboardDocument{}, ConversionReport{}, fmt.Errorf("invalid grafana dashboard: %w", err)
-		}
-		dashboard = &raw
-	}
-
-	if strings.TrimSpace(dashboard.Title) == "" {
-		return DashboardDocument{}, ConversionReport{}, fmt.Errorf("grafana dashboard title is required")
-	}
-
-	// Count field overrides per panel from raw JSON
 	overrideCounts := countFieldOverrides(data)
 
 	report := ConversionReport{
@@ -273,11 +185,12 @@ func ConvertGrafanaDashboardWithReport(data []byte) (DashboardDocument, Conversi
 
 		report.PanelDiagnostics = append(report.PanelDiagnostics, diag)
 
-		if panel.GridPos == nil {
-			panel.GridPos = map[string]int{"x": 0, "y": idx * 8, "w": 12, "h": 8}
+		gridPos := panel.GridPos
+		if gridPos == nil {
+			gridPos = map[string]int{"x": 0, "y": idx * 8, "w": 12, "h": 8}
 		}
 
-		query := map[string]string{}
+		var qr *QueryResource
 		if len(panel.Targets) > 0 {
 			target := panel.Targets[0]
 			expr := strings.TrimSpace(target.Expr)
@@ -285,20 +198,11 @@ func ConvertGrafanaDashboardWithReport(data []byte) (DashboardDocument, Conversi
 				expr = strings.TrimSpace(target.Query)
 			}
 			if expr != "" {
-				query["expr"] = expr
+				qr = &QueryResource{Expr: expr}
+				if target.RefID != "" {
+					qr.Extra = map[string]any{"ref_id": target.RefID}
+				}
 			}
-			if target.RefID != "" {
-				query["ref_id"] = target.RefID
-			}
-		}
-
-		queryRaw := json.RawMessage("{}")
-		if len(query) > 0 {
-			encodedQuery, err := json.Marshal(query)
-			if err != nil {
-				return DashboardDocument{}, ConversionReport{}, fmt.Errorf("failed to encode panel query: %w", err)
-			}
-			queryRaw = encodedQuery
 		}
 
 		panelTitle := strings.TrimSpace(panel.Title)
@@ -307,48 +211,24 @@ func ConvertGrafanaDashboardWithReport(data []byte) (DashboardDocument, Conversi
 		}
 
 		panels = append(panels, PanelResource{
-			Title:   panelTitle,
-			Type:    mappedType,
-			GridPos: panel.GridPos,
-			Query:   queryRaw,
+			Title: panelTitle,
+			Type:  mappedType,
+			Position: GridPosition{
+				X: gridPos["x"], Y: gridPos["y"],
+				W: gridPos["w"], H: gridPos["h"],
+			},
+			Query: qr,
 		})
 	}
 
-	variables := make([]VariableResource, 0, len(dashboard.Templating.List))
-	for _, variable := range dashboard.Templating.List {
-		query := strings.TrimSpace(variable.Query)
-		if query == "" {
-			query = strings.TrimSpace(variable.Definition)
-		}
-		variables = append(variables, VariableResource{
-			Name:       variable.Name,
-			Type:       variable.Type,
-			Label:      variable.Label,
-			Query:      query,
-			Multi:      variable.Multi,
-			IncludeAll: variable.IncludeAll,
-		})
-	}
-	report.VariablesFound = len(variables)
-
-	var timeRange *TimeRangeResource
-	if dashboard.Time != nil {
-		timeRange = &TimeRangeResource{
-			From: dashboard.Time.From,
-			To:   dashboard.Time.To,
-		}
-	}
+	// Count variables for the report but don't store in document
+	report.VariablesFound = len(dashboard.Templating.List)
 
 	doc := DashboardDocument{
-		SchemaVersion: CurrentSchemaVersion,
-		Dashboard: DashboardResource{
-			Title:           dashboard.Title,
-			Description:     optionalString(dashboard.Description),
-			Panels:          panels,
-			Variables:       variables,
-			TimeRange:       timeRange,
-			RefreshInterval: optionalString(dashboard.Refresh),
-		},
+		Version:     CurrentSchemaVersion,
+		Title:       dashboard.Title,
+		Description: strings.TrimSpace(dashboard.Description),
+		Panels:      panels,
 	}
 
 	if report.TotalPanels > 0 {
@@ -360,6 +240,56 @@ func ConvertGrafanaDashboardWithReport(data []byte) (DashboardDocument, Conversi
 	}
 
 	return doc, report, nil
+}
+
+func parseGrafanaInput(data []byte) (*grafanaDashboard, error) {
+	var envelope grafanaEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("invalid grafana JSON: %w", err)
+	}
+
+	if envelope.Dashboard != nil {
+		if strings.TrimSpace(envelope.Dashboard.Title) == "" {
+			return nil, fmt.Errorf("grafana dashboard title is required")
+		}
+		return envelope.Dashboard, nil
+	}
+
+	var raw grafanaDashboard
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("invalid grafana dashboard: %w", err)
+	}
+	if strings.TrimSpace(raw.Title) == "" {
+		return nil, fmt.Errorf("grafana dashboard title is required")
+	}
+	return &raw, nil
+}
+
+func mapGrafanaPanelType(panelType string) (string, string) {
+	switch strings.ToLower(strings.TrimSpace(panelType)) {
+	case "graph", "timeseries":
+		return "line_chart", ""
+	case "gauge":
+		return "gauge", ""
+	case "stat":
+		return "stat", ""
+	case "piechart", "pie chart":
+		return "pie", ""
+	case "logs":
+		return "logs", ""
+	case "table":
+		return "table", ""
+	case "bargauge":
+		return "bar_gauge", ""
+	case "barchart":
+		return "bar_chart", ""
+	case "heatmap":
+		return "heatmap", ""
+	case "histogram":
+		return "histogram", ""
+	default:
+		return "line_chart", fmt.Sprintf("unsupported panel type %q mapped to line_chart", panelType)
+	}
 }
 
 // countFieldOverrides attempts to count fieldConfig.overrides per panel from raw JSON.
@@ -390,12 +320,4 @@ func countFieldOverrides(data []byte) []int {
 		}
 	}
 	return counts
-}
-
-func optionalString(value string) *string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return nil
-	}
-	return &trimmed
 }

--- a/backend/internal/converter/grafana_test.go
+++ b/backend/internal/converter/grafana_test.go
@@ -23,16 +23,13 @@ func TestMapGrafanaPanelType(t *testing.T) {
 		{"barchart", "bar_chart", false},
 		{"heatmap", "heatmap", false},
 		{"histogram", "histogram", false},
-		// Case insensitivity
 		{"Graph", "line_chart", false},
 		{"TIMESERIES", "line_chart", false},
 		{"Gauge", "gauge", false},
 		{"PieChart", "pie", false},
 		{"BarGauge", "bar_gauge", false},
-		// Whitespace trimming
 		{" graph ", "line_chart", false},
 		{" table ", "table", false},
-		// Unknown types fall back to line_chart with warning
 		{"unknown_panel", "line_chart", true},
 		{"nodeGraph", "line_chart", true},
 		{"", "line_chart", true},
@@ -61,33 +58,12 @@ func TestConvertGrafanaDashboard_EnvelopeFormat(t *testing.T) {
     "time": {"from": "now-6h", "to": "now"},
     "templating": {
       "list": [
-        {
-          "name": "service",
-          "type": "query",
-          "label": "Service",
-          "query": "label_values(up, service)",
-          "multi": true,
-          "includeAll": true
-        }
+        {"name": "service", "type": "query", "label": "Service", "query": "label_values(up, service)", "multi": true, "includeAll": true}
       ]
     },
     "panels": [
-      {
-        "title": "CPU Usage",
-        "type": "timeseries",
-        "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
-        "targets": [
-          {"refId": "A", "expr": "sum(rate(container_cpu_usage_seconds_total[5m]))"}
-        ]
-      },
-      {
-        "title": "Requests",
-        "type": "gauge",
-        "gridPos": {"x": 0, "y": 8, "w": 6, "h": 4},
-        "targets": [
-          {"refId": "B", "expr": "sum(up)"}
-        ]
-      }
+      {"title": "CPU Usage", "type": "timeseries", "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}, "targets": [{"refId": "A", "expr": "sum(rate(container_cpu_usage_seconds_total[5m]))"}]},
+      {"title": "Requests", "type": "gauge", "gridPos": {"x": 0, "y": 8, "w": 6, "h": 4}, "targets": [{"refId": "B", "expr": "sum(up)"}]}
     ]
   }
 }`)
@@ -97,65 +73,41 @@ func TestConvertGrafanaDashboard_EnvelopeFormat(t *testing.T) {
 		t.Fatalf("expected conversion to succeed: %v", err)
 	}
 
-	if doc.Dashboard.Title != "Grafana CPU" {
-		t.Fatalf("expected title 'Grafana CPU', got %q", doc.Dashboard.Title)
+	if doc.Title != "Grafana CPU" {
+		t.Fatalf("expected title 'Grafana CPU', got %q", doc.Title)
 	}
-	if len(doc.Dashboard.Panels) != 2 {
-		t.Fatalf("expected 2 panels, got %d", len(doc.Dashboard.Panels))
+	if len(doc.Panels) != 2 {
+		t.Fatalf("expected 2 panels, got %d", len(doc.Panels))
 	}
-	if doc.Dashboard.Panels[0].Type != "line_chart" {
-		t.Fatalf("expected timeseries → line_chart, got %q", doc.Dashboard.Panels[0].Type)
+	if doc.Panels[0].Type != "line_chart" {
+		t.Fatalf("expected timeseries -> line_chart, got %q", doc.Panels[0].Type)
 	}
-	if doc.Dashboard.Panels[1].Type != "gauge" {
-		t.Fatalf("expected gauge → gauge, got %q", doc.Dashboard.Panels[1].Type)
+	if doc.Panels[1].Type != "gauge" {
+		t.Fatalf("expected gauge -> gauge, got %q", doc.Panels[1].Type)
 	}
 	if len(warnings) != 0 {
 		t.Fatalf("expected no warnings, got %d: %v", len(warnings), warnings)
 	}
-
-	// Variables
-	if len(doc.Dashboard.Variables) != 1 || doc.Dashboard.Variables[0].Name != "service" {
-		t.Fatalf("expected mapped variable 'service'")
+	if doc.Panels[0].Position.W != 12 || doc.Panels[0].Position.H != 8 {
+		t.Fatalf("expected position w=12 h=8, got %+v", doc.Panels[0].Position)
 	}
-	v := doc.Dashboard.Variables[0]
-	if !v.Multi || !v.IncludeAll {
-		t.Fatalf("expected multi=true, includeAll=true")
-	}
-
-	// Time range
-	if doc.Dashboard.TimeRange == nil || doc.Dashboard.TimeRange.From != "now-6h" {
-		t.Fatalf("expected mapped time range")
-	}
-
-	// Refresh
-	if doc.Dashboard.RefreshInterval == nil || *doc.Dashboard.RefreshInterval != "10s" {
-		t.Fatalf("expected refresh interval '10s'")
+	if doc.Panels[0].Query == nil || doc.Panels[0].Query.Expr == "" {
+		t.Fatal("expected panel to have a query with expr")
 	}
 }
 
 func TestConvertGrafanaDashboard_RawFormat(t *testing.T) {
-	// Without the {"dashboard": ...} envelope
-	payload := []byte(`{
-    "title": "Raw Dashboard",
-    "panels": [
-      {
-        "title": "Panel 1",
-        "type": "stat",
-        "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4},
-        "targets": [{"refId": "A", "expr": "up"}]
-      }
-    ]
-  }`)
+	payload := []byte(`{"title": "Raw Dashboard", "panels": [{"title": "Panel 1", "type": "stat", "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4}, "targets": [{"refId": "A", "expr": "up"}]}]}`)
 
 	doc, _, err := ConvertGrafanaDashboard(payload)
 	if err != nil {
 		t.Fatalf("expected raw format to succeed: %v", err)
 	}
-	if doc.Dashboard.Title != "Raw Dashboard" {
-		t.Fatalf("expected title 'Raw Dashboard', got %q", doc.Dashboard.Title)
+	if doc.Title != "Raw Dashboard" {
+		t.Fatalf("expected title 'Raw Dashboard', got %q", doc.Title)
 	}
-	if doc.Dashboard.Panels[0].Type != "stat" {
-		t.Fatalf("expected stat panel type, got %q", doc.Dashboard.Panels[0].Type)
+	if doc.Panels[0].Type != "stat" {
+		t.Fatalf("expected stat panel type, got %q", doc.Panels[0].Type)
 	}
 }
 
@@ -164,37 +116,20 @@ func TestConvertGrafanaDashboard_AllPanelTypes(t *testing.T) {
 		grafanaType string
 		aceType     string
 	}{
-		{"graph", "line_chart"},
-		{"timeseries", "line_chart"},
-		{"gauge", "gauge"},
-		{"stat", "stat"},
-		{"piechart", "pie"},
-		{"logs", "logs"},
-		{"table", "table"},
-		{"bargauge", "bar_gauge"},
-		{"barchart", "bar_chart"},
-		{"heatmap", "heatmap"},
-		{"histogram", "histogram"},
+		{"graph", "line_chart"}, {"timeseries", "line_chart"}, {"gauge", "gauge"},
+		{"stat", "stat"}, {"piechart", "pie"}, {"logs", "logs"}, {"table", "table"},
+		{"bargauge", "bar_gauge"}, {"barchart", "bar_chart"}, {"heatmap", "heatmap"}, {"histogram", "histogram"},
 	}
 
 	for _, p := range panels {
 		t.Run(p.grafanaType, func(t *testing.T) {
-			payload := []byte(`{
-        "title": "Test",
-        "panels": [{
-          "title": "P",
-          "type": "` + p.grafanaType + `",
-          "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
-          "targets": [{"refId": "A", "expr": "up"}]
-        }]
-      }`)
-
+			payload := []byte(`{"title": "Test", "panels": [{"title": "P", "type": "` + p.grafanaType + `", "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}, "targets": [{"refId": "A", "expr": "up"}]}]}`)
 			doc, warnings, err := ConvertGrafanaDashboard(payload)
 			if err != nil {
 				t.Fatalf("conversion failed for %s: %v", p.grafanaType, err)
 			}
-			if doc.Dashboard.Panels[0].Type != p.aceType {
-				t.Errorf("%s → got %q, want %q", p.grafanaType, doc.Dashboard.Panels[0].Type, p.aceType)
+			if doc.Panels[0].Type != p.aceType {
+				t.Errorf("%s -> got %q, want %q", p.grafanaType, doc.Panels[0].Type, p.aceType)
 			}
 			if len(warnings) != 0 {
 				t.Errorf("%s: unexpected warnings: %v", p.grafanaType, warnings)
@@ -204,22 +139,14 @@ func TestConvertGrafanaDashboard_AllPanelTypes(t *testing.T) {
 }
 
 func TestConvertGrafanaDashboard_UnsupportedPanelTypeWarning(t *testing.T) {
-	payload := []byte(`{
-    "title": "Test",
-    "panels": [{
-      "title": "Custom Plugin",
-      "type": "custom-plugin-panel",
-      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
-      "targets": [{"refId": "A", "expr": "up"}]
-    }]
-  }`)
+	payload := []byte(`{"title": "Test", "panels": [{"title": "Custom Plugin", "type": "custom-plugin-panel", "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}, "targets": [{"refId": "A", "expr": "up"}]}]}`)
 
 	doc, warnings, err := ConvertGrafanaDashboard(payload)
 	if err != nil {
 		t.Fatalf("conversion failed: %v", err)
 	}
-	if doc.Dashboard.Panels[0].Type != "line_chart" {
-		t.Errorf("expected fallback to line_chart, got %q", doc.Dashboard.Panels[0].Type)
+	if doc.Panels[0].Type != "line_chart" {
+		t.Errorf("expected fallback to line_chart, got %q", doc.Panels[0].Type)
 	}
 	if len(warnings) != 1 {
 		t.Fatalf("expected 1 warning, got %d", len(warnings))
@@ -244,129 +171,57 @@ func TestConvertGrafanaDashboard_MalformedJSON(t *testing.T) {
 }
 
 func TestConvertGrafanaDashboard_MissingTitle(t *testing.T) {
-	payload := []byte(`{
-    "panels": [{
-      "title": "P",
-      "type": "stat",
-      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4},
-      "targets": [{"refId": "A", "expr": "up"}]
-    }]
-  }`)
-
-	_, _, err := ConvertGrafanaDashboard(payload)
+	_, _, err := ConvertGrafanaDashboard([]byte(`{"panels": [{"title": "P", "type": "stat", "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4}, "targets": [{"refId": "A", "expr": "up"}]}]}`))
 	if err == nil {
 		t.Fatal("expected error for missing title")
 	}
 }
 
 func TestConvertGrafanaDashboard_MissingPanelTitle(t *testing.T) {
-	payload := []byte(`{
-    "title": "Test",
-    "panels": [{
-      "title": "",
-      "type": "stat",
-      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4},
-      "targets": [{"refId": "A", "expr": "up"}]
-    }]
-  }`)
-
+	payload := []byte(`{"title": "Test", "panels": [{"title": "", "type": "stat", "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4}, "targets": [{"refId": "A", "expr": "up"}]}]}`)
 	doc, _, err := ConvertGrafanaDashboard(payload)
 	if err != nil {
 		t.Fatalf("conversion should succeed with auto-generated title: %v", err)
 	}
-	if doc.Dashboard.Panels[0].Title != "Panel 1" {
-		t.Errorf("expected auto-generated title 'Panel 1', got %q", doc.Dashboard.Panels[0].Title)
+	if doc.Panels[0].Title != "Panel 1" {
+		t.Errorf("expected auto-generated title 'Panel 1', got %q", doc.Panels[0].Title)
 	}
 }
 
 func TestConvertGrafanaDashboard_MissingGridPos(t *testing.T) {
-	payload := []byte(`{
-    "title": "Test",
-    "panels": [{
-      "title": "P",
-      "type": "stat",
-      "targets": [{"refId": "A", "expr": "up"}]
-    }]
-  }`)
-
+	payload := []byte(`{"title": "Test", "panels": [{"title": "P", "type": "stat", "targets": [{"refId": "A", "expr": "up"}]}]}`)
 	doc, _, err := ConvertGrafanaDashboard(payload)
 	if err != nil {
-		t.Fatalf("should auto-generate grid_pos: %v", err)
+		t.Fatalf("should auto-generate position: %v", err)
 	}
-	gp := doc.Dashboard.Panels[0].GridPos
-	if gp["w"] != 12 || gp["h"] != 8 {
-		t.Errorf("expected default grid_pos w=12 h=8, got %v", gp)
+	pos := doc.Panels[0].Position
+	if pos.W != 12 || pos.H != 8 {
+		t.Errorf("expected default position w=12 h=8, got %+v", pos)
 	}
 }
 
-func TestConvertGrafanaDashboard_VariableExtraction(t *testing.T) {
-	payload := []byte(`{
-    "title": "Vars Test",
-    "templating": {
-      "list": [
-        {"name": "job", "type": "query", "query": "label_values(up, job)", "multi": false, "includeAll": false},
-        {"name": "env", "type": "custom", "label": "Environment", "definition": "prod,staging,dev", "multi": true, "includeAll": true},
-        {"name": "const", "type": "constant", "query": "fixed-value"}
-      ]
-    },
-    "panels": [{
-      "title": "P",
-      "type": "stat",
-      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4},
-      "targets": [{"refId": "A", "expr": "up{job=\"$job\"}"}]
-    }]
-  }`)
+func TestConvertGrafanaDashboardWithReport_VariablesCount(t *testing.T) {
+	payload := []byte(`{"title": "Vars Test", "templating": {"list": [{"name": "job", "type": "query", "query": "label_values(up, job)"}, {"name": "env", "type": "custom", "definition": "prod,staging,dev", "multi": true, "includeAll": true}, {"name": "const", "type": "constant", "query": "fixed-value"}]}, "panels": [{"title": "P", "type": "stat", "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4}, "targets": [{"refId": "A", "expr": "up"}]}]}`)
 
-	doc, _, err := ConvertGrafanaDashboard(payload)
+	doc, report, err := ConvertGrafanaDashboardWithReport(payload)
 	if err != nil {
 		t.Fatalf("conversion failed: %v", err)
 	}
-	if len(doc.Dashboard.Variables) != 3 {
-		t.Fatalf("expected 3 variables, got %d", len(doc.Dashboard.Variables))
+	if report.VariablesFound != 3 {
+		t.Fatalf("expected 3 variables in report, got %d", report.VariablesFound)
 	}
-
-	// First var: query type, uses query field
-	v0 := doc.Dashboard.Variables[0]
-	if v0.Name != "job" || v0.Type != "query" || v0.Query != "label_values(up, job)" {
-		t.Errorf("variable 0 mismatch: %+v", v0)
-	}
-
-	// Second var: custom type, falls back to definition field
-	v1 := doc.Dashboard.Variables[1]
-	if v1.Name != "env" || v1.Type != "custom" || v1.Query != "prod,staging,dev" {
-		t.Errorf("variable 1 mismatch: %+v", v1)
-	}
-	if !v1.Multi || !v1.IncludeAll {
-		t.Errorf("variable 1 multi/includeAll mismatch")
-	}
-
-	// Third var: constant type
-	v2 := doc.Dashboard.Variables[2]
-	if v2.Name != "const" || v2.Type != "constant" || v2.Query != "fixed-value" {
-		t.Errorf("variable 2 mismatch: %+v", v2)
+	if doc.Title != "Vars Test" {
+		t.Fatalf("expected title 'Vars Test', got %q", doc.Title)
 	}
 }
 
 func TestConvertGrafanaDashboard_QueryFallbackToQueryField(t *testing.T) {
-	// When expr is empty, should fall back to the query field
-	payload := []byte(`{
-    "title": "Test",
-    "panels": [{
-      "title": "P",
-      "type": "table",
-      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
-      "targets": [{"refId": "A", "query": "sum(up)"}]
-    }]
-  }`)
-
+	payload := []byte(`{"title": "Test", "panels": [{"title": "P", "type": "table", "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}, "targets": [{"refId": "A", "query": "sum(up)"}]}]}`)
 	doc, _, err := ConvertGrafanaDashboard(payload)
 	if err != nil {
 		t.Fatalf("conversion failed: %v", err)
 	}
-
-	// Query should contain the expression from the query field
-	queryStr := string(doc.Dashboard.Panels[0].Query)
-	if !strings.Contains(queryStr, "sum(up)") {
-		t.Errorf("expected query to contain 'sum(up)', got %s", queryStr)
+	if doc.Panels[0].Query == nil || doc.Panels[0].Query.Expr != "sum(up)" {
+		t.Errorf("expected query expr 'sum(up)', got %v", doc.Panels[0].Query)
 	}
 }

--- a/backend/internal/handlers/dashboard_cac.go
+++ b/backend/internal/handlers/dashboard_cac.go
@@ -71,7 +71,7 @@ func (h *DashboardHandler) Export(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := h.pool.Query(ctx,
-		`SELECT title, type, grid_pos, query, datasource_id
+		`SELECT title, type, grid_pos, query
 		 FROM panels
 		 WHERE dashboard_id = $1
 		 ORDER BY created_at ASC`,
@@ -83,38 +83,84 @@ func (h *DashboardHandler) Export(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 
-	panels := make([]converter.PanelResource, 0)
-	for rows.Next() {
-		var panel converter.PanelResource
-		var gridPosRaw []byte
-		var queryRaw []byte
-		var datasourceID *uuid.UUID
+	// Collect panels and extract datasource IDs from query blobs
+	type rawPanel struct {
+		title     string
+		panelType string
+		gridPos   json.RawMessage
+		queryBlob json.RawMessage
+		datasrcID string // extracted from query blob
+	}
+	var rawPanels []rawPanel
+	dsIDs := make(map[string]bool)
 
-		if err := rows.Scan(&panel.Title, &panel.Type, &gridPosRaw, &queryRaw, &datasourceID); err != nil {
+	for rows.Next() {
+		var rp rawPanel
+		if err := rows.Scan(&rp.title, &rp.panelType, &rp.gridPos, &rp.queryBlob); err != nil {
 			http.Error(w, `{"error":"failed to read dashboard panels"}`, http.StatusInternalServerError)
 			return
 		}
-		if err := json.Unmarshal(gridPosRaw, &panel.GridPos); err != nil {
+		rp.datasrcID = converter.ExtractDatasourceID(rp.queryBlob)
+		if rp.datasrcID != "" {
+			dsIDs[rp.datasrcID] = true
+		}
+		rawPanels = append(rawPanels, rp)
+	}
+
+	// Batch-resolve datasource UUIDs to name+type
+	resolver := NewDatasourceResolver(h.pool)
+	var dsUUIDs []uuid.UUID
+	for idStr := range dsIDs {
+		if id, err := uuid.Parse(idStr); err == nil {
+			dsUUIDs = append(dsUUIDs, id)
+		}
+	}
+	dsRefs, err := resolver.LookupRefs(ctx, dsUUIDs)
+	if err != nil {
+		http.Error(w, `{"error":"failed to resolve datasources"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Build v2 panels
+	panels := make([]converter.PanelResource, 0, len(rawPanels))
+	for _, rp := range rawPanels {
+		var pos converter.GridPosition
+		if err := json.Unmarshal(rp.gridPos, &pos); err != nil {
 			http.Error(w, `{"error":"failed to decode panel layout"}`, http.StatusInternalServerError)
 			return
 		}
-		if len(queryRaw) > 0 {
-			panel.Query = queryRaw
+
+		q, d := converter.QueryBlobToResources(rp.queryBlob)
+
+		panel := converter.PanelResource{
+			Title:    rp.title,
+			Type:     rp.panelType,
+			Position: pos,
+			Query:    q,
+			Display:  d,
 		}
-		if datasourceID != nil {
-			panel.DataSourceID = datasourceID
+
+		if rp.datasrcID != "" {
+			if dsID, err := uuid.Parse(rp.datasrcID); err == nil {
+				if ref, ok := dsRefs[dsID]; ok {
+					panel.Datasource = &ref
+				}
+			}
 		}
+
 		panels = append(panels, panel)
 	}
 
+	description := ""
+	if dashboard.Description != nil {
+		description = *dashboard.Description
+	}
+
 	doc := converter.DashboardDocument{
-		SchemaVersion: converter.CurrentSchemaVersion,
-		Dashboard: converter.DashboardResource{
-			ID:          &dashboard.ID,
-			Title:       dashboard.Title,
-			Description: dashboard.Description,
-			Panels:      panels,
-		},
+		Version:     converter.CurrentSchemaVersion,
+		Title:       dashboard.Title,
+		Description: description,
+		Panels:      panels,
 	}
 
 	payload, err := converter.EncodeDashboardDocument(doc, format)
@@ -182,13 +228,18 @@ func (h *DashboardHandler) Import(w http.ResponseWriter, r *http.Request) {
 	}
 	defer tx.Rollback(ctx)
 
+	descPtr := &doc.Description
+	if doc.Description == "" {
+		descPtr = nil
+	}
+
 	var imported models.Dashboard
 	err = tx.QueryRow(ctx,
 		`INSERT INTO dashboards (title, description, organization_id, created_by)
 		 VALUES ($1, $2, $3, $4)
 		 RETURNING id, title, description, folder_id, sort_order, created_at, updated_at, organization_id, created_by`,
-		doc.Dashboard.Title,
-		doc.Dashboard.Description,
+		doc.Title,
+		descPtr,
 		orgID,
 		userID,
 	).Scan(&imported.ID, &imported.Title, &imported.Description, &imported.FolderID, &imported.SortOrder, &imported.CreatedAt, &imported.UpdatedAt, &imported.OrganizationID, &imported.CreatedBy)
@@ -197,17 +248,31 @@ func (h *DashboardHandler) Import(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, panel := range doc.Dashboard.Panels {
-		gridPosRaw, err := json.Marshal(panel.GridPos)
+	resolver := NewDatasourceResolver(h.pool)
+
+	for _, panel := range doc.Panels {
+		gridPosRaw, err := json.Marshal(panel.Position)
 		if err != nil {
 			http.Error(w, `{"error":"failed to encode panel layout"}`, http.StatusBadRequest)
 			return
 		}
 
+		// Resolve datasource ref to UUID
+		var dsIDStr *string
 		var datasourceID any
-		if panel.DataSourceID != nil {
-			datasourceID = *panel.DataSourceID
+		if panel.Datasource != nil {
+			resolved, err := resolver.ResolveRef(ctx, orgID, *panel.Datasource)
+			if err != nil {
+				http.Error(w, `{"error":"datasource not found: `+panel.Datasource.Type+`"}`, http.StatusBadRequest)
+				return
+			}
+			datasourceID = *resolved
+			s := resolved.String()
+			dsIDStr = &s
 		}
+
+		// Re-assemble query blob from structured fields
+		queryBlob := converter.ResourcesToQueryBlob(panel.Query, panel.Display, dsIDStr)
 
 		_, err = tx.Exec(ctx,
 			`INSERT INTO panels (dashboard_id, title, type, grid_pos, query, datasource_id, created_by)
@@ -216,7 +281,7 @@ func (h *DashboardHandler) Import(w http.ResponseWriter, r *http.Request) {
 			panel.Title,
 			panel.Type,
 			gridPosRaw,
-			panel.Query,
+			queryBlob,
 			datasourceID,
 			userID,
 		)

--- a/backend/internal/handlers/dashboard_cac.go
+++ b/backend/internal/handlers/dashboard_cac.go
@@ -106,6 +106,10 @@ func (h *DashboardHandler) Export(w http.ResponseWriter, r *http.Request) {
 		}
 		rawPanels = append(rawPanels, rp)
 	}
+	if err := rows.Err(); err != nil {
+		http.Error(w, `{"error":"failed to read dashboard panels"}`, http.StatusInternalServerError)
+		return
+	}
 
 	// Batch-resolve datasource UUIDs to name+type
 	resolver := NewDatasourceResolver(h.pool)

--- a/backend/internal/handlers/datasource_resolver.go
+++ b/backend/internal/handlers/datasource_resolver.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/aceobservability/ace/backend/internal/converter"
+)
+
+// DatasourceResolver translates between datasource UUIDs (DB) and
+// portable DatasourceRef values (name + type) used in the v2 export format.
+type DatasourceResolver struct {
+	pool *pgxpool.Pool
+}
+
+func NewDatasourceResolver(pool *pgxpool.Pool) *DatasourceResolver {
+	return &DatasourceResolver{pool: pool}
+}
+
+// LookupRefs returns a DatasourceRef (name + type) for each given UUID.
+// Unknown IDs are silently skipped (panel may have no datasource).
+func (r *DatasourceResolver) LookupRefs(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]converter.DatasourceRef, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, name, type FROM datasources WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("lookup datasources: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[uuid.UUID]converter.DatasourceRef, len(ids))
+	for rows.Next() {
+		var id uuid.UUID
+		var name, dsType string
+		if err := rows.Scan(&id, &name, &dsType); err != nil {
+			return nil, fmt.Errorf("scan datasource: %w", err)
+		}
+		result[id] = converter.DatasourceRef{Name: name, Type: dsType}
+	}
+	return result, rows.Err()
+}
+
+// ResolveRef finds a datasource UUID in the given org matching a DatasourceRef.
+// Priority: exact name+type match → default datasource of that type → any of that type → error.
+func (r *DatasourceResolver) ResolveRef(ctx context.Context, orgID uuid.UUID, ref converter.DatasourceRef) (*uuid.UUID, error) {
+	// Try exact name+type match
+	if ref.Name != "" {
+		var id uuid.UUID
+		err := r.pool.QueryRow(ctx,
+			`SELECT id FROM datasources
+			 WHERE organization_id = $1 AND name = $2 AND type = $3
+			 LIMIT 1`,
+			orgID, ref.Name, ref.Type,
+		).Scan(&id)
+		if err == nil {
+			return &id, nil
+		}
+	}
+
+	// Fall back to default datasource of that type, or any of that type
+	var id uuid.UUID
+	err := r.pool.QueryRow(ctx,
+		`SELECT id FROM datasources
+		 WHERE organization_id = $1 AND type = $2
+		 ORDER BY is_default DESC, created_at ASC
+		 LIMIT 1`,
+		orgID, ref.Type,
+	).Scan(&id)
+	if err != nil {
+		return nil, fmt.Errorf("no datasource of type %q found in organization", ref.Type)
+	}
+	return &id, nil
+}

--- a/backend/internal/handlers/grafana_converter_test.go
+++ b/backend/internal/handlers/grafana_converter_test.go
@@ -40,8 +40,8 @@ func TestGrafanaConverterHandler_Convert_Success(t *testing.T) {
 	if response.Format != "yaml" {
 		t.Fatalf("expected yaml format, got %q", response.Format)
 	}
-	if response.Document.Dashboard.Title != "API Overview" {
-		t.Fatalf("expected converted title, got %q", response.Document.Dashboard.Title)
+	if response.Document.Title != "API Overview" {
+		t.Fatalf("expected converted title, got %q", response.Document.Title)
 	}
 }
 

--- a/frontend/src/api/dashboards.export.spec.ts
+++ b/frontend/src/api/dashboards.export.spec.ts
@@ -18,7 +18,7 @@ describe('exportDashboardYaml', () => {
   it('downloads yaml payload from export endpoint', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      text: () => Promise.resolve('schema_version: 1\ndashboard:\n  title: Test\n'),
+      text: () => Promise.resolve('version: 2\ntitle: Test\n'),
     })
 
     const result = await exportDashboardYaml('dashboard-1')

--- a/frontend/src/api/dashboards.import.spec.ts
+++ b/frontend/src/api/dashboards.import.spec.ts
@@ -27,7 +27,7 @@ describe('importDashboardYaml', () => {
         }),
     })
 
-    const yamlPayload = 'schema_version: 1\ndashboard:\n  title: Imported Dashboard\n'
+    const yamlPayload = 'version: 2\ntitle: Imported Dashboard\n'
     const result = await importDashboardYaml('org-1', yamlPayload)
 
     expect(mockFetch).toHaveBeenCalledWith(

--- a/frontend/src/components/CreateDashboardModal.spec.ts
+++ b/frontend/src/components/CreateDashboardModal.spec.ts
@@ -134,7 +134,7 @@ describe('CreateDashboardModal', () => {
     const input = wrapper.find('input#yaml-file')
     const file = new File(
       [
-        'schema_version: 1\ndashboard:\n  title: Imported Dashboard\n  panels:\n    - title: Requests\n      type: line_chart\n    - title: Errors\n      type: stat\n',
+        'version: 2\ntitle: Imported Dashboard\npanels:\n  - title: Requests\n    type: line_chart\n  - title: Errors\n    type: stat\n',
       ],
       'dashboard.yaml',
       { type: 'application/x-yaml' },
@@ -154,7 +154,7 @@ describe('CreateDashboardModal', () => {
 
     expect(api.importDashboardYaml).toHaveBeenCalledWith(
       'org-1',
-      expect.stringContaining('dashboard:'),
+      expect.stringContaining('title: Imported Dashboard'),
     )
     expect(wrapper.emitted('created')).toBeTruthy()
   })
@@ -195,7 +195,7 @@ describe('CreateDashboardModal', () => {
       ?.trigger('click')
 
     const input = wrapper.find('input#yaml-file')
-    const file = new File(['schema_version: 1\nname: invalid\n'], 'dashboard.yaml', {
+    const file = new File(['version: 2\nname: invalid\n'], 'dashboard.yaml', {
       type: 'application/x-yaml',
     })
 
@@ -206,7 +206,7 @@ describe('CreateDashboardModal', () => {
     await input.trigger('change')
     await flushPromises()
 
-    expect(wrapper.text()).toContain('Invalid YAML file. Missing dashboard section')
+    expect(wrapper.text()).toContain('Invalid YAML file. Missing dashboard title')
   })
 
   it('imports dashboard from grafana json conversion', async () => {

--- a/frontend/src/components/CreateDashboardModal.spec.ts
+++ b/frontend/src/components/CreateDashboardModal.spec.ts
@@ -213,20 +213,18 @@ describe('CreateDashboardModal', () => {
     vi.mocked(converterApi.convertGrafanaDashboard).mockResolvedValue({
       format: 'yaml',
       content:
-        'schema_version: 1\ndashboard:\n  title: Converted Dashboard\n  panels:\n    - title: Requests\n',
+        'version: 2\ntitle: Converted Dashboard\npanels:\n  - title: Requests\n',
       document: {
-        schema_version: 1,
-        dashboard: {
-          title: 'Converted Dashboard',
-          description: 'From Grafana',
-          panels: [
-            {
-              title: 'Requests',
-              type: 'line_chart',
-              grid_pos: { x: 0, y: 0, w: 24, h: 8 },
-            },
-          ],
-        },
+        version: 2,
+        title: 'Converted Dashboard',
+        description: 'From Grafana',
+        panels: [
+          {
+            title: 'Requests',
+            type: 'line_chart',
+            position: { x: 0, y: 0, w: 24, h: 8 },
+          },
+        ],
       },
       warnings: ['Converted unsupported panel type'],
     })
@@ -266,7 +264,7 @@ describe('CreateDashboardModal', () => {
 
     expect(api.importDashboardYaml).toHaveBeenCalledWith(
       'org-1',
-      expect.stringContaining('schema_version'),
+      expect.stringContaining('version: 2'),
     )
     expect(wrapper.emitted('created')).toBeTruthy()
   })

--- a/frontend/src/components/CreateDashboardModal.vue
+++ b/frontend/src/components/CreateDashboardModal.vue
@@ -92,18 +92,12 @@ function normalizeYamlValue(value: string): string {
 }
 
 function buildYamlPreview(rawYaml: string): ImportPreview {
-  const schemaVersionMatch = rawYaml.match(/(?:^|\n)schema_version:\s*(.+)/)
-  if (!schemaVersionMatch) {
-    throw new Error('Missing schema_version')
+  const versionMatch = rawYaml.match(/(?:^|\n)version:\s*(.+)/)
+  if (!versionMatch) {
+    throw new Error('Missing version')
   }
 
-  const dashboardSectionMatch = rawYaml.match(/(?:^|\n)dashboard:\s*\n([\s\S]*)/)
-  if (!dashboardSectionMatch) {
-    throw new Error('Missing dashboard section')
-  }
-
-  const dashboardSection = dashboardSectionMatch[1]
-  const titleMatch = dashboardSection.match(/(?:^|\n)\s{2}title:\s*(.+)/)
+  const titleMatch = rawYaml.match(/(?:^|\n)title:\s*(.+)/)
   if (!titleMatch) {
     throw new Error('Missing dashboard title')
   }
@@ -113,11 +107,11 @@ function buildYamlPreview(rawYaml: string): ImportPreview {
     throw new Error('Dashboard title is empty')
   }
 
-  const descriptionMatch = dashboardSection.match(/(?:^|\n)\s{2}description:\s*(.+)/)
-  const panelsSectionMatch = dashboardSection.match(
-    /(?:^|\n)\s{2}panels:\s*\n([\s\S]*?)(?=\n\s{2}[a-zA-Z_][\w-]*:\s*|\s*$)/,
+  const descriptionMatch = rawYaml.match(/(?:^|\n)description:\s*(.+)/)
+  const panelsSectionMatch = rawYaml.match(
+    /(?:^|\n)panels:\s*\n([\s\S]*?)(?=\n[a-zA-Z_][\w-]*:\s*|\s*$)/,
   )
-  const panelCount = (panelsSectionMatch?.[1]?.match(/(?:^|\n)\s{4}-\s+/g) ?? []).length
+  const panelCount = (panelsSectionMatch?.[1]?.match(/(?:^|\n)\s{2}-\s+/g) ?? []).length
 
   return {
     title: extractedTitle,

--- a/frontend/src/components/CreateDashboardModal.vue
+++ b/frontend/src/components/CreateDashboardModal.vue
@@ -126,16 +126,14 @@ function setMode(nextMode: CreationMode) {
 }
 
 function setImportPreviewFromDocument(document: {
-  dashboard: {
-    title: string
-    description?: string
-    panels: unknown[]
-  }
+  title: string
+  description?: string
+  panels: unknown[]
 }) {
   importPreview.value = {
-    title: document.dashboard.title,
-    description: document.dashboard.description ?? '',
-    panelCount: document.dashboard.panels.length,
+    title: document.title,
+    description: document.description ?? '',
+    panelCount: document.panels.length,
   }
 }
 
@@ -301,18 +299,8 @@ async function convertGrafana() {
     setImportPreviewFromDocument(response.document)
     extractGrafanaDatasources(grafanaSource.value)
 
-    // Extract variables for persistence
-    const vars = response.document?.dashboard?.variables
-    if (vars && vars.length > 0) {
-      convertedVariables.value = vars.map(v => ({
-        name: v.name,
-        type: v.type || 'query',
-        label: v.label,
-        query: v.query,
-        multi: v.multi ?? false,
-        include_all: v.include_all ?? false,
-      }))
-    }
+    // Variables are not included in v2 export format (counted in report only)
+    convertedVariables.value = []
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to convert Grafana dashboard'
   } finally {

--- a/frontend/src/components/DashboardSpecPreview.spec.ts
+++ b/frontend/src/components/DashboardSpecPreview.spec.ts
@@ -55,20 +55,23 @@ function makeSpec(overrides?: Partial<DashboardSpec>): DashboardSpec {
       {
         title: 'Requests',
         type: 'line_chart',
-        grid_pos: { x: 0, y: 0, w: 6, h: 2 },
-        query: { datasource_id: 'ds-1', expr: 'rate(up[5m])' },
+        position: { x: 0, y: 0, w: 6, h: 2 },
+        datasource_id: 'ds-1',
+        query: { expr: 'rate(up[5m])' },
       },
       {
         title: 'Errors',
         type: 'stat',
-        grid_pos: { x: 6, y: 0, w: 6, h: 2 },
-        query: { datasource_id: 'ds-1', expr: 'sum(errors_total)' },
+        position: { x: 6, y: 0, w: 6, h: 2 },
+        datasource_id: 'ds-1',
+        query: { expr: 'sum(errors_total)' },
       },
       {
         title: 'CPU',
         type: 'gauge',
-        grid_pos: { x: 0, y: 2, w: 4, h: 2 },
-        query: { datasource_id: 'ds-1', expr: 'process_cpu_seconds_total' },
+        position: { x: 0, y: 2, w: 4, h: 2 },
+        datasource_id: 'ds-1',
+        query: { expr: 'process_cpu_seconds_total' },
       },
     ],
     ...overrides,
@@ -128,7 +131,7 @@ describe('DashboardSpecPreview', () => {
   it('shows validation errors and disables save when spec is invalid', async () => {
     mockValidateDashboardSpec.mockReturnValue({
       valid: false,
-      errors: ['Panel 1: grid_pos.x + w must be <= 12, got 14'],
+      errors: ['Panel 1: position.x + w must be <= 12, got 14'],
     })
 
     const spec = makeSpec({
@@ -136,8 +139,9 @@ describe('DashboardSpecPreview', () => {
         {
           title: 'Wide panel',
           type: 'line_chart',
-          grid_pos: { x: 8, y: 0, w: 6, h: 2 },
-          query: { datasource_id: 'ds-1', expr: 'up' },
+          position: { x: 8, y: 0, w: 6, h: 2 },
+          datasource_id: 'ds-1',
+        query: { expr: 'up' },
         },
       ],
     })
@@ -149,7 +153,7 @@ describe('DashboardSpecPreview', () => {
     await flushPromises()
 
     // Validation errors should appear
-    expect(wrapper.text()).toContain('grid_pos.x + w must be <= 12')
+    expect(wrapper.text()).toContain('position.x + w must be <= 12')
     // Save button should be disabled after validation errors are set
     expect(saveBtn.attributes('disabled')).toBeDefined()
   })
@@ -161,8 +165,9 @@ describe('DashboardSpecPreview', () => {
         {
           title: 'HTTP Requests',
           type: 'line_chart',
-          grid_pos: { x: 0, y: 0, w: 12, h: 2 },
-          query: { datasource_id: 'ds-1', expr: 'rate(http_requests_total[5m])' },
+          position: { x: 0, y: 0, w: 12, h: 2 },
+          datasource_id: 'ds-1',
+        query: { expr: 'rate(http_requests_total[5m])' },
         },
       ],
     })
@@ -177,8 +182,9 @@ describe('DashboardSpecPreview', () => {
         {
           title: 'Custom metric',
           type: 'line_chart',
-          grid_pos: { x: 0, y: 0, w: 12, h: 2 },
-          query: { datasource_id: 'ds-1', expr: 'rate(my_custom_metric[5m])' },
+          position: { x: 0, y: 0, w: 12, h: 2 },
+          datasource_id: 'ds-1',
+        query: { expr: 'rate(my_custom_metric[5m])' },
         },
       ],
     })

--- a/frontend/src/components/DashboardSpecPreview.vue
+++ b/frontend/src/components/DashboardSpecPreview.vue
@@ -80,7 +80,7 @@ const panelTypeIcons: Record<PanelType, Component> = {
 /** Maximum row across all panels — used to size the grid height */
 const maxGridRow = computed(() => {
   if (!props.spec.panels || props.spec.panels.length === 0) return 1
-  return Math.max(...props.spec.panels.map((p) => (p.grid_pos?.y ?? 0) + (p.grid_pos?.h ?? 1)))
+  return Math.max(...props.spec.panels.map((p) => (p.position?.y ?? 0) + (p.position?.h ?? 1)))
 })
 
 const isSaved = computed(() => savedDashboardId.value !== null)
@@ -103,7 +103,7 @@ async function runDryRuns() {
 
   const promises = props.spec.panels.map(async (panel, index) => {
     try {
-      const result = await queryDataSource(panel.query.datasource_id, {
+      const result = await queryDataSource(panel.datasource_id, {
         query: panel.query.expr,
         signal: 'metrics',
         start: now - 300,
@@ -241,8 +241,8 @@ function dryRunDotClass(status: DryRunStatus): string {
           :aria-label="`${panel.title} (${panel.type})`"
           class="bg-[var(--color-surface-container-low)] rounded flex items-center gap-1 px-1.5 py-0.5 min-w-0 relative"
           :style="{
-            gridColumn: `${(panel.grid_pos?.x ?? 0) + 1} / span ${panel.grid_pos?.w ?? 4}`,
-            gridRow: `${(panel.grid_pos?.y ?? 0) + 1} / span ${panel.grid_pos?.h ?? 1}`,
+            gridColumn: `${(panel.position?.x ?? 0) + 1} / span ${panel.position?.w ?? 4}`,
+            gridRow: `${(panel.position?.y ?? 0) + 1} / span ${panel.position?.h ?? 1}`,
           }"
         >
           <component

--- a/frontend/src/composables/useDashboardGeneration.spec.ts
+++ b/frontend/src/composables/useDashboardGeneration.spec.ts
@@ -41,8 +41,9 @@ const validSpec = {
     {
       title: 'Panel 1',
       type: 'line_chart',
-      grid_pos: { x: 0, y: 0, w: 6, h: 3 },
-      query: { expr: 'up', datasource_id: '' },
+      position: { x: 0, y: 0, w: 6, h: 3 },
+      datasource_id: '',
+      query: { expr: 'up' },
     },
   ],
 }
@@ -92,7 +93,7 @@ describe('useDashboardGeneration', () => {
       expect(mockExecuteTool).toHaveBeenCalledOnce()
     })
 
-    it('injects datasourceId into every panel query.datasource_id', async () => {
+    it('injects datasourceId into every panel datasource_id', async () => {
       mockSendChatRequest.mockResolvedValueOnce({
         content: null,
         toolCalls: [makeToolCall('generate_dashboard', validSpec)],
@@ -105,7 +106,7 @@ describe('useDashboardGeneration', () => {
         'MyDS',
       )
 
-      expect(result.spec!.panels[0].query.datasource_id).toBe('ds-1')
+      expect(result.spec!.panels[0].datasource_id).toBe('ds-1')
     })
 
     it('calls onContent callback when AI returns content between iterations', async () => {

--- a/frontend/src/composables/useDashboardGeneration.ts
+++ b/frontend/src/composables/useDashboardGeneration.ts
@@ -92,7 +92,7 @@ export function useDashboardGeneration(
             }
 
             spec.panels?.forEach((p) => {
-              if (p.query) p.query.datasource_id = datasourceId()
+              p.datasource_id = datasourceId()
             })
 
             const validation = validateDashboardSpec(spec, [datasourceId()])

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -274,6 +274,58 @@
   ::-webkit-scrollbar-thumb:hover {
     background: var(--color-surface-bright);
   }
+
+  /* Range slider — themed to match dark surfaces */
+  input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    height: 4px;
+    border-radius: 9999px;
+    background: var(--color-surface-bright);
+    outline: none;
+    cursor: pointer;
+  }
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 9999px;
+    background: var(--color-primary);
+    border: 2px solid var(--color-surface-container-high);
+    box-shadow: 0 0 0 0 rgba(201, 150, 15, 0);
+    transition: box-shadow 150ms ease, background 150ms ease;
+  }
+  input[type="range"]::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 9999px;
+    background: var(--color-primary);
+    border: 2px solid var(--color-surface-container-high);
+    box-shadow: 0 0 0 0 rgba(201, 150, 15, 0);
+    transition: box-shadow 150ms ease, background 150ms ease;
+  }
+  input[type="range"]:hover::-webkit-slider-thumb {
+    box-shadow: 0 0 0 4px rgba(201, 150, 15, 0.16);
+  }
+  input[type="range"]:hover::-moz-range-thumb {
+    box-shadow: 0 0 0 4px rgba(201, 150, 15, 0.16);
+  }
+  input[type="range"]:active::-webkit-slider-thumb {
+    background: color-mix(in srgb, var(--color-primary) 80%, white);
+  }
+  input[type="range"]:active::-moz-range-thumb {
+    background: color-mix(in srgb, var(--color-primary) 80%, white);
+  }
+  input[type="range"]:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  input[type="range"]::-moz-range-track {
+    height: 4px;
+    border-radius: 9999px;
+    background: var(--color-surface-bright);
+  }
 }
 
 /* ─── Utility animations ─── */

--- a/frontend/src/types/converter.ts
+++ b/frontend/src/types/converter.ts
@@ -7,29 +7,20 @@ export interface DashboardVariable {
   include_all?: boolean
 }
 
-interface DashboardTimeRange {
-  from: string
-  to: string
-}
-
 interface DashboardPanelResource {
   title: string
   type: string
-  grid_pos: Record<string, number>
-  query?: Record<string, string>
+  position: { x: number; y: number; w: number; h: number }
+  datasource?: { name?: string; type: string }
+  query?: Record<string, unknown>
+  display?: Record<string, unknown>
 }
 
 export interface DashboardDocument {
-  schema_version: number
-  dashboard: {
-    id?: string
-    title: string
-    description?: string
-    panels: DashboardPanelResource[]
-    variables?: DashboardVariable[]
-    time_range?: DashboardTimeRange
-    refresh_interval?: string
-  }
+  version: number
+  title: string
+  description?: string
+  panels: DashboardPanelResource[]
 }
 
 export interface PanelDiagnostic {

--- a/frontend/src/utils/dashboardSpec.spec.ts
+++ b/frontend/src/utils/dashboardSpec.spec.ts
@@ -27,20 +27,23 @@ function makeValidSpec(overrides?: Partial<DashboardSpec>): DashboardSpec {
       {
         title: 'Requests per second',
         type: 'line_chart',
-        grid_pos: { x: 0, y: 0, w: 6, h: 2 },
-        query: { datasource_id: 'ds-1', expr: 'rate(http_requests_total[5m])' },
+        position: { x: 0, y: 0, w: 6, h: 2 },
+        datasource_id: 'ds-1',
+        query: { expr: 'rate(http_requests_total[5m])' },
       },
       {
         title: 'Error rate',
         type: 'stat',
-        grid_pos: { x: 6, y: 0, w: 6, h: 2 },
-        query: { datasource_id: 'ds-1', expr: 'sum(rate(errors_total[5m]))' },
+        position: { x: 6, y: 0, w: 6, h: 2 },
+        datasource_id: 'ds-1',
+        query: { expr: 'sum(rate(errors_total[5m]))' },
       },
       {
         title: 'CPU usage',
         type: 'gauge',
-        grid_pos: { x: 0, y: 2, w: 4, h: 2 },
-        query: { datasource_id: 'ds-1', expr: 'process_cpu_seconds_total' },
+        position: { x: 0, y: 2, w: 4, h: 2 },
+        datasource_id: 'ds-1',
+        query: { expr: 'process_cpu_seconds_total' },
       },
     ],
     ...overrides,
@@ -66,15 +69,16 @@ describe('validateDashboardSpec', () => {
         {
           title: 'Wide panel',
           type: 'line_chart',
-          grid_pos: { x: 8, y: 0, w: 6, h: 2 },
-          query: { datasource_id: 'ds-1', expr: 'up' },
+          position: { x: 8, y: 0, w: 6, h: 2 },
+          datasource_id: 'ds-1',
+        query: { expr: 'up' },
         },
       ],
     })
     const result = validateDashboardSpec(spec, ['ds-1'])
 
     expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.includes('grid_pos.x + w must be <= 12'))).toBe(true)
+    expect(result.errors.some((e) => e.includes('position.x + w must be <= 12'))).toBe(true)
   })
 
   // T3: empty expr
@@ -84,8 +88,9 @@ describe('validateDashboardSpec', () => {
         {
           title: 'Empty query panel',
           type: 'line_chart',
-          grid_pos: { x: 0, y: 0, w: 6, h: 2 },
-          query: { datasource_id: 'ds-1', expr: '' },
+          position: { x: 0, y: 0, w: 6, h: 2 },
+          datasource_id: 'ds-1',
+        query: { expr: '' },
         },
       ],
     })
@@ -102,8 +107,9 @@ describe('validateDashboardSpec', () => {
         {
           title: 'Unknown ds panel',
           type: 'line_chart',
-          grid_pos: { x: 0, y: 0, w: 6, h: 2 },
-          query: { datasource_id: 'unknown-id', expr: 'up' },
+          position: { x: 0, y: 0, w: 6, h: 2 },
+          datasource_id: 'unknown-id',
+        query: { expr: 'up' },
         },
       ],
     })
@@ -120,8 +126,9 @@ describe('validateDashboardSpec', () => {
         {
           title: 'Bad type panel',
           type: 'invalid_type' as unknown as PanelType,
-          grid_pos: { x: 0, y: 0, w: 6, h: 2 },
-          query: { datasource_id: 'ds-1', expr: 'up' },
+          position: { x: 0, y: 0, w: 6, h: 2 },
+          datasource_id: 'ds-1',
+        query: { expr: 'up' },
         },
       ],
     })
@@ -150,7 +157,7 @@ describe('saveDashboardSpec', () => {
       dashboard_id: 'dash-1',
       title: 'Panel',
       type: 'line_chart',
-      grid_pos: { x: 0, y: 0, w: 6, h: 2 },
+      position: { x: 0, y: 0, w: 6, h: 2 },
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-01-01T00:00:00Z',
     })
@@ -184,7 +191,7 @@ describe('saveDashboardSpec', () => {
         dashboard_id: 'dash-2',
         title: 'Panel 1',
         type: 'line_chart',
-        grid_pos: { x: 0, y: 0, w: 6, h: 2 },
+        position: { x: 0, y: 0, w: 6, h: 2 },
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
       })

--- a/frontend/src/utils/dashboardSpec.ts
+++ b/frontend/src/utils/dashboardSpec.ts
@@ -16,12 +16,12 @@ export interface DashboardSpec {
 export interface PanelSpec {
   title: string
   type: PanelType
-  grid_pos: GridPos
+  position: GridPos
+  datasource_id: string
   query: {
-    datasource_id: string // injected by frontend, AI omits this
     expr: string
     signal?: 'metrics' | 'logs' | 'traces'
-    legend_format?: string
+    legend?: string
   }
 }
 
@@ -63,24 +63,24 @@ export function validateDashboardSpec(
       }
 
       // Grid position validation
-      if (!panel.grid_pos) {
-        errors.push(`${prefix}: grid_pos is required`)
+      if (!panel.position) {
+        errors.push(`${prefix}: position is required`)
       } else {
-        const { x, y, w, h } = panel.grid_pos
+        const { x, y, w, h } = panel.position
         if (x < 0) {
-          errors.push(`${prefix}: grid_pos.x must be >= 0, got ${x}`)
+          errors.push(`${prefix}: position.x must be >= 0, got ${x}`)
         }
         if (y < 0) {
-          errors.push(`${prefix}: grid_pos.y must be >= 0, got ${y}`)
+          errors.push(`${prefix}: position.y must be >= 0, got ${y}`)
         }
         if (w <= 0) {
-          errors.push(`${prefix}: grid_pos.w must be > 0, got ${w}`)
+          errors.push(`${prefix}: position.w must be > 0, got ${w}`)
         }
         if (h <= 0) {
-          errors.push(`${prefix}: grid_pos.h must be > 0, got ${h}`)
+          errors.push(`${prefix}: position.h must be > 0, got ${h}`)
         }
         if (x + w > GRID_COLUMNS) {
-          errors.push(`${prefix}: grid_pos.x + w must be <= ${GRID_COLUMNS}, got ${x + w}`)
+          errors.push(`${prefix}: position.x + w must be <= ${GRID_COLUMNS}, got ${x + w}`)
         }
       }
 
@@ -90,9 +90,9 @@ export function validateDashboardSpec(
       }
 
       // Datasource ID must exist in known list
-      if (!knownDatasourceIds.includes(panel.query.datasource_id)) {
+      if (!knownDatasourceIds.includes(panel.datasource_id)) {
         errors.push(
-          `${prefix}: unknown datasource_id "${panel.query.datasource_id}"`,
+          `${prefix}: unknown datasource_id "${panel.datasource_id}"`,
         )
       }
     }
@@ -125,13 +125,13 @@ export async function saveDashboardSpec(
       await createPanel(dashboardId, {
         title: panel.title,
         type: panel.type,
-        grid_pos: panel.grid_pos,
+        grid_pos: panel.position,
         query: {
-          datasource_id: panel.query.datasource_id,
+          datasource_id: panel.datasource_id,
           expr: panel.query.expr,
           ...(panel.query.signal !== undefined ? { signal: panel.query.signal } : {}),
-          ...(panel.query.legend_format !== undefined
-            ? { legend_format: panel.query.legend_format }
+          ...(panel.query.legend !== undefined
+            ? { legend_format: panel.query.legend }
             : {}),
         },
       })


### PR DESCRIPTION
## Summary

Overhauls the dashboard export/import YAML format from v1 to v2, and themes the native range input sliders to match the dark design system.

**Dashboard Export v2:**
- Flat root structure (no `schema_version` + `dashboard:` wrapper)
- Structured `query` + `display` fields replacing opaque JSON blob
- Portable datasource references by `{name, type}` instead of UUIDs
- `GridPosition` struct replacing `map[string]int`
- Canvas panel data preserved via `raw_data` JSON string field
- `queryBlobToResources` / `resourcesToQueryBlob` for lossless DB translation
- `DatasourceResolver` with batch `LookupRefs` (export) and `ResolveRef` with name+type fallback (import)

**Frontend Alignment:**
- `PanelSpec` fields renamed: `grid_pos` → `position`, `query.datasource_id` → top-level, `query.legend_format` → `query.legend`
- `CreateDashboardModal` YAML preview updated for v2 format parsing

**Themed Range Sliders:**
- Custom CSS for `input[type="range"]` matching the Kinetic v2 design system
- Brass thumb, dark track, glow on hover, cross-browser (Webkit + Firefox)

## Test Coverage
- Backend: 32 converter tests + handler tests all pass
- Frontend: 1185 tests all pass
- New tests: `TestQueryBlobToResources` (8 panel type variants), `TestResourcesToQueryBlob`, `TestExtractDatasourceID`, `TestCanvasDataRoundTrip`, `TestGridPositionFlowYAML`, `TestValidateDashboardDocumentV2` (9 validation cases)

## Test plan
- [x] `go test ./internal/converter/...` passes
- [x] `go test ./internal/handlers/...` passes
- [x] `go build ./...` compiles cleanly
- [x] `bun run test` — 1185 tests pass
- [ ] Manual: export a dashboard → inspect YAML → import it back → verify panels match

🤖 Generated with [Claude Code](https://claude.com/claude-code)