### PR TITLE
ci: regenerate website docs on release PRs

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -72,11 +72,17 @@ jobs:
           fi
           printf "branch=%s\n" "$branch" >> "$GITHUB_OUTPUT"
 
+      - name: Setup Go
+        if: steps.pr-info.outputs.branch != ''
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+
       - name: Install helm-docs
         if: steps.pr-info.outputs.branch != ''
         uses: ./.github/actions/setup-helm-docs
 
-      - name: Generate Helm docs
+      - name: Generate docs
         if: steps.pr-info.outputs.branch != ''
         run: |
           set -euo pipefail
@@ -84,12 +90,13 @@ jobs:
           git checkout "${{ steps.pr-info.outputs.branch }}"
 
           ./helm-docs --chart-search-root charts --log-level warn
+          bash scripts/build-docs.sh --skip-build
 
           # Commit if changed
-          if ! git diff --quiet charts/ace/README.md; then
+          if ! git diff --quiet charts/ace/README.md website/; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add charts/ace/README.md
-            git commit -m "docs: regenerate Helm chart README"
+            git add charts/ace/README.md website/
+            git commit -m "docs: regenerate generated docs for release"
             git push origin "${{ steps.pr-info.outputs.branch }}"
           fi

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -92,8 +92,8 @@ jobs:
           ./helm-docs --chart-search-root charts --log-level warn
           bash scripts/build-docs.sh --skip-build
 
-          # Commit if changed
-          if ! git diff --quiet charts/ace/README.md website/; then
+          # Commit if changed (status catches modified and untracked files)
+          if [ -n "$(git status --porcelain charts/ace/README.md website/)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add charts/ace/README.md website/

--- a/website/guide/contributing.md
+++ b/website/guide/contributing.md
@@ -2,160 +2,29 @@
 title: "Contributing"
 ---
 
-# AGENTS.md
-Practical instructions for agentic coding workflows in this repository.
+# Ace
 
-## 1) Project overview
-- Monorepo with two main apps:
-  - `backend/` - Go 1.25 API server
-  - `frontend/` - Vue 3 + TypeScript + Vite + Vitest
-- Key root files:
-  - `Makefile` (dev/lint/seed/security entrypoints)
-  - `Tiltfile` (local dev orchestration)
-  - `deploy/charts/ace-local-infra/` (local infra Helm chart)
-  - `mise.toml` (`go = 1.25`)
-  - `backend/.golangci.yml` (backend lint policy)
-  - `frontend/biome.jsonc` (frontend lint/format policy)
+## Design System
 
-## 2) Prerequisites
-- Bun 1.3+ (frontend and docs package manager)
-- Go 1.25+
-- Docker
-- A local Kubernetes cluster (kind/minikube/Docker Desktop Kubernetes)
-- kubectl + Helm + Tilt
-- Optional: `air` for backend hot reload
+Always read DESIGN.md before making any visual or UI decisions.
+All font choices, colors, spacing, and aesthetic direction are defined there.
+Do not deviate without explicit user approval.
+In QA mode, flag any code that doesn't match DESIGN.md.
 
-## 3) Core local commands
-Run from repo root unless noted.
+## Git
 
-### Infra + dev servers
-```bash
-tilt up
-tilt down
+Prefer worktrees for any medium or larger tasks (tasks that would affect 5 or more files)
 
-make backend
-make frontend
-```
+## Agent skills
 
-Notes:
-- Backend default URL: `http://localhost:8080`
-- Frontend default URL: `http://localhost:5173`
-- Optional observability services (`prometheus`, `loki`, `victoria-metrics`, `victoria-logs`, `tempo`) are disabled by default in Tilt and can be enabled from the Tilt UI
-- `make backend` uses `air` if installed, else `go run ./cmd/api`
+### Issue tracker
 
-### Seed data
-```bash
-make seed
-make seed EMAIL=admin@example.com PASSWORD='AdminPass123'
-make seed-tilt
-```
+Issues are tracked in the `aceobservability/ace` GitHub repo via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
-Notes:
-- `make seed` creates the default organizations and datasources for local Docker Compose/dev usage.
-- `make seed-tilt` uses Kubernetes service URLs for Tilt-based environments.
+### Triage labels
 
-## 4) Build/lint/test commands
-### Frontend (`frontend/`)
-```bash
-cd frontend
-bun install
-bun run dev
-bun run build
-bun run preview
-bun run type-check
-bun run test
-bun run test:watch
-bun run test:coverage
-bun run lint
-bun run lint:dead-code
-bun run format:check
-bun run test -- src/api/datasources.spec.ts
-bun run test -- src/api/datasources.spec.ts -t "throws on 403"
-```
-### Backend (`backend/`)
-```bash
-cd backend
-go run ./cmd/api
-go build ./cmd/api
-go test ./...
-go test ./internal/handlers
-go test ./internal/handlers -run '^TestDataSourceHandler_Query_InvalidUUID$' -count=1
-go test ./internal/auth -run '^TestVerifyPasswordIncorrect$' -count=1
-go test ./internal/handlers -list '^Test'
-```
-### Root quality/security tasks
-```bash
-make backend-lint
-make frontend-lint
-make lint
-make security-local
-```
+Five canonical triage roles mapped 1:1 to default label strings. See `docs/agents/triage-labels.md`.
 
-## 5) Lint and formatting reality
-- Backend linting: `golangci-lint` with `govet`, `ineffassign`, `misspell`, `staticcheck`, `unconvert`
-- Backend formatters in CI: `gofmt` and `goimports`
-- Frontend linting: Biome (`bun run lint`) + Knip (`bun run lint:dead-code`)
-- Biome formatting rules: 2-space indent, single quotes, semicolons as needed, trailing commas, line width 100
-- Before finishing backend edits, run `gofmt -w` on touched Go files
+### Domain docs
 
-## 6) Code style guidelines
-Follow existing code patterns first. Use these defaults when unclear.
-
-### Imports
-- Go: stdlib imports first, then blank line, then external/internal imports
-- TypeScript/Vue: external imports before local imports
-- TypeScript: use `import type` for type-only imports
-
-### Formatting
-- Go: canonical `gofmt` output only
-- TypeScript/Vue: 2-space indentation, single quotes, trailing commas in multiline literals
-- Keep long expressions wrapped for readability
-
-### Types and data modeling
-- Frontend TS is strict (`strict`, `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`)
-- Avoid `any`; prefer explicit interfaces/unions and narrow unknown values
-- Backend optional update fields commonly use pointer fields in request structs
-- Keep JSON tags and payload field names stable across frontend/backend
-- Use `type_` if a variable name would collide with reserved words
-
-### Naming conventions
-- Go exported symbols: `PascalCase`; unexported symbols: `camelCase`
-- Go constructors: `NewXxx(...)`
-- Handler method verbs usually follow CRUD-ish names: `Create`, `List`, `Get`, `Update`, `Delete`, `Query`
-- Vue components and view files: `PascalCase.vue`
-- Composables: `useXxx`
-- Test files: frontend `*.spec.ts`, backend `*_test.go`
-
-### Error handling
-- Backend:
-  - Return early on auth/validation failures
-  - Use deliberate HTTP status codes (`400`, `401`, `403`, `404`, `409`, `500`)
-  - Return JSON error payloads consistently
-  - Use `context.WithTimeout` for DB/external calls
-- Frontend:
-  - Throw concise `Error` messages from API helpers
-  - Parse backend error JSON when available, with safe fallback messages
-  - Normalize caught values via `e instanceof Error ? e.message : '<fallback>'`
-
-## 7) Testing conventions
-- Go tests: use `TestXxx`, prefer table-driven cases, use `httptest.NewRequest` + `httptest.NewRecorder`, and include expected/actual in failures
-- Vitest tests: use behavior-focused `describe`/`it`, mock `fetch` with `vi.fn()` + `vi.stubGlobal`, reset mocks in `beforeEach`, and assert URL/method/headers/body for API calls
-
-## 8) Cursor/Copilot instruction files
-- `.cursorrules`: not present
-- `.cursor/rules/`: not present
-- `.github/copilot-instructions.md`: not present
-- If any of these files are added later, treat them as higher-priority instructions and update this document
-
-## 9) Agent workflow expectations
-- Keep diffs minimal and scoped to the requested task
-- Inspect nearby code before editing to mirror local style and architecture
-- Preserve API contracts unless the task explicitly requires a contract change
-- Run relevant checks for touched areas before finishing
-- Avoid adding new dependencies unless clearly necessary
-
-## 10) Progress log policy
-- Maintain root `progress.txt` with recent implementation entries
-- `progress.txt` is intentionally tracked; do not add it to `.gitignore`
-- Keep only the 10 most recent entries
-- When adding a new entry beyond 10, remove the oldest entry
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.


### PR DESCRIPTION
## Summary

Fixes Docs CI failures on release PRs by auto-regenerating VitePress content when `release-please` updates the release branch.

- Extends the existing `release-pr.yml` docs step to run `build-docs.sh --skip-build` alongside `helm-docs`
- Commits updated `website/` files (mainly `website/guide/changelog.md`) to the release branch before Docs CI runs

## Problem

The Docs workflow regenerates `website/` from source files (`CHANGELOG.md`, `AGENTS.md`, etc.) and fails if they are out of sync. Release PRs update `CHANGELOG.md` via release-please but previously only regenerated Helm chart README — not the website copies.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Verify the next release PR gets a bot commit updating `website/`
- [ ] Confirm Docs CI passes on the release PR