### PR TITLE
feat(backend): configurable listen address via ACE_LISTEN_ADDR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# Context — Ace deployment vocabulary
+
+A glossary of the language we use when talking about how Ace is packaged and
+deployed. Conceptual only — no implementation details.
+
+## Terms
+
+### Combined image
+A single container image that bundles the **frontend** and the **backend**
+together, fronted by one web server that serves the SPA and forwards API
+traffic to the backend in the same container. The datastores (Postgres,
+Valkey) are **not** part of it — they are external. Intended for simple
+single-host deployments (e.g. a low-power VM) where running and wiring several
+images is undesirable. Published as the *standalone* image
+(`ace-standalone`).
+
+### Frontend-only image
+A container image that serves just the SPA. It can forward API traffic to a
+**backend** that lives elsewhere (another container or host), with that
+backend's address supplied at run time rather than baked in at build time.
+This is the image used in Kubernetes, where path routing to the backend is
+handled outside the image.
+
+### Backend upstream (`ACE_BACKEND_URL`)
+The address the web server forwards API traffic to. It is the *upstream the
+proxy points at*, not an address the browser ever contacts directly. When
+unset, no forwarding is configured and API routing is assumed to be handled by
+the surrounding infrastructure (e.g. an ingress).
+
+### Same-origin API
+The default contract: the browser sends API calls to the same origin that
+served the page. Whatever resolves those calls — an ingress, the combined
+image's web server, or a configured frontend-only image — is a deployment
+concern invisible to the browser.

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -339,8 +339,9 @@ func main() {
 	handler = auditLogger.Middleware(handler)
 
 	// Create server
+	listenAddr := resolveListenAddr(os.Getenv)
 	server := &http.Server{
-		Addr:        ":8080",
+		Addr:        listenAddr,
 		Handler:     handler,
 		ReadTimeout: 15 * time.Second,
 		// WriteTimeout is 0 to allow SSE streaming responses to run as long as
@@ -352,7 +353,7 @@ func main() {
 
 	// Start server in goroutine
 	go func() {
-		logger.Info("starting server", zap.String("addr", ":8080"))
+		logger.Info("starting server", zap.String("addr", listenAddr))
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logger.Fatal("server error", zap.Error(err))
 		}
@@ -387,4 +388,15 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// resolveListenAddr returns the HTTP listen address for the backend. It uses
+// ACE_LISTEN_ADDR when set (e.g. "127.0.0.1:9090" so the standalone image can
+// bind the backend to loopback behind nginx) and falls back to ":8080". getenv
+// is injected so the resolution stays a pure, unit-testable function.
+func resolveListenAddr(getenv func(string) string) string {
+	if addr := getenv("ACE_LISTEN_ADDR"); addr != "" {
+		return addr
+	}
+	return ":8080"
 }

--- a/backend/cmd/api/main_test.go
+++ b/backend/cmd/api/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestResolveListenAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "defaults to :8080 when unset",
+			env:  map[string]string{},
+			want: ":8080",
+		},
+		{
+			name: "defaults to :8080 when empty",
+			env:  map[string]string{"ACE_LISTEN_ADDR": ""},
+			want: ":8080",
+		},
+		{
+			name: "uses ACE_LISTEN_ADDR when set",
+			env:  map[string]string{"ACE_LISTEN_ADDR": "127.0.0.1:9090"},
+			want: "127.0.0.1:9090",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string { return tt.env[key] }
+			if got := resolveListenAddr(getenv); got != tt.want {
+				t.Errorf("resolveListenAddr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/adr/0001-standalone-image-and-runtime-api-proxy.md
+++ b/docs/adr/0001-standalone-image-and-runtime-api-proxy.md
@@ -4,6 +4,16 @@ status: accepted
 
 # Standalone image and runtime API proxy
 
+> **Implementation status:** This records an *accepted decision*, not the current
+> state of the tree. It is delivered incrementally across #265–#269: configurable
+> `ACE_LISTEN_ADDR` (#265, landed), the runtime `/api` proxy and removal of
+> `VITE_API_URL`/`ACE_BACKEND_URL` wiring (#266), the combined image and its
+> loopback binding (#267), compose + smoke test (#268), and release (#269). Until
+> those land, the present-tense statements below describe the target, not behaviour
+> you can rely on from the existing images — e.g. setting `ACE_BACKEND_URL` has no
+> effect yet, and the standalone image's loopback bind is enforced by #267's
+> packaging (the backend default remains `:8080`).
+
 To let operators run Ace on a single low-power host without building images or
 cloning the repo (issue #255), we publish a second **combined image**
 (`ghcr.io/aceobservability/ace-standalone`) that bundles the frontend and

--- a/docs/adr/0001-standalone-image-and-runtime-api-proxy.md
+++ b/docs/adr/0001-standalone-image-and-runtime-api-proxy.md
@@ -1,0 +1,48 @@
+---
+status: accepted
+---
+
+# Standalone image and runtime API proxy
+
+To let operators run Ace on a single low-power host without building images or
+cloning the repo (issue #255), we publish a second **combined image**
+(`ghcr.io/aceobservability/ace-standalone`) that bundles the frontend and
+backend behind one nginx, and we make the **frontend-only image** able to
+forward `/api` to a backend whose address (`ACE_BACKEND_URL`) is supplied at run
+time instead of baked in at build time. In both images nginx owns `/api` and
+the only thing that varies is the upstream — the browser always talks
+[same-origin](../../CONTEXT.md), so the build-time `VITE_API_URL` is removed and
+`API_BASE` becomes a constant empty string.
+
+## Considered options
+
+- **Embed the SPA in the Go backend and drop nginx** — one process, no proxy.
+  Rejected: the frontend-only image still needs a web server, so we'd maintain
+  two static-serving implementations; nginx stays the single static server in
+  both images.
+- **supervisord for the two-process combined image** — rejected: pulls Python
+  (~50 MB) into an Alpine image, against the low-power/small-image goal. We use
+  **s6-overlay** for correct PID1, signal forwarding, and per-service
+  crash-detection at a few hundred KB.
+- **Bundle Postgres + Valkey into the standalone image** — rejected: stateful
+  datastores in an app image is an anti-pattern (state in the container layer,
+  tangled upgrades, image bloat). The image is app-only; the datastores are
+  external, supplied by a published `docker-compose.yml`.
+- **Browser calls the backend directly cross-origin** (the original issue's
+  literal reading) — rejected in favour of an nginx same-origin proxy: no CORS
+  dependency, and the backend need not be exposed to the browser at all.
+
+## Consequences
+
+- **Breaking:** `VITE_API_URL` is gone. Anyone building the frontend with it
+  must switch to running with `ACE_BACKEND_URL` (or front the app with an
+  ingress). Called out in the changelog.
+- The `/api` proxy in the frontend-only image is **opt-in**: emitted only when
+  `ACE_BACKEND_URL` is set, so the existing Kubernetes/ingress deployment —
+  where the ingress routes `/api` — is unchanged.
+- In the combined image the backend binds `127.0.0.1` (via a new
+  `ACE_LISTEN_ADDR`, default `:8080`), reachable only through nginx.
+- The proxy must keep streaming endpoints working (SSE + chunked):
+  `proxy_buffering off`, HTTP/1.1, long read timeout.
+- The backend's wildcard CORS is now redundant for our deployments; tightening
+  it is a separate follow-up.


### PR DESCRIPTION
## Summary

Makes the backend HTTP listen address runtime-configurable via `ACE_LISTEN_ADDR`, defaulting to `:8080` when unset. This lets the upcoming `ace-standalone` combined image bind the backend to loopback while nginx owns the public port.

- Added a pure `resolveListenAddr(getenv)` function and wired it into server startup (`Addr` + startup log).
- Added table-driven unit tests (set / unset / empty).
- Landed the deployment design docs (`CONTEXT.md` and `docs/adr/0001-standalone-image-and-runtime-api-proxy.md`) so subsequent AFK slices branch from them.

## Acceptance criteria

- [x] Backend binds `ACE_LISTEN_ADDR` when set, `:8080` when unset
- [x] Address resolution is a pure function with unit tests covering set / unset cases
- [x] Backend boots and serves `/api/health` on a custom address — verified live: `ACE_LISTEN_ADDR=127.0.0.1:9090` against Postgres+Valkey returned `200 {"status":"ok"}`; nothing on `:8080`
- [x] `CONTEXT.md` and ADR-0001 committed
- [x] Existing backend tests remain green (`go test ./...`)

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)