### PR TITLE
feat: sync crosshair and tooltip across dashboard panels

### DIFF
--- a/frontend/src/components/BarChart.vue
+++ b/frontend/src/components/BarChart.vue
@@ -10,7 +10,10 @@ import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import VChart from 'vue-echarts'
-import { chartPalette, chartColors } from '../utils/chartTheme'
+import { useCrosshairSync } from '../composables/useCrosshairSync'
+import { chartPalette, chartColors, crosshairPointerStyle } from '../utils/chartTheme'
+
+const { groupId } = useCrosshairSync()
 
 // Register ECharts components
 use([
@@ -114,6 +117,10 @@ const chartOption = computed(() => {
       : undefined,
     tooltip: {
       trigger: 'axis',
+      axisPointer: {
+        type: 'line' as const,
+        ...crosshairPointerStyle,
+      },
       backgroundColor: chartColors.tooltipBg,
       borderColor: chartColors.tooltipBorder,
       borderWidth: 1,
@@ -233,6 +240,7 @@ onUnmounted(() => {
       ref="chartRef"
       :option="chartOption"
       :autoresize="true"
+      :group="groupId ?? undefined"
       class="h-full w-full"
     />
   </div>

--- a/frontend/src/components/LineChart.spec.ts
+++ b/frontend/src/components/LineChart.spec.ts
@@ -6,8 +6,8 @@ import LineChart from './LineChart.vue'
 vi.mock('vue-echarts', () => ({
   default: {
     name: 'VChart',
-    props: ['option', 'autoresize'],
-    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)"></div>',
+    props: ['option', 'autoresize', 'group'],
+    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)" :data-group="group"></div>',
     methods: {
       resize: vi.fn(),
     },
@@ -16,6 +16,8 @@ vi.mock('vue-echarts', () => ({
 
 vi.mock('echarts/core', () => ({
   use: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
 }))
 
 vi.mock('echarts/renderers', () => ({
@@ -243,6 +245,40 @@ describe('LineChart', () => {
         expect(s.areaStyle.color.colorStops).toHaveLength(2)
         expect(s.stack).toBe('total')
       }
+    })
+  })
+
+  describe('crosshair sync', () => {
+    it('passes group prop to VChart when crosshair context is provided', () => {
+      // The composable uses a Symbol injection key. We need to provide it
+      // via the global provide option using the same Symbol.
+      // Since the Symbol is private, we provide using a known string fallback
+      // and verify the group attribute is set.
+      const wrapper = mount(LineChart, {
+        props: { series: mockSeries },
+        global: {
+          provide: {
+            // The composable uses Symbol('crosshairSync') — we must match it.
+            // Instead we use the actual composable to get the key.
+          },
+        },
+      })
+      // Without a provider, groupId should be null and group should not be set
+      const chart = wrapper.find('.echarts-mock')
+      expect(chart.attributes('data-group')).toBeUndefined()
+    })
+
+    it('configures axisPointer on tooltip', () => {
+      const wrapper = mount(LineChart, {
+        props: { series: mockSeries },
+      })
+      const chart = wrapper.find('.echarts-mock')
+      const option = JSON.parse(chart.attributes('data-option') || '{}')
+
+      expect(option.tooltip.axisPointer).toBeDefined()
+      expect(option.tooltip.axisPointer.type).toBe('line')
+      expect(option.tooltip.axisPointer.lineStyle).toBeDefined()
+      expect(option.tooltip.axisPointer.lineStyle.type).toBe('dashed')
     })
   })
 })

--- a/frontend/src/components/LineChart.spec.ts
+++ b/frontend/src/components/LineChart.spec.ts
@@ -249,21 +249,10 @@ describe('LineChart', () => {
   })
 
   describe('crosshair sync', () => {
-    it('passes group prop to VChart when crosshair context is provided', () => {
-      // The composable uses a Symbol injection key. We need to provide it
-      // via the global provide option using the same Symbol.
-      // Since the Symbol is private, we provide using a known string fallback
-      // and verify the group attribute is set.
+    it('does not set group prop when no crosshair context is provided', () => {
       const wrapper = mount(LineChart, {
         props: { series: mockSeries },
-        global: {
-          provide: {
-            // The composable uses Symbol('crosshairSync') — we must match it.
-            // Instead we use the actual composable to get the key.
-          },
-        },
       })
-      // Without a provider, groupId should be null and group should not be set
       const chart = wrapper.find('.echarts-mock')
       expect(chart.attributes('data-group')).toBeUndefined()
     })

--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -10,7 +10,10 @@ import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import VChart from 'vue-echarts'
-import { chartPalette, chartColors } from '../utils/chartTheme'
+import { useCrosshairSync } from '../composables/useCrosshairSync'
+import { chartPalette, chartColors, crosshairPointerStyle } from '../utils/chartTheme'
+
+const { groupId } = useCrosshairSync()
 
 // Register ECharts components
 use([
@@ -121,6 +124,10 @@ const chartOption = computed(() => {
       : undefined,
     tooltip: {
       trigger: 'axis',
+      axisPointer: {
+        type: 'line' as const,
+        ...crosshairPointerStyle,
+      },
       backgroundColor: chartColors.tooltipBg,
       borderColor: chartColors.tooltipBorder,
       borderWidth: 1,
@@ -246,6 +253,7 @@ onUnmounted(() => {
       ref="chartRef"
       :option="chartOption"
       :autoresize="true"
+      :group="groupId ?? undefined"
       class="h-full w-full"
     />
   </div>

--- a/frontend/src/components/panels/CandlestickPanel.spec.ts
+++ b/frontend/src/components/panels/CandlestickPanel.spec.ts
@@ -7,8 +7,8 @@ import { clearRegistry } from '../../utils/panelRegistry'
 vi.mock('vue-echarts', () => ({
   default: {
     name: 'VChart',
-    props: ['option', 'autoresize'],
-    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)"></div>',
+    props: ['option', 'autoresize', 'group'],
+    template: '<div class="echarts-mock" :data-option="JSON.stringify(option)" :data-group="group"></div>',
     methods: {
       resize: vi.fn(),
     },
@@ -17,6 +17,8 @@ vi.mock('vue-echarts', () => ({
 
 vi.mock('echarts/core', () => ({
   use: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
 }))
 
 vi.mock('echarts/renderers', () => ({

--- a/frontend/src/components/panels/CandlestickPanel.vue
+++ b/frontend/src/components/panels/CandlestickPanel.vue
@@ -6,12 +6,15 @@ import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import VChart from 'vue-echarts'
+import { useCrosshairSync } from '../../composables/useCrosshairSync'
 import {
   chartAxisStyle,
   chartGridStyle,
   chartTooltipStyle,
   thresholdColors,
 } from '../../utils/chartTheme'
+
+const { groupId } = useCrosshairSync()
 
 // Register ECharts components
 use([CanvasRenderer, CandlestickChart, GridComponent, TooltipComponent])
@@ -158,6 +161,7 @@ onUnmounted(() => {
       ref="chartRef"
       :option="chartOption"
       :autoresize="true"
+      :group="groupId ?? undefined"
       class="h-full w-full"
     />
   </div>

--- a/frontend/src/composables/useCrosshairSync.spec.ts
+++ b/frontend/src/composables/useCrosshairSync.spec.ts
@@ -1,0 +1,97 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, inject } from 'vue'
+
+// Mock echarts/core before importing the composable
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+import { connect, disconnect } from 'echarts/core'
+import { provideCrosshairSync, useCrosshairSync } from './useCrosshairSync'
+
+describe('useCrosshairSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('provideCrosshairSync creates group ID with dashboard- prefix', () => {
+    const Provider = defineComponent({
+      setup() {
+        const groupId = provideCrosshairSync('abc-123')
+        return { groupId }
+      },
+      template: '<div />',
+    })
+
+    const wrapper = mount(Provider)
+    expect(wrapper.vm.groupId).toBe('dashboard-abc-123')
+  })
+
+  it('provideCrosshairSync calls connect with the group ID', () => {
+    const Provider = defineComponent({
+      setup() {
+        provideCrosshairSync('test-id')
+      },
+      template: '<div />',
+    })
+
+    mount(Provider)
+    expect(connect).toHaveBeenCalledWith('dashboard-test-id')
+  })
+
+  it('useCrosshairSync returns groupId when inside a provider context', () => {
+    let capturedGroupId: string | null = null
+
+    const Child = defineComponent({
+      setup() {
+        const { groupId } = useCrosshairSync()
+        capturedGroupId = groupId
+      },
+      template: '<div />',
+    })
+
+    const Parent = defineComponent({
+      components: { Child },
+      setup() {
+        provideCrosshairSync('my-dash')
+      },
+      template: '<Child />',
+    })
+
+    mount(Parent)
+    expect(capturedGroupId).toBe('dashboard-my-dash')
+  })
+
+  it('useCrosshairSync returns null when outside provider context', () => {
+    let capturedGroupId: string | null = 'should-be-null'
+
+    const Standalone = defineComponent({
+      setup() {
+        const { groupId } = useCrosshairSync()
+        capturedGroupId = groupId
+      },
+      template: '<div />',
+    })
+
+    mount(Standalone)
+    expect(capturedGroupId).toBeNull()
+  })
+
+  it('disconnect is called on component unmount', () => {
+    const Provider = defineComponent({
+      setup() {
+        provideCrosshairSync('unmount-test')
+      },
+      template: '<div />',
+    })
+
+    const wrapper = mount(Provider)
+    expect(disconnect).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    expect(disconnect).toHaveBeenCalledWith('dashboard-unmount-test')
+  })
+})

--- a/frontend/src/composables/useCrosshairSync.spec.ts
+++ b/frontend/src/composables/useCrosshairSync.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, inject } from 'vue'
+import { defineComponent } from 'vue'
 
 // Mock echarts/core before importing the composable
 vi.mock('echarts/core', () => ({

--- a/frontend/src/composables/useCrosshairSync.ts
+++ b/frontend/src/composables/useCrosshairSync.ts
@@ -1,0 +1,34 @@
+import { connect, disconnect } from 'echarts/core'
+import { type InjectionKey, inject, onUnmounted, provide } from 'vue'
+
+const CROSSHAIR_SYNC_KEY: InjectionKey<string> = Symbol('crosshairSync')
+
+/**
+ * Provide a crosshair sync group for all chart panels within this dashboard.
+ * Call once from the dashboard root component (e.g. DashboardDetailView).
+ *
+ * All VChart instances that share the same `group` will have their tooltips
+ * and axis pointers synchronised automatically via ECharts' built-in
+ * `connect(groupId)` mechanism.
+ */
+export function provideCrosshairSync(dashboardId: string): string {
+  const groupId = `dashboard-${dashboardId}`
+  connect(groupId)
+  provide(CROSSHAIR_SYNC_KEY, groupId)
+
+  onUnmounted(() => {
+    disconnect(groupId)
+  })
+
+  return groupId
+}
+
+/**
+ * Inject the crosshair sync group ID provided by a parent dashboard.
+ * Returns `{ groupId: null }` when called outside a provider context
+ * (e.g. in a standalone chart preview).
+ */
+export function useCrosshairSync(): { groupId: string | null } {
+  const groupId = inject(CROSSHAIR_SYNC_KEY, null)
+  return { groupId }
+}

--- a/frontend/src/utils/chartTheme.ts
+++ b/frontend/src/utils/chartTheme.ts
@@ -111,6 +111,19 @@ export const chartLegendStyle = {
 }
 
 // ---------------------------------------------------------------------------
+// Crosshair pointer
+// ---------------------------------------------------------------------------
+
+/** Shared axisPointer style for cross-panel crosshair sync. */
+export const crosshairPointerStyle = {
+  lineStyle: {
+    color: '#757578',
+    width: 1,
+    type: 'dashed' as const,
+  },
+}
+
+// ---------------------------------------------------------------------------
 // Helper
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/views/DashboardDetailView.vue
+++ b/frontend/src/views/DashboardDetailView.vue
@@ -14,6 +14,7 @@ import { useCommandContext } from '../composables/useCommandContext'
 import { useFavorites } from '../composables/useFavorites'
 import { useOrganization } from '../composables/useOrganization'
 import { useTimeRange } from '../composables/useTimeRange'
+import { provideCrosshairSync } from '../composables/useCrosshairSync'
 import { useVariables } from '../composables/useVariables'
 import type { Dashboard } from '../types/dashboard'
 import type { Panel as PanelType } from '../types/panel'
@@ -35,6 +36,7 @@ const showDeleteConfirm = ref(false)
 const deletingPanel = ref<PanelType | null>(null)
 
 const dashboardId = route.params.id as string
+provideCrosshairSync(dashboardId)
 
 // Template variables
 const {


### PR DESCRIPTION
## Summary
- Add cross-panel crosshair/tooltip synchronization using ECharts' built-in `connect` API
- When hovering one chart panel, the crosshair line and tooltip appear on all other supported panels at the same timestamp
- Supported panel types: line_chart, bar_chart, candlestick (all axis-triggered with time x-axis)
- New `useCrosshairSync` composable using Vue provide/inject to scope sync per dashboard

## Changes
- **New:** `useCrosshairSync.ts` composable + spec (5 tests)
- **New:** `crosshairPointerStyle` in chartTheme.ts for consistent dashed crosshair line
- **Modified:** DashboardDetailView provides crosshair sync context
- **Modified:** LineChart, BarChart, CandlestickPanel inject group ID and pass to VChart
- **Modified:** LineChart.spec.ts, CandlestickPanel.spec.ts updated mocks

## Test plan
- [ ] Open a dashboard with multiple line/bar charts
- [ ] Hover one chart — crosshair and tooltip should appear on all other axis-triggered panels
- [ ] Move mouse away — all tooltips hide
- [ ] Charts with no data at hovered timestamp show nothing (graceful)
- [ ] Panel add/remove doesn't break sync
- [ ] Panel edit modal charts don't sync with dashboard
- [ ] `bun run test` passes (1192 tests)
- [ ] `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)