### PR TITLE
feat(frontend)!: runtime-configurable API URL via same-origin /api proxy

### DIFF
--- a/deploy/docker/demo/docker-compose.yml
+++ b/deploy/docker/demo/docker-compose.yml
@@ -123,6 +123,9 @@ services:
       DATABASE_URL: postgres://ace:ace@postgres:5432/ace?sslmode=disable
       VALKEY_URL: valkey://valkey:6379
       JWT_SECRET: demo-secret-change-in-production
+      # Browser reaches the backend same-origin via the frontend proxy, so OAuth
+      # callback URLs must use the public frontend origin, not the backend's port.
+      BASE_URL: http://localhost:5173
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/docker/demo/docker-compose.yml
+++ b/deploy/docker/demo/docker-compose.yml
@@ -135,10 +135,11 @@ services:
     build:
       context: ../../..
       dockerfile: frontend/Dockerfile
-      args:
-        VITE_API_URL: http://localhost:8080
+    # Browser talks same-origin to the frontend; nginx proxies /api to the backend.
+    environment:
+      ACE_BACKEND_URL: http://ace-backend:8080
     ports:
-      - "5173:80"
+      - "5173:8080"
     depends_on:
       - ace-backend
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,5 @@
 FROM oven/bun:1-alpine AS builder
 
-# Optional build-time override. Empty default keeps production calls same-origin under /api.
-ARG VITE_API_URL=
-ENV VITE_API_URL=$VITE_API_URL
-
 WORKDIR /app
 
 COPY frontend/package.json frontend/bun.lock ./
@@ -17,6 +13,9 @@ FROM nginxinc/nginx-unprivileged:1.27-alpine
 LABEL org.opencontainers.image.source=https://github.com/aceobservability/ace
 
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+# Rendered into /etc/nginx/conf.d/api-proxy.inc by the entrypoint before nginx
+# starts; executable so the entrypoint runs it rather than sourcing it.
+COPY --chmod=0755 frontend/docker-entrypoint.d/30-render-api-proxy.sh /docker-entrypoint.d/30-render-api-proxy.sh
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 EXPOSE 8080

--- a/frontend/docker-entrypoint.d/30-render-api-proxy.sh
+++ b/frontend/docker-entrypoint.d/30-render-api-proxy.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Render the optional same-origin /api reverse proxy for the frontend-only image.
 #
-# When ACE_BACKEND_URL is set, emit a `location /api` block that forwards to that
+# When ACE_BACKEND_URL is set, emit a `location /api/` block that forwards to that
 # backend upstream and keeps streaming endpoints (SSE + chunked) working. When it
 # is unset, write an empty file so the `include` in nginx.conf always resolves and
 # the existing Kubernetes/ingress deployment — where the ingress owns /api — is
@@ -17,8 +17,29 @@ if [ -z "$backend_url" ]; then
   exit 0
 fi
 
+# Strip trailing slashes: with a slash present `proxy_pass` would carry a URI and
+# nginx would rewrite the matched /api/ prefix away (so /api/auth -> /auth, 404).
+backend_url="$(printf '%s' "$backend_url" | sed 's#/*$##')"
+
+# Reject anything that isn't a clean http(s) URL, so a stray space, newline, or
+# ';' can't break nginx startup or inject extra directives. set -e in the image
+# entrypoint turns this non-zero exit into a clear container abort.
+case "$backend_url" in
+  *[[:space:]]* | *';'*)
+    echo "error: ACE_BACKEND_URL must not contain whitespace or ';': '$ACE_BACKEND_URL'" >&2
+    exit 1 ;;
+esac
+case "$backend_url" in
+  http://?* | https://?*) ;;
+  *)
+    echo "error: ACE_BACKEND_URL must be an http:// or https:// URL: '$ACE_BACKEND_URL'" >&2
+    exit 1 ;;
+esac
+
+# location /api/ (not /api) so prefixes like /apiary or a future SPA /api-keys
+# route fall through to the SPA instead of being proxied to the backend.
 cat >"$out" <<EOF
-location /api {
+location /api/ {
   proxy_pass $backend_url;
   proxy_http_version 1.1;
   proxy_set_header Host \$host;

--- a/frontend/docker-entrypoint.d/30-render-api-proxy.sh
+++ b/frontend/docker-entrypoint.d/30-render-api-proxy.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Render the optional same-origin /api reverse proxy for the frontend-only image.
+#
+# When ACE_BACKEND_URL is set, emit a `location /api` block that forwards to that
+# backend upstream and keeps streaming endpoints (SSE + chunked) working. When it
+# is unset, write an empty file so the `include` in nginx.conf always resolves and
+# the existing Kubernetes/ingress deployment — where the ingress owns /api — is
+# unchanged. See docs/adr/0001-standalone-image-and-runtime-api-proxy.md.
+set -eu
+
+backend_url="${ACE_BACKEND_URL:-}"
+out="${ACE_API_PROXY_CONF:-/etc/nginx/conf.d/api-proxy.inc}"
+
+if [ -z "$backend_url" ]; then
+  : >"$out"
+  echo "ACE_BACKEND_URL unset: no /api proxy emitted (ingress is assumed to route /api)"
+  exit 0
+fi
+
+cat >"$out" <<EOF
+location /api {
+  proxy_pass $backend_url;
+  proxy_http_version 1.1;
+  proxy_set_header Host \$host;
+  proxy_set_header X-Real-IP \$remote_addr;
+  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+  proxy_set_header Connection "";
+
+  # Keep SSE and chunked responses streaming instead of buffering them.
+  proxy_buffering off;
+  proxy_read_timeout 1h;
+}
+EOF
+
+echo "ACE_BACKEND_URL set: proxying /api to $backend_url"

--- a/frontend/docker-entrypoint.d/render-api-proxy.spec.ts
+++ b/frontend/docker-entrypoint.d/render-api-proxy.spec.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const script = fileURLToPath(new URL('./30-render-api-proxy.sh', import.meta.url))
+
+let workdir: string
+let out: string
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'api-proxy-'))
+  out = join(workdir, 'api-proxy.inc')
+})
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true })
+})
+
+function render(backendUrl?: string): string {
+  const env: Record<string, string> = { ...process.env, ACE_API_PROXY_CONF: out }
+  if (backendUrl === undefined) {
+    delete env.ACE_BACKEND_URL
+  } else {
+    env.ACE_BACKEND_URL = backendUrl
+  }
+  const result = spawnSync('sh', [script], { env, encoding: 'utf8' })
+  expect(result.status, result.stderr).toBe(0)
+  return readFileSync(out, 'utf8')
+}
+
+describe('render-api-proxy', () => {
+  it('emits no /api block when ACE_BACKEND_URL is unset', () => {
+    expect(render(undefined).trim()).toBe('')
+  })
+
+  it('emits a streaming /api proxy block when ACE_BACKEND_URL is set', () => {
+    const rendered = render('http://ace-backend:8080')
+    expect(rendered).toContain('location /api {')
+    expect(rendered).toContain('proxy_pass http://ace-backend:8080;')
+    // Streaming endpoints (SSE + chunked) must not be buffered.
+    expect(rendered).toContain('proxy_http_version 1.1;')
+    expect(rendered).toContain('proxy_buffering off;')
+    expect(rendered).toContain('proxy_read_timeout 1h;')
+  })
+})

--- a/frontend/docker-entrypoint.d/render-api-proxy.spec.ts
+++ b/frontend/docker-entrypoint.d/render-api-proxy.spec.ts
@@ -20,7 +20,7 @@ afterEach(() => {
   rmSync(workdir, { recursive: true, force: true })
 })
 
-function render(backendUrl?: string): string {
+function run(backendUrl?: string): { status: number | null; stderr: string } {
   const env: Record<string, string> = { ...process.env, ACE_API_PROXY_CONF: out }
   if (backendUrl === undefined) {
     delete env.ACE_BACKEND_URL
@@ -28,6 +28,11 @@ function render(backendUrl?: string): string {
     env.ACE_BACKEND_URL = backendUrl
   }
   const result = spawnSync('sh', [script], { env, encoding: 'utf8' })
+  return { status: result.status, stderr: result.stderr }
+}
+
+function render(backendUrl?: string): string {
+  const result = run(backendUrl)
   expect(result.status, result.stderr).toBe(0)
   return readFileSync(out, 'utf8')
 }
@@ -37,13 +42,28 @@ describe('render-api-proxy', () => {
     expect(render(undefined).trim()).toBe('')
   })
 
-  it('emits a streaming /api proxy block when ACE_BACKEND_URL is set', () => {
+  it('emits a streaming /api/ proxy block when ACE_BACKEND_URL is set', () => {
     const rendered = render('http://ace-backend:8080')
-    expect(rendered).toContain('location /api {')
+    // /api/ (not /api) so /apiary etc. fall through to the SPA.
+    expect(rendered).toContain('location /api/ {')
     expect(rendered).toContain('proxy_pass http://ace-backend:8080;')
     // Streaming endpoints (SSE + chunked) must not be buffered.
     expect(rendered).toContain('proxy_http_version 1.1;')
     expect(rendered).toContain('proxy_buffering off;')
     expect(rendered).toContain('proxy_read_timeout 1h;')
+  })
+
+  it('strips a trailing slash so proxy_pass keeps the /api prefix', () => {
+    const rendered = render('http://ace-backend:8080/')
+    expect(rendered).toContain('proxy_pass http://ace-backend:8080;')
+    expect(rendered).not.toContain('http://ace-backend:8080/;')
+  })
+
+  it.each([
+    ['http://ace-backend:8080; return 444', 'embedded directive'],
+    ['http://ace backend:8080', 'whitespace'],
+    ['ace-backend:8080', 'missing scheme'],
+  ])('rejects an invalid ACE_BACKEND_URL (%s)', (value) => {
+    expect(run(value).status).not.toBe(0)
   })
 })

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,12 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # Optional same-origin /api reverse proxy, rendered at startup by
+  # docker-entrypoint.d/30-render-api-proxy.sh. Empty unless ACE_BACKEND_URL is set.
+  # Note: .inc (not .conf) so nginx's http-level `conf.d/*.conf` glob doesn't also
+  # load this server-context snippet at the wrong scope.
+  include /etc/nginx/conf.d/api-proxy.inc;
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/frontend/src/api/base.spec.ts
+++ b/frontend/src/api/base.spec.ts
@@ -1,18 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
-import { normalizeApiBase } from './base'
+import { describe, expect, it } from 'vitest'
+import { API_BASE } from './base'
 
-describe('API base helper', () => {
-  it('defaults to same-origin relative API calls', async () => {
-    vi.resetModules()
-    vi.stubEnv('VITE_API_URL', '')
-
-    const { API_BASE } = await import('./base')
-
+describe('API base', () => {
+  it('is always same-origin relative', () => {
     expect(API_BASE).toBe('')
-    vi.unstubAllEnvs()
-  })
-
-  it('normalizes configured API URL overrides', () => {
-    expect(normalizeApiBase(' http://localhost:8080/ ')).toBe('http://localhost:8080')
   })
 })

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -1,6 +1,6 @@
-export function normalizeApiBase(apiUrl: string | undefined): string {
-  const trimmed = apiUrl?.trim() ?? ''
-  return trimmed.replace(/\/+$/, '')
-}
-
-export const API_BASE = normalizeApiBase(import.meta.env.VITE_API_URL)
+// The browser always talks to the same origin that served the page, so every
+// API call goes to a relative `/api/...`. Whatever resolves it — an ingress,
+// the combined image's nginx, or a configured frontend-only image — is a
+// deployment concern invisible here. See CONTEXT.md and
+// docs/adr/0001-standalone-image-and-runtime-api-proxy.md.
+export const API_BASE = ''


### PR DESCRIPTION
## What & why

Closes #266 — the runtime `/api` proxy slice of ADR-0001.

Moves the frontend's API target from a build-time baked URL to a same-origin `/api` that nginx proxies to a configurable upstream at run time.

## Changes

- **`API_BASE` is now a constant empty string** (`frontend/src/api/base.ts`); every browser call goes same-origin to `/api/...`. The build-time `VITE_API_URL` plumbing (and the now-dead `normalizeApiBase` helper) is removed. `base.spec.ts` asserts `API_BASE === ''` unconditionally.
- **Opt-in `/api` reverse proxy in the frontend-only image.** A POSIX-sh entrypoint script (`frontend/docker-entrypoint.d/30-render-api-proxy.sh`) emits a `location /api { proxy_pass $ACE_BACKEND_URL; … }` block **only when `ACE_BACKEND_URL` is set**, and an empty include otherwise — so the existing Kubernetes/ingress deployment (ingress routes `/api`) is unchanged. The block keeps streaming endpoints (SSE + chunked) working: `proxy_buffering off`, HTTP/1.1, long read timeout. `nginx.conf` `include`s the rendered snippet inside the `server` block.
- **Demo compose** runs the frontend-only image with `ACE_BACKEND_URL=http://ace-backend:8080` and its port mapping is corrected from `5173:80` to `5173:8080` (nginx listens on `:8080`).

## Verification

- `bun run test` (1210 tests), `lint`, and `type-check` pass.
- New test `render-api-proxy.spec.ts` asserts the opt-in render behavior (block + streaming directives present when set, empty when unset).
- Manually confirmed the rendered config passes `nginx -t` in both states inside the real `nginxinc/nginx-unprivileged` image.

## Breaking change

`VITE_API_URL` is removed. Builds that set it must instead run the frontend image with `ACE_BACKEND_URL` (or front the app with an ingress that routes `/api`). Recorded via the `BREAKING CHANGE:` commit footer for release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)