### PR TITLE
feat(frontend): React auth and session (#295)

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -25,7 +25,6 @@
     "monaco-editor",
     "react-hook-form",
     "zod",
-
     "d3-force",
     "@types/d3-force",
     "echarts",

--- a/frontend/src/api/auth.spec.ts
+++ b/frontend/src/api/auth.spec.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchSSOProviders } from './auth'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('auth API', () => {
+  it('encodes org slug in fetchSSOProviders path', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([{ provider: 'google' }]),
+    })
+
+    const result = await fetchSSOProviders('acme/corp')
+
+    expect(result).toEqual([{ provider: 'google' }])
+    expect(mockFetch).toHaveBeenCalledWith('/api/orgs/acme%2Fcorp/sso/providers')
+  })
+
+  it('returns empty array when fetchSSOProviders fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+    })
+
+    const result = await fetchSSOProviders('acme')
+
+    expect(result).toEqual([])
+  })
+})

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,5 @@
 import { API_BASE } from './base'
+import { clearTokens, getAccessToken, getRefreshToken, storeTokens } from '@/lib/tokenStorage'
 
 export interface User {
   id: string
@@ -6,6 +7,17 @@ export interface User {
   name?: string
   created_at: string
   updated_at: string
+}
+
+export type OrganizationMembership = {
+  id: string
+  name: string
+  slug: string
+  role: 'admin' | 'editor' | 'viewer' | 'auditor'
+}
+
+export interface MeResponse extends User {
+  organizations: OrganizationMembership[]
 }
 
 interface AuthResponse {
@@ -26,21 +38,43 @@ interface RegisterRequest {
   name?: string
 }
 
-export interface MeResponse extends User {
-  organizations: Array<{
-    id: string
-    name: string
-    slug: string
-    role: 'admin' | 'editor' | 'viewer' | 'auditor'
-  }>
+type MeApiOrganization = {
+  organization_id: string
+  organization_name: string
+  organization_slug: string
+  role: OrganizationMembership['role']
 }
 
-function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token')
+type MeApiResponse = User & {
+  organizations?: MeApiOrganization[]
+}
+
+export type SSOProvider = {
+  provider: string
+}
+
+function normalizeMe(me: MeApiResponse): MeResponse {
+  return {
+    ...me,
+    organizations: (me.organizations ?? []).map(org => ({
+      id: org.organization_id,
+      name: org.organization_name,
+      slug: org.organization_slug,
+      role: org.role,
+    })),
+  }
+}
+
+export function getAuthHeaders(): HeadersInit {
+  const token = getAccessToken()
   return {
     'Content-Type': 'application/json',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
   }
+}
+
+function persistAuthResponse(response: AuthResponse): void {
+  storeTokens(response.access_token, response.refresh_token, response.expires_in)
 }
 
 export async function login(data: LoginRequest): Promise<AuthResponse> {
@@ -56,7 +90,9 @@ export async function login(data: LoginRequest): Promise<AuthResponse> {
     const error = await response.json().catch(() => ({}))
     throw new Error(error.error || 'Login failed')
   }
-  return response.json()
+  const auth = (await response.json()) as AuthResponse
+  persistAuthResponse(auth)
+  return auth
 }
 
 export async function register(data: RegisterRequest): Promise<AuthResponse> {
@@ -76,7 +112,9 @@ export async function register(data: RegisterRequest): Promise<AuthResponse> {
     const error = await response.json().catch(() => ({}))
     throw new Error(error.error || 'Registration failed')
   }
-  return response.json()
+  const auth = (await response.json()) as AuthResponse
+  persistAuthResponse(auth)
+  return auth
 }
 
 export async function getMe(): Promise<MeResponse> {
@@ -89,7 +127,34 @@ export async function getMe(): Promise<MeResponse> {
     }
     throw new Error('Failed to get user info')
   }
-  return response.json()
+  const me = (await response.json()) as MeApiResponse
+  return normalizeMe(me)
+}
+
+export async function refreshTokens(): Promise<AuthResponse> {
+  const refreshToken = getRefreshToken()
+  if (!refreshToken) {
+    throw new Error('No refresh token')
+  }
+
+  const response = await fetch(`${API_BASE}/api/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+
+  if (!response.ok) {
+    clearTokens()
+    if (response.status === 401) {
+      throw new Error('Session expired')
+    }
+    const error = await response.json().catch(() => ({}))
+    throw new Error(error.error || 'Token refresh failed')
+  }
+
+  const auth = (await response.json()) as AuthResponse
+  persistAuthResponse(auth)
+  return auth
 }
 
 export async function logout(refreshToken: string): Promise<void> {
@@ -101,4 +166,18 @@ export async function logout(refreshToken: string): Promise<void> {
   if (!response.ok) {
     throw new Error('Logout failed')
   }
+}
+
+export async function fetchSSOProviders(orgSlug: string): Promise<SSOProvider[]> {
+  try {
+    const response = await fetch(`${API_BASE}/api/orgs/${orgSlug}/sso/providers`)
+    if (!response.ok) return []
+    return (await response.json()) as SSOProvider[]
+  } catch {
+    return []
+  }
+}
+
+export function storeSessionFromTokens(accessToken: string, refreshToken: string, expiresIn = 900): void {
+  storeTokens(accessToken, refreshToken, expiresIn)
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -182,7 +182,7 @@ export async function logout(refreshToken: string): Promise<void> {
 
 export async function fetchSSOProviders(orgSlug: string): Promise<SSOProvider[]> {
   try {
-    const response = await fetch(`${API_BASE}/api/orgs/${orgSlug}/sso/providers`)
+    const response = await fetch(`${API_BASE}/api/orgs/${encodeURIComponent(orgSlug)}/sso/providers`)
     if (!response.ok) return []
     return (await response.json()) as SSOProvider[]
   } catch {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -131,6 +131,18 @@ export async function getMe(): Promise<MeResponse> {
   return normalizeMe(me)
 }
 
+export async function getMeWithRefresh(): Promise<MeResponse> {
+  try {
+    return await getMe()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Not authenticated' && getRefreshToken()) {
+      await refreshTokens()
+      return await getMe()
+    }
+    throw error
+  }
+}
+
 export async function refreshTokens(): Promise<AuthResponse> {
   const refreshToken = getRefreshToken()
   if (!refreshToken) {

--- a/frontend/src/layouts/AuthGuard.tsx
+++ b/frontend/src/layouts/AuthGuard.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { Navigate, Outlet, useLocation, useMatches } from 'react-router-dom'
+import { safeRedirectPath } from '@/lib/safeRedirect'
 import type { RouteMeta } from '@/router'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -25,8 +26,7 @@ export function AuthGuard() {
 
   if (isPublic && location.pathname === '/login' && isAuthenticated) {
     const params = new URLSearchParams(location.search)
-    const redirect = params.get('redirect')
-    const destination = redirect?.startsWith('/') ? redirect : '/app'
+    const destination = safeRedirectPath(params.get('redirect')) ?? '/app'
     return <Navigate to={destination} replace />
   }
 

--- a/frontend/src/layouts/AuthGuard.tsx
+++ b/frontend/src/layouts/AuthGuard.tsx
@@ -24,7 +24,10 @@ export function AuthGuard() {
   const isPublic = meta?.public === true
 
   if (isPublic && location.pathname === '/login' && isAuthenticated) {
-    return <Navigate to="/app" replace />
+    const params = new URLSearchParams(location.search)
+    const redirect = params.get('redirect')
+    const destination = redirect?.startsWith('/') ? redirect : '/app'
+    return <Navigate to={destination} replace />
   }
 
   if (!isPublic && !isAuthenticated) {

--- a/frontend/src/lib/safeRedirect.spec.ts
+++ b/frontend/src/lib/safeRedirect.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { safeRedirectPath } from '@/lib/safeRedirect'
+
+describe('safeRedirectPath', () => {
+  it('accepts same-origin relative paths', () => {
+    expect(safeRedirectPath('/app/dashboards')).toBe('/app/dashboards')
+  })
+
+  it('rejects protocol-relative and external paths', () => {
+    expect(safeRedirectPath('//evil.com')).toBeNull()
+    expect(safeRedirectPath('https://evil.com')).toBeNull()
+    expect(safeRedirectPath('/app\\evil')).toBeNull()
+  })
+})

--- a/frontend/src/lib/safeRedirect.ts
+++ b/frontend/src/lib/safeRedirect.ts
@@ -1,0 +1,8 @@
+/** Returns a same-origin relative path safe for client-side navigation, or null. */
+export function safeRedirectPath(path: string | null | undefined): string | null {
+  if (!path) return null
+  if (!path.startsWith('/') || path.startsWith('//') || path.includes('\\')) {
+    return null
+  }
+  return path
+}

--- a/frontend/src/lib/ssoRedirect.ts
+++ b/frontend/src/lib/ssoRedirect.ts
@@ -1,0 +1,18 @@
+import { safeRedirectPath } from '@/lib/safeRedirect'
+
+const SSO_REDIRECT_KEY = 'sso_redirect'
+
+export function storeSsoRedirect(path: string | null | undefined): void {
+  const safe = safeRedirectPath(path)
+  if (safe) {
+    sessionStorage.setItem(SSO_REDIRECT_KEY, safe)
+  } else {
+    sessionStorage.removeItem(SSO_REDIRECT_KEY)
+  }
+}
+
+export function consumeSsoRedirect(): string | null {
+  const stored = sessionStorage.getItem(SSO_REDIRECT_KEY)
+  sessionStorage.removeItem(SSO_REDIRECT_KEY)
+  return safeRedirectPath(stored)
+}

--- a/frontend/src/lib/tokenStorage.spec.ts
+++ b/frontend/src/lib/tokenStorage.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearTokens,
+  getTokenExpiresAt,
+  hasStoredSession,
+  isAccessTokenExpired,
+  shouldRefreshAccessToken,
+  storeTokens,
+} from '@/lib/tokenStorage'
+
+describe('tokenStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('stores tokens with an expiry timestamp', () => {
+    storeTokens('access', 'refresh', 900)
+    expect(hasStoredSession()).toBe(true)
+    expect(getTokenExpiresAt()).toBeGreaterThan(Date.now())
+  })
+
+  it('treats missing expiry metadata as needing refresh', () => {
+    localStorage.setItem('access_token', 'access')
+    localStorage.setItem('refresh_token', 'refresh')
+    expect(shouldRefreshAccessToken()).toBe(true)
+    expect(isAccessTokenExpired()).toBe(true)
+  })
+
+  it('detects access tokens within the refresh buffer', () => {
+    const expiresAt = Date.now() + 30_000
+    localStorage.setItem('access_token', 'access')
+    localStorage.setItem('refresh_token', 'refresh')
+    localStorage.setItem('token_expires_at', String(expiresAt))
+    expect(shouldRefreshAccessToken()).toBe(true)
+  })
+
+  it('clears all token keys', () => {
+    storeTokens('access', 'refresh', 900)
+    clearTokens()
+    expect(hasStoredSession()).toBe(false)
+    expect(getTokenExpiresAt()).toBeNull()
+  })
+})

--- a/frontend/src/lib/tokenStorage.ts
+++ b/frontend/src/lib/tokenStorage.ts
@@ -1,0 +1,50 @@
+const ACCESS_TOKEN_KEY = 'access_token'
+const REFRESH_TOKEN_KEY = 'refresh_token'
+const TOKEN_EXPIRES_AT_KEY = 'token_expires_at'
+
+/** Refresh when less than this many seconds remain before expiry. */
+const REFRESH_BUFFER_SECONDS = 60
+
+export type StoredTokens = {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+}
+
+export function getAccessToken(): string | null {
+  return localStorage.getItem(ACCESS_TOKEN_KEY)
+}
+
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_TOKEN_KEY)
+}
+
+export function getTokenExpiresAt(): number | null {
+  const raw = localStorage.getItem(TOKEN_EXPIRES_AT_KEY)
+  if (!raw) return null
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function storeTokens(accessToken: string, refreshToken: string, expiresInSeconds: number): void {
+  const expiresAt = Date.now() + expiresInSeconds * 1000
+  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken)
+  localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken)
+  localStorage.setItem(TOKEN_EXPIRES_AT_KEY, String(expiresAt))
+}
+
+export function clearTokens(): void {
+  localStorage.removeItem(ACCESS_TOKEN_KEY)
+  localStorage.removeItem(REFRESH_TOKEN_KEY)
+  localStorage.removeItem(TOKEN_EXPIRES_AT_KEY)
+}
+
+export function isAccessTokenExpired(): boolean {
+  const expiresAt = getTokenExpiresAt()
+  if (!expiresAt) return false
+  return Date.now() >= expiresAt - REFRESH_BUFFER_SECONDS * 1000
+}
+
+export function hasStoredSession(): boolean {
+  return Boolean(getAccessToken() && getRefreshToken())
+}

--- a/frontend/src/lib/tokenStorage.ts
+++ b/frontend/src/lib/tokenStorage.ts
@@ -40,8 +40,15 @@ export function clearTokens(): void {
 }
 
 export function isAccessTokenExpired(): boolean {
+  return shouldRefreshAccessToken()
+}
+
+/** True when the access token should be refreshed before use. */
+export function shouldRefreshAccessToken(): boolean {
+  if (!hasStoredSession()) return false
   const expiresAt = getTokenExpiresAt()
-  if (!expiresAt) return false
+  // Legacy sessions (Vue migration) lack expiry metadata — refresh to be safe.
+  if (!expiresAt) return true
   return Date.now() >= expiresAt - REFRESH_BUFFER_SECONDS * 1000
 }
 

--- a/frontend/src/pages/AuthCallbackPage.spec.tsx
+++ b/frontend/src/pages/AuthCallbackPage.spec.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as authApi from '@/api/auth'
+import { AuthCallbackPage } from '@/pages/AuthCallbackPage'
+import { useAuthStore } from '@/stores/authStore'
+
+vi.mock('@/analytics', () => ({
+  identifyUser: vi.fn(),
+  resetUserAnalytics: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+describe('AuthCallbackPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    useAuthStore.setState({
+      user: null,
+      userOrganizations: [],
+      loading: false,
+      initialized: false,
+      isAuthenticated: false,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('parses hash tokens, applies session, and navigates to stored redirect', async () => {
+    sessionStorage.setItem('sso_redirect', '/app/dashboards')
+    const applySession = vi.spyOn(useAuthStore.getState(), 'applySession').mockResolvedValue()
+    const storeSpy = vi.spyOn(authApi, 'storeSessionFromTokens').mockImplementation(() => {})
+
+    const router = createMemoryRouter(
+      [
+        { path: '/auth/callback', element: <AuthCallbackPage /> },
+        { path: '/app/dashboards', element: <div>Dashboards</div> },
+      ],
+      { initialEntries: ['/auth/callback#access_token=abc&refresh_token=def'] },
+    )
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(storeSpy).toHaveBeenCalledWith('abc', 'def')
+      expect(applySession).toHaveBeenCalled()
+      expect(router.state.location.pathname).toBe('/app/dashboards')
+    })
+  })
+
+  it('shows an error when tokens are missing from the hash', async () => {
+    const router = createMemoryRouter([{ path: '/auth/callback', element: <AuthCallbackPage /> }], {
+      initialEntries: ['/auth/callback#token_type=Bearer'],
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText(/missing tokens/i)).toBeTruthy()
+  })
+
+  it('clears tokens when applySession fails', async () => {
+    localStorage.setItem('access_token', 'old')
+    localStorage.setItem('refresh_token', 'old')
+    vi.spyOn(useAuthStore.getState(), 'applySession').mockRejectedValue(new Error('fail'))
+
+    const router = createMemoryRouter([{ path: '/auth/callback', element: <AuthCallbackPage /> }], {
+      initialEntries: ['/auth/callback#access_token=abc&refresh_token=def'],
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not establish a session/i)).toBeTruthy()
+      expect(localStorage.getItem('access_token')).toBeNull()
+    })
+  })
+})

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { storeSessionFromTokens } from '@/api/auth'
+import { useAuthStore } from '@/stores/authStore'
+
+function parseHashTokens(hash: string): { accessToken: string | null; refreshToken: string | null } {
+  const params = new URLSearchParams(hash.replace(/^#/, ''))
+  return {
+    accessToken: params.get('access_token'),
+    refreshToken: params.get('refresh_token'),
+  }
+}
+
+export function AuthCallbackPage() {
+  const navigate = useNavigate()
+  const { applySession } = useAuthStore()
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const { accessToken, refreshToken } = parseHashTokens(window.location.hash)
+
+    if (!accessToken || !refreshToken) {
+      setError('Sign-in failed — missing tokens from identity provider.')
+      return
+    }
+
+    void (async () => {
+      try {
+        storeSessionFromTokens(accessToken, refreshToken)
+        await applySession()
+        navigate('/app', { replace: true })
+      } catch {
+        setError('Sign-in failed — could not establish a session.')
+      }
+    })()
+  }, [applySession, navigate])
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface px-4 text-sm text-error">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface text-sm text-on-surface-variant">
+      Completing sign-in…
+    </div>
+  )
+}

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { storeSessionFromTokens } from '@/api/auth'
+import { clearTokens } from '@/lib/tokenStorage'
+import { consumeSsoRedirect } from '@/lib/ssoRedirect'
 import { useAuthStore } from '@/stores/authStore'
 
 function parseHashTokens(hash: string): { accessToken: string | null; refreshToken: string | null } {
@@ -11,13 +13,19 @@ function parseHashTokens(hash: string): { accessToken: string | null; refreshTok
   }
 }
 
+function stripHashFromUrl(): void {
+  history.replaceState(null, '', window.location.pathname + window.location.search)
+}
+
 export function AuthCallbackPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { applySession } = useAuthStore()
   const [error, setError] = useState('')
 
   useEffect(() => {
-    const { accessToken, refreshToken } = parseHashTokens(window.location.hash)
+    const { accessToken, refreshToken } = parseHashTokens(location.hash)
+    stripHashFromUrl()
 
     if (!accessToken || !refreshToken) {
       setError('Sign-in failed — missing tokens from identity provider.')
@@ -28,12 +36,14 @@ export function AuthCallbackPage() {
       try {
         storeSessionFromTokens(accessToken, refreshToken)
         await applySession()
-        navigate('/app', { replace: true })
+        const destination = consumeSsoRedirect() ?? '/app'
+        navigate(destination, { replace: true })
       } catch {
+        clearTokens()
         setError('Sign-in failed — could not establish a session.')
       }
     })()
-  }, [applySession, navigate])
+  }, [applySession, location.hash, navigate])
 
   if (error) {
     return (

--- a/frontend/src/pages/LoginPage.spec.tsx
+++ b/frontend/src/pages/LoginPage.spec.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as authApi from '@/api/auth'
+import { LoginPage } from '@/pages/LoginPage'
+import { useAuthStore } from '@/stores/authStore'
+
+vi.mock('@/analytics', () => ({
+  identifyUser: vi.fn(),
+  resetUserAnalytics: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+function renderLogin(initialEntry = '/login') {
+  const router = createMemoryRouter(
+    [
+      { path: '/login', element: <LoginPage /> },
+      { path: '/app', element: <div>Command Center</div> },
+      { path: '/app/dashboards', element: <div>Dashboards</div> },
+    ],
+    { initialEntries: [initialEntry] },
+  )
+
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useAuthStore.setState({
+      user: null,
+      userOrganizations: [],
+      loading: false,
+      initialized: true,
+      isAuthenticated: false,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('submits credentials and navigates to the redirect target', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(authApi, 'login').mockResolvedValue({
+      access_token: 'access-1',
+      refresh_token: 'refresh-1',
+      token_type: 'Bearer',
+      expires_in: 900,
+    })
+    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      organizations: [],
+    })
+
+    const router = renderLogin('/login?redirect=%2Fapp%2Fdashboards')
+
+    await user.type(screen.getByTestId('email-input'), 'user@example.com')
+    await user.type(screen.getByTestId('password-input'), 'Password1')
+    await user.click(screen.getByTestId('login-submit-btn'))
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/app/dashboards')
+    })
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+  })
+
+  it('renders SSO providers when org query param is present', async () => {
+    vi.spyOn(authApi, 'fetchSSOProviders').mockResolvedValue([{ provider: 'google' }])
+    renderLogin('/login?org=acme')
+
+    expect(await screen.findByTestId('sso-providers')).toBeTruthy()
+    expect(screen.getByTestId('sso-btn-google')).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/LoginPage.spec.tsx
+++ b/frontend/src/pages/LoginPage.spec.tsx
@@ -47,7 +47,7 @@ describe('LoginPage', () => {
       token_type: 'Bearer',
       expires_in: 900,
     })
-    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+    vi.spyOn(authApi, 'getMeWithRefresh').mockResolvedValue({
       id: 'user-1',
       email: 'user@example.com',
       created_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,276 @@
+import { AlertCircle, Lock, LogIn, Mail, User, UserPlus } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { API_BASE } from '@/api/base'
+import type { SSOProvider } from '@/api/auth'
+import { fetchSSOProviders } from '@/api/auth'
+import { Button } from '@/components/ui/button'
+import { useAuthStore } from '@/stores/authStore'
+
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  google: 'Google',
+  microsoft: 'Microsoft',
+  okta: 'Okta',
+}
+
+const PROVIDER_ICON_LETTERS: Record<string, string> = {
+  google: 'G',
+  microsoft: 'M',
+  okta: 'O',
+}
+
+export function LoginPage() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { login, register } = useAuthStore()
+
+  const [mode, setMode] = useState<'login' | 'register'>('login')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [orgSlug, setOrgSlug] = useState<string | null>(null)
+  const [ssoProviders, setSsoProviders] = useState<SSOProvider[]>([])
+  const [ssoLoading, setSsoLoading] = useState(false)
+
+  useEffect(() => {
+    const org = searchParams.get('org')
+    if (!org) return
+
+    setOrgSlug(org)
+    setSsoLoading(true)
+    void fetchSSOProviders(org).then(providers => {
+      setSsoProviders(providers)
+      setSsoLoading(false)
+    })
+  }, [searchParams])
+
+  function handleSSOLogin(provider: string) {
+    if (!orgSlug) return
+    window.location.href = `${API_BASE}/api/auth/${provider}/login?org=${encodeURIComponent(orgSlug)}`
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError('')
+    setLoading(true)
+
+    try {
+      if (mode === 'login') {
+        await login(email, password)
+      } else {
+        await register(email, password, name || undefined)
+      }
+
+      const redirect = searchParams.get('redirect')
+      navigate(redirect?.startsWith('/') ? redirect : '/app', { replace: true })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'An error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function switchMode() {
+    setMode(current => (current === 'login' ? 'register' : 'login'))
+    setError('')
+  }
+
+  return (
+    <div className="login-page relative flex min-h-screen items-center justify-center overflow-hidden px-4">
+      <div className="absolute inset-0 bg-[var(--color-surface)]" />
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse 60% 50% at 50% 40%, rgba(163,166,255,0.06) 0%, transparent 70%), radial-gradient(ellipse 40% 40% at 20% 80%, rgba(96,99,238,0.04) 0%, transparent 60%), radial-gradient(ellipse 50% 30% at 80% 20%, rgba(105,246,184,0.03) 0%, transparent 50%)',
+        }}
+      />
+      <div
+        className="absolute inset-0 opacity-[0.03]"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(255,255,255,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.1) 1px, transparent 1px)',
+          backgroundSize: '64px 64px',
+        }}
+      />
+
+      <div className="relative z-10 w-full max-w-md rounded-lg bg-[var(--color-surface-container-low)] p-8">
+        <div className="mb-8 text-center">
+          <div className="mb-6 flex flex-col items-center justify-center">
+            <div
+              className="relative inline-flex h-11 w-11 items-center justify-center rounded-sm font-mono text-sm font-bold text-white"
+              style={{
+                background: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dim) 100%)',
+                boxShadow: '0 0 20px rgba(163,166,255,0.2), 0 2px 8px rgba(0,0,0,0.3)',
+              }}
+            >
+              A
+            </div>
+            <span className="mt-2.5 font-mono text-[0.6875rem] uppercase tracking-[0.2em] text-[var(--color-outline)]">
+              Ace Observability
+            </span>
+          </div>
+          <h1 className="text-center font-display text-2xl font-bold text-[var(--color-on-surface)]">
+            {mode === 'login' ? 'Welcome back' : 'Create account'}
+          </h1>
+          <p className="mt-2 text-center text-sm text-[var(--color-outline)]">
+            {mode === 'login' ? 'Sign in to your account to continue' : 'Get started with your new account'}
+          </p>
+        </div>
+
+        {ssoProviders.length > 0 && mode === 'login' && (
+          <div className="mb-5 flex flex-col gap-3" data-testid="sso-providers">
+            {ssoProviders.map(provider => (
+              <Button
+                key={provider.provider}
+                type="button"
+                variant="outline"
+                className="w-full justify-center border-[var(--color-outline-variant)] bg-transparent py-2.5 text-[var(--color-on-surface)] hover:bg-[var(--color-surface-container-high)]"
+                data-testid={`sso-btn-${provider.provider}`}
+                onClick={() => handleSSOLogin(provider.provider)}
+              >
+                <span
+                  className="inline-flex h-5 w-5 items-center justify-center rounded-sm text-xs font-bold"
+                  style={{
+                    background: 'var(--color-surface-container-high)',
+                    color: 'var(--color-on-surface)',
+                  }}
+                >
+                  {PROVIDER_ICON_LETTERS[provider.provider] || provider.provider[0]?.toUpperCase()}
+                </span>
+                Continue with {PROVIDER_DISPLAY_NAMES[provider.provider] || provider.provider}
+              </Button>
+            ))}
+
+            <div className="my-4 flex items-center gap-3">
+              <div className="h-px flex-1 bg-[var(--color-outline)]" />
+              <span className="text-xs uppercase tracking-wider text-[var(--color-on-surface-variant)]">or</span>
+              <div className="h-px flex-1 bg-[var(--color-outline)]" />
+            </div>
+          </div>
+        )}
+
+        {ssoLoading && mode === 'login' && orgSlug && (
+          <p className="mb-4 text-center text-xs text-[var(--color-outline)]">Loading sign-in options…</p>
+        )}
+
+        <form className="flex flex-col gap-5" onSubmit={handleSubmit} data-testid="login-form">
+          {error && (
+            <div
+              className="flex items-center gap-2 rounded-sm bg-[var(--color-error)]/10 px-4 py-3 text-sm text-[var(--color-error)]"
+              data-testid="login-error"
+            >
+              <AlertCircle size={16} className="shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {mode === 'register' && (
+            <div className="flex flex-col">
+              <label htmlFor="name" className="mb-1.5 block text-sm font-medium text-[var(--color-on-surface-variant)]">
+                Name
+              </label>
+              <div className="relative flex items-center">
+                <User size={18} className="pointer-events-none absolute left-3.5 text-[var(--color-outline)]" />
+                <input
+                  id="name"
+                  value={name}
+                  onChange={event => setName(event.target.value)}
+                  type="text"
+                  placeholder="Your name (optional)"
+                  disabled={loading}
+                  data-testid="name-input"
+                  className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] py-2.5 pr-4 pl-11 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="flex flex-col">
+            <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-[var(--color-on-surface-variant)]">
+              Email
+            </label>
+            <div className="relative flex items-center">
+              <Mail size={18} className="pointer-events-none absolute left-3.5 text-[var(--color-outline)]" />
+              <input
+                id="email"
+                value={email}
+                onChange={event => setEmail(event.target.value)}
+                type="email"
+                placeholder="you@example.com"
+                required
+                disabled={loading}
+                data-testid="email-input"
+                className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] py-2.5 pr-4 pl-11 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col">
+            <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-[var(--color-on-surface-variant)]">
+              Password
+            </label>
+            <div className="relative flex items-center">
+              <Lock size={18} className="pointer-events-none absolute left-3.5 text-[var(--color-outline)]" />
+              <input
+                id="password"
+                value={password}
+                onChange={event => setPassword(event.target.value)}
+                type="password"
+                placeholder="Enter your password"
+                required
+                disabled={loading}
+                data-testid="password-input"
+                className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] py-2.5 pr-4 pl-11 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+              />
+            </div>
+            {mode === 'register' && (
+              <p className="mt-1 text-xs text-[var(--color-outline)]">
+                Min 8 characters with uppercase, lowercase, and number
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-sm py-2.5 text-sm font-semibold text-white transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dim) 100%)',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.1)',
+            }}
+            disabled={loading}
+            data-testid="login-submit-btn"
+          >
+            {loading ? (
+              <>
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                {mode === 'login' ? 'Signing in...' : 'Creating account...'}
+              </>
+            ) : (
+              <>
+                {mode === 'login' ? <LogIn size={18} /> : <UserPlus size={18} />}
+                {mode === 'login' ? 'Sign in' : 'Create account'}
+              </>
+            )}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center">
+          <p className="text-sm text-[var(--color-outline)]">
+            {mode === 'login' ? "Don't have an account?" : 'Already have an account?'}{' '}
+            <button
+              type="button"
+              className="ml-1 cursor-pointer border-none bg-transparent p-0 text-sm font-medium text-[var(--color-primary)] hover:underline"
+              onClick={switchMode}
+              data-testid="auth-mode-switch-btn"
+            >
+              {mode === 'login' ? 'Create one' : 'Sign in'}
+            </button>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,6 +5,8 @@ import { API_BASE } from '@/api/base'
 import type { SSOProvider } from '@/api/auth'
 import { fetchSSOProviders } from '@/api/auth'
 import { Button } from '@/components/ui/button'
+import { safeRedirectPath } from '@/lib/safeRedirect'
+import { storeSsoRedirect } from '@/lib/ssoRedirect'
 import { useAuthStore } from '@/stores/authStore'
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
@@ -36,7 +38,12 @@ export function LoginPage() {
 
   useEffect(() => {
     const org = searchParams.get('org')
-    if (!org) return
+    if (!org) {
+      setOrgSlug(null)
+      setSsoProviders([])
+      setSsoLoading(false)
+      return
+    }
 
     setOrgSlug(org)
     setSsoLoading(true)
@@ -48,6 +55,7 @@ export function LoginPage() {
 
   function handleSSOLogin(provider: string) {
     if (!orgSlug) return
+    storeSsoRedirect(searchParams.get('redirect'))
     window.location.href = `${API_BASE}/api/auth/${provider}/login?org=${encodeURIComponent(orgSlug)}`
   }
 
@@ -63,8 +71,8 @@ export function LoginPage() {
         await register(email, password, name || undefined)
       }
 
-      const redirect = searchParams.get('redirect')
-      navigate(redirect?.startsWith('/') ? redirect : '/app', { replace: true })
+      const destination = safeRedirectPath(searchParams.get('redirect')) ?? '/app'
+      navigate(destination, { replace: true })
     } catch (e) {
       setError(e instanceof Error ? e.message : 'An error occurred')
     } finally {

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -7,6 +7,10 @@ import { createParamRedirect } from '@/lib/redirects'
 const PlaceholderPage = lazy(() =>
   import('@/pages/PlaceholderPage').then(m => ({ default: m.PlaceholderPage })),
 )
+const LoginPage = lazy(() => import('@/pages/LoginPage').then(m => ({ default: m.LoginPage })))
+const AuthCallbackPage = lazy(() =>
+  import('@/pages/AuthCallbackPage').then(m => ({ default: m.AuthCallbackPage })),
+)
 
 const DashboardAliasRedirect = createParamRedirect('/app/dashboards/:id')
 const DashboardSettingsAliasRedirect = createParamRedirect('/app/dashboards/:id/settings')
@@ -144,7 +148,12 @@ export const router = createBrowserRouter([
         handle: withMeta('Sign in | Ace', 'Sign in to Ace to manage dashboards, alerts, and observability workflows.', {
           public: true,
         }),
-        element: placeholder('Sign in'),
+        element: <LoginPage />,
+      },
+      {
+        path: '/auth/callback',
+        handle: withMeta('Signing in | Ace', undefined, { public: true }),
+        element: <AuthCallbackPage />,
       },
       {
         element: <AppLayout />,

--- a/frontend/src/stores/authStore.spec.ts
+++ b/frontend/src/stores/authStore.spec.ts
@@ -26,7 +26,7 @@ describe('useAuthStore', () => {
 
   it('initializes session from stored tokens', async () => {
     storeTokens('access-1', 'refresh-1', 900)
-    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+    vi.spyOn(authApi, 'getMeWithRefresh').mockResolvedValue({
       id: 'user-1',
       email: 'user@example.com',
       name: 'User',
@@ -40,6 +40,33 @@ describe('useAuthStore', () => {
     expect(authenticated).toBe(true)
     expect(useAuthStore.getState().user?.email).toBe('user@example.com')
     expect(useAuthStore.getState().userOrganizations).toHaveLength(1)
+  })
+
+  it('refreshes legacy sessions without expiry metadata before loading', async () => {
+    localStorage.setItem('access_token', 'stale-access')
+    localStorage.setItem('refresh_token', 'refresh-1')
+
+    const refreshSpy = vi.spyOn(authApi, 'refreshTokens').mockImplementation(async () => {
+      storeTokens('fresh-access', 'fresh-refresh', 900)
+      return {
+        access_token: 'fresh-access',
+        refresh_token: 'fresh-refresh',
+        token_type: 'Bearer',
+        expires_in: 900,
+      }
+    })
+    vi.spyOn(authApi, 'getMeWithRefresh').mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      organizations: [],
+    })
+
+    const authenticated = await useAuthStore.getState().initialize()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(authenticated).toBe(true)
   })
 
   it('refreshes expired access tokens before loading the session', async () => {
@@ -57,7 +84,7 @@ describe('useAuthStore', () => {
         expires_in: 900,
       }
     })
-    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+    vi.spyOn(authApi, 'getMeWithRefresh').mockResolvedValue({
       id: 'user-1',
       email: 'user@example.com',
       created_at: '2026-01-01T00:00:00Z',
@@ -80,7 +107,7 @@ describe('useAuthStore', () => {
       token_type: 'Bearer',
       expires_in: 900,
     })
-    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+    vi.spyOn(authApi, 'getMeWithRefresh').mockResolvedValue({
       id: 'user-1',
       email: 'user@example.com',
       created_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/stores/authStore.spec.ts
+++ b/frontend/src/stores/authStore.spec.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as authApi from '@/api/auth'
+import { storeTokens } from '@/lib/tokenStorage'
+import { useAuthStore } from '@/stores/authStore'
+import { useOrgStore } from '@/stores/orgStore'
+
+vi.mock('@/analytics', () => ({
+  identifyUser: vi.fn(),
+  resetUserAnalytics: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useAuthStore.setState({
+      user: null,
+      userOrganizations: [],
+      loading: false,
+      initialized: false,
+      isAuthenticated: false,
+    })
+    useOrgStore.setState({ currentOrgId: null })
+    vi.restoreAllMocks()
+  })
+
+  it('initializes session from stored tokens', async () => {
+    storeTokens('access-1', 'refresh-1', 900)
+    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      organizations: [{ id: 'org-1', name: 'Org', slug: 'org', role: 'admin' }],
+    })
+
+    const authenticated = await useAuthStore.getState().initialize()
+
+    expect(authenticated).toBe(true)
+    expect(useAuthStore.getState().user?.email).toBe('user@example.com')
+    expect(useAuthStore.getState().userOrganizations).toHaveLength(1)
+  })
+
+  it('refreshes expired access tokens before loading the session', async () => {
+    const expiredAt = Date.now() - 1000
+    localStorage.setItem('access_token', 'stale-access')
+    localStorage.setItem('refresh_token', 'refresh-1')
+    localStorage.setItem('token_expires_at', String(expiredAt))
+
+    const refreshSpy = vi.spyOn(authApi, 'refreshTokens').mockImplementation(async () => {
+      storeTokens('fresh-access', 'fresh-refresh', 900)
+      return {
+        access_token: 'fresh-access',
+        refresh_token: 'fresh-refresh',
+        token_type: 'Bearer',
+        expires_in: 900,
+      }
+    })
+    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      organizations: [],
+    })
+
+    const authenticated = await useAuthStore.getState().initialize()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(authenticated).toBe(true)
+    expect(localStorage.getItem('access_token')).toBe('fresh-access')
+  })
+
+  it('logs in, stores tokens, and initializes org context from memberships', async () => {
+    localStorage.setItem('current_org_id', 'org-2')
+    vi.spyOn(authApi, 'login').mockResolvedValue({
+      access_token: 'access-1',
+      refresh_token: 'refresh-1',
+      token_type: 'Bearer',
+      expires_in: 900,
+    })
+    vi.spyOn(authApi, 'getMe').mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      organizations: [
+        { id: 'org-1', name: 'One', slug: 'one', role: 'viewer' },
+        { id: 'org-2', name: 'Two', slug: 'two', role: 'admin' },
+      ],
+    })
+
+    await useAuthStore.getState().login('user@example.com', 'Password1')
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+    expect(useOrgStore.getState().currentOrgId).toBe('org-2')
+  })
+})

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,15 +1,63 @@
-import { identifyUser, resetUserAnalytics } from '@/analytics'
-import type { MeResponse, User } from '@/api/auth'
+import { identifyUser, resetUserAnalytics, trackEvent } from '@/analytics'
+import type { MeResponse, OrganizationMembership, User } from '@/api/auth'
 import * as authApi from '@/api/auth'
+import { clearTokens, getRefreshToken, hasStoredSession, isAccessTokenExpired } from '@/lib/tokenStorage'
+import { useOrgStore } from '@/stores/orgStore'
 import { create } from 'zustand'
 
 type AuthState = {
   user: User | null
-  userOrganizations: MeResponse['organizations']
+  userOrganizations: OrganizationMembership[]
   loading: boolean
   initialized: boolean
   isAuthenticated: boolean
   initialize: () => Promise<boolean>
+  login: (email: string, password: string) => Promise<void>
+  register: (email: string, password: string, name?: string) => Promise<void>
+  logout: () => Promise<void>
+  applySession: () => Promise<void>
+  refreshSession: () => Promise<boolean>
+}
+
+function applyUserSession(me: MeResponse): void {
+  const user: User = {
+    id: me.id,
+    email: me.email,
+    name: me.name,
+    created_at: me.created_at,
+    updated_at: me.updated_at,
+  }
+  identifyUser({ id: me.id, email: me.email, name: me.name })
+  useOrgStore.getState().initializeFromMemberships(me.organizations)
+  useAuthStore.setState({
+    user,
+    userOrganizations: me.organizations,
+    isAuthenticated: true,
+  })
+}
+
+function clearSession(): void {
+  clearTokens()
+  resetUserAnalytics()
+  useOrgStore.getState().clear()
+  useAuthStore.setState({
+    user: null,
+    userOrganizations: [],
+    isAuthenticated: false,
+  })
+}
+
+async function ensureFreshAccessToken(): Promise<boolean> {
+  if (!hasStoredSession()) return false
+  if (!isAccessTokenExpired()) return true
+
+  try {
+    await authApi.refreshTokens()
+    return true
+  } catch {
+    clearSession()
+    return false
+  }
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
@@ -24,42 +72,83 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return get().isAuthenticated
     }
 
-    const token = localStorage.getItem('access_token')
-    if (!token) {
+    set({ loading: true })
+
+    if (!hasStoredSession()) {
       set({ loading: false, initialized: true, isAuthenticated: false })
       return false
     }
 
     try {
-      const me = await authApi.getMe()
-      const user: User = {
-        id: me.id,
-        email: me.email,
-        name: me.name,
-        created_at: me.created_at,
-        updated_at: me.updated_at,
+      const hasToken = await ensureFreshAccessToken()
+      if (!hasToken) {
+        set({ loading: false, initialized: true, isAuthenticated: false })
+        return false
       }
-      identifyUser({ id: me.id, email: me.email, name: me.name })
-      set({
-        user,
-        userOrganizations: me.organizations ?? [],
-        loading: false,
-        initialized: true,
-        isAuthenticated: true,
-      })
+
+      const me = await authApi.getMe()
+      applyUserSession(me)
+      set({ loading: false, initialized: true, isAuthenticated: true })
       return true
     } catch {
-      localStorage.removeItem('access_token')
-      localStorage.removeItem('refresh_token')
-      resetUserAnalytics()
-      set({
-        user: null,
-        userOrganizations: [],
-        loading: false,
-        initialized: true,
-        isAuthenticated: false,
-      })
+      clearSession()
+      set({ loading: false, initialized: true, isAuthenticated: false })
       return false
     }
+  },
+
+  async applySession() {
+    const me = await authApi.getMe()
+    applyUserSession(me)
+    set({ isAuthenticated: true, loading: false, initialized: true })
+  },
+
+  async refreshSession() {
+    if (!hasStoredSession()) {
+      clearSession()
+      set({ loading: false, initialized: true, isAuthenticated: false })
+      return false
+    }
+
+    try {
+      await authApi.refreshTokens()
+      await get().applySession()
+      return true
+    } catch {
+      clearSession()
+      set({ loading: false, initialized: true, isAuthenticated: false })
+      return false
+    }
+  },
+
+  async login(email, password) {
+    await authApi.login({ email, password })
+    await get().applySession()
+    trackEvent('auth_login', {
+      organization_count: get().userOrganizations.length,
+    })
+  },
+
+  async register(email, password, name) {
+    await authApi.register({ email, password, name })
+    await get().applySession()
+    trackEvent('auth_signup', {
+      organization_count: get().userOrganizations.length,
+    })
+  },
+
+  async logout() {
+    const refreshToken = getRefreshToken()
+    if (refreshToken) {
+      try {
+        await authApi.logout(refreshToken)
+      } catch {
+        // Clear local session even if server logout fails.
+      }
+    }
+
+    trackEvent('auth_logout')
+    clearSession()
+    set({ loading: false, initialized: true, isAuthenticated: false })
   },
 }))

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,7 +1,7 @@
 import { identifyUser, resetUserAnalytics, trackEvent } from '@/analytics'
 import type { MeResponse, OrganizationMembership, User } from '@/api/auth'
 import * as authApi from '@/api/auth'
-import { clearTokens, getRefreshToken, hasStoredSession, isAccessTokenExpired } from '@/lib/tokenStorage'
+import { clearTokens, getRefreshToken, hasStoredSession, shouldRefreshAccessToken } from '@/lib/tokenStorage'
 import { useOrgStore } from '@/stores/orgStore'
 import { create } from 'zustand'
 
@@ -18,6 +18,8 @@ type AuthState = {
   applySession: () => Promise<void>
   refreshSession: () => Promise<boolean>
 }
+
+let initPromise: Promise<boolean> | null = null
 
 function applyUserSession(me: MeResponse): void {
   const user: User = {
@@ -49,13 +51,40 @@ function clearSession(): void {
 
 async function ensureFreshAccessToken(): Promise<boolean> {
   if (!hasStoredSession()) return false
-  if (!isAccessTokenExpired()) return true
+  if (!shouldRefreshAccessToken()) return true
 
   try {
     await authApi.refreshTokens()
     return true
   } catch {
     clearSession()
+    return false
+  }
+}
+
+async function loadSession(set: (partial: Partial<AuthState>) => void): Promise<boolean> {
+  set({ loading: true })
+
+  if (!hasStoredSession()) {
+    useOrgStore.getState().clear()
+    set({ loading: false, initialized: true, isAuthenticated: false })
+    return false
+  }
+
+  try {
+    const hasToken = await ensureFreshAccessToken()
+    if (!hasToken) {
+      set({ loading: false, initialized: true, isAuthenticated: false })
+      return false
+    }
+
+    const me = await authApi.getMeWithRefresh()
+    applyUserSession(me)
+    set({ loading: false, initialized: true, isAuthenticated: true })
+    return true
+  } catch {
+    clearSession()
+    set({ loading: false, initialized: true, isAuthenticated: false })
     return false
   }
 }
@@ -72,33 +101,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return get().isAuthenticated
     }
 
-    set({ loading: true })
-
-    if (!hasStoredSession()) {
-      set({ loading: false, initialized: true, isAuthenticated: false })
-      return false
-    }
-
-    try {
-      const hasToken = await ensureFreshAccessToken()
-      if (!hasToken) {
-        set({ loading: false, initialized: true, isAuthenticated: false })
-        return false
-      }
-
-      const me = await authApi.getMe()
-      applyUserSession(me)
-      set({ loading: false, initialized: true, isAuthenticated: true })
-      return true
-    } catch {
-      clearSession()
-      set({ loading: false, initialized: true, isAuthenticated: false })
-      return false
-    }
+    initPromise ??= loadSession(set).finally(() => {
+      initPromise = null
+    })
+    return initPromise
   },
 
   async applySession() {
-    const me = await authApi.getMe()
+    const me = await authApi.getMeWithRefresh()
     applyUserSession(me)
     set({ isAuthenticated: true, loading: false, initialized: true })
   },

--- a/frontend/src/stores/orgStore.spec.ts
+++ b/frontend/src/stores/orgStore.spec.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useOrgStore } from '@/stores/orgStore'
+
+describe('useOrgStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useOrgStore.setState({ currentOrgId: null })
+  })
+
+  it('keeps a valid stored org id after login', () => {
+    localStorage.setItem('current_org_id', 'org-b')
+    useOrgStore.getState().initializeFromMemberships([
+      { id: 'org-a', name: 'A', slug: 'a', role: 'viewer' },
+      { id: 'org-b', name: 'B', slug: 'b', role: 'admin' },
+    ])
+
+    expect(useOrgStore.getState().currentOrgId).toBe('org-b')
+    expect(localStorage.getItem('current_org_id')).toBe('org-b')
+  })
+
+  it('falls back to the first membership when stored org is invalid', () => {
+    localStorage.setItem('current_org_id', 'missing')
+    useOrgStore.getState().initializeFromMemberships([
+      { id: 'org-a', name: 'A', slug: 'a', role: 'viewer' },
+      { id: 'org-b', name: 'B', slug: 'b', role: 'admin' },
+    ])
+
+    expect(useOrgStore.getState().currentOrgId).toBe('org-a')
+  })
+})

--- a/frontend/src/stores/orgStore.ts
+++ b/frontend/src/stores/orgStore.ts
@@ -1,0 +1,48 @@
+import type { OrganizationMembership } from '@/api/auth'
+import { create } from 'zustand'
+
+const CURRENT_ORG_KEY = 'current_org_id'
+
+type OrgState = {
+  currentOrgId: string | null
+  initializeFromMemberships: (memberships: OrganizationMembership[]) => void
+  clear: () => void
+}
+
+function readStoredOrgId(): string | null {
+  return localStorage.getItem(CURRENT_ORG_KEY)
+}
+
+function persistOrgId(orgId: string | null): void {
+  if (orgId) {
+    localStorage.setItem(CURRENT_ORG_KEY, orgId)
+  } else {
+    localStorage.removeItem(CURRENT_ORG_KEY)
+  }
+}
+
+function resolveOrgId(memberships: OrganizationMembership[]): string | null {
+  if (memberships.length === 0) return null
+
+  const stored = readStoredOrgId()
+  if (stored && memberships.some(org => org.id === stored)) {
+    return stored
+  }
+
+  return memberships[0]?.id ?? null
+}
+
+export const useOrgStore = create<OrgState>(set => ({
+  currentOrgId: readStoredOrgId(),
+
+  initializeFromMemberships(memberships) {
+    const orgId = resolveOrgId(memberships)
+    persistOrgId(orgId)
+    set({ currentOrgId: orgId })
+  },
+
+  clear() {
+    persistOrgId(null)
+    set({ currentOrgId: null })
+  },
+}))

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,59 +1,39 @@
 // Polyfill localStorage for Node.js v22+ where a native but incomplete
 // localStorage global exists and conflicts with happy-dom's implementation.
+function createStoragePolyfill(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value))
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+    clear() {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null
+    },
+  } as Storage
+}
+
 if (
   typeof globalThis.localStorage === 'undefined' ||
   typeof globalThis.localStorage.getItem !== 'function'
 ) {
-  const store: Record<string, string> = {}
-  globalThis.localStorage = {
-    getItem(key: string) {
-      return store[key] ?? null
-    },
-    setItem(key: string, value: string) {
-      store[key] = String(value)
-    },
-    removeItem(key: string) {
-      delete store[key]
-    },
-    clear() {
-      for (const key of Object.keys(store)) {
-        delete store[key]
-      }
-    },
-    get length() {
-      return Object.keys(store).length
-    },
-    key(index: number) {
-      return Object.keys(store)[index] ?? null
-    },
-  } as Storage
+  globalThis.localStorage = createStoragePolyfill()
 }
 
 if (
   typeof globalThis.sessionStorage === 'undefined' ||
   typeof globalThis.sessionStorage.getItem !== 'function'
 ) {
-  const store: Record<string, string> = {}
-  globalThis.sessionStorage = {
-    getItem(key: string) {
-      return store[key] ?? null
-    },
-    setItem(key: string, value: string) {
-      store[key] = String(value)
-    },
-    removeItem(key: string) {
-      delete store[key]
-    },
-    clear() {
-      for (const key of Object.keys(store)) {
-        delete store[key]
-      }
-    },
-    get length() {
-      return Object.keys(store).length
-    },
-    key(index: number) {
-      return Object.keys(store)[index] ?? null
-    },
-  } as Storage
+  globalThis.sessionStorage = createStoragePolyfill()
 }


### PR DESCRIPTION
## Summary

Tracer bullet [#295 — Auth and session](https://github.com/aceobservability/ace/issues/295) on the [Vue → React rewrite map](https://github.com/aceobservability/ace/issues/292). Builds on the #294 React foundation scaffold (included in this branch; #294 branch not yet on remote).

Delivers end-to-end authentication for the React frontend:

- **LoginPage** — email/password, register toggle, SSO provider buttons when `?org=` slug is present
- **AuthCallbackPage** — handles `/auth/callback#access_token=…&refresh_token=…` (gap in Vue; backend already redirects here)
- **authStore** (Zustand) — login/register/logout, session init, proactive JWT refresh
- **orgStore** — initializes `current_org_id` from localStorage against `/me` memberships
- **AuthGuard** — redirects unauthenticated users to `/login?redirect=…`

## Review fixes (pre-PR)

Code review surfaced several edge cases, all addressed in `346e0b2`:

- Legacy Vue sessions (no `token_expires_at`) now refresh before `getMe`
- `initialize()` deduplicated to avoid StrictMode double-init races
- `getMeWithRefresh()` retries once via refresh token on 401
- `safeRedirectPath()` blocks protocol-relative open redirects (`//evil.com`)
- SSO callback strips hash tokens from URL; clears storage on failure; restores redirect via sessionStorage

## Tests

299 tests pass. New coverage: login redirect, guard redirect, token refresh (including legacy sessions), org context init, SSO callback happy/error paths, `tokenStorage`, `safeRedirect`.

## Checklist

- [x] `npm run type-check`
- [x] `npm run test`
- [x] `npm run build`
- [x] No backend API changes

## Unblocks

[#296 App shell and navigation](https://github.com/aceobservability/ace/issues/296)