### PR TITLE
ci: keep release-please on 0.x until v1.0.0 is intentional

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,6 +4,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "bump-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         "VERSION",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ This project uses automated SemVer releases based on Conventional Commits.
 
 - `feat:` -> minor bump (`0.1.0` -> `0.2.0`)
 - `fix:` -> patch bump (`0.1.0` -> `0.1.1`)
-- `feat!:` or `BREAKING CHANGE:` footer -> major bump (`0.x` -> `1.0.0` when applicable)
+- `feat!:` or `BREAKING CHANGE:` footer -> major bump (`0.x` -> `1.0.0`) once we ship `v1.0.0`; until then `bump-minor-pre-major` keeps breaking changes on `0.x` (e.g. `0.16.0` -> `0.17.0`)
 - `docs:`, `ci:`, `refactor:`, etc. are included in notes but do not force a bump by themselves
 
 Use Conventional Commit messages for all merge commits/PR titles to keep release automation accurate.

--- a/website/guide/release-process.md
+++ b/website/guide/release-process.md
@@ -20,7 +20,7 @@ This project uses automated SemVer releases based on Conventional Commits.
 
 - `feat:` -> minor bump (`0.1.0` -> `0.2.0`)
 - `fix:` -> patch bump (`0.1.0` -> `0.1.1`)
-- `feat!:` or `BREAKING CHANGE:` footer -> major bump (`0.x` -> `1.0.0` when applicable)
+- `feat!:` or `BREAKING CHANGE:` footer -> major bump (`0.x` -> `1.0.0`) once we ship `v1.0.0`; until then `bump-minor-pre-major` in `.release-please-config.json` keeps breaking changes on `0.x` (e.g. `0.16.0` -> `0.17.0`)
 - `docs:`, `ci:`, `refactor:`, etc. are included in notes but do not force a bump by themselves
 
 Use Conventional Commit messages for all merge commits/PR titles to keep release automation accurate.


### PR DESCRIPTION
Adds `bump-minor-pre-major` so breaking changes before v1.0.0 bump the minor version (e.g. 0.16.0 → 0.17.0) instead of opening a 1.0.0 release PR.

This should update #271 from `release 1.0.0` to `release 0.17.0` on the next release-please run.