### PR TITLE
feat(frontend): home command center (#297)

### DIFF
--- a/frontend/src/components/AiInsightCard.tsx
+++ b/frontend/src/components/AiInsightCard.tsx
@@ -1,0 +1,40 @@
+type InsightType = 'anomaly' | 'optimization' | 'forecast'
+
+type AiInsightCardProps = {
+  title: string
+  description: string
+  timestamp: string
+  type: InsightType
+}
+
+const colorMap: Record<InsightType, { border: string; bg: string }> = {
+  anomaly: { border: '#C9960F', bg: 'rgba(201,150,15,0.05)' },
+  optimization: { border: '#4D8BBD', bg: 'rgba(77,139,189,0.05)' },
+  forecast: { border: '#D4A11E', bg: 'rgba(212,161,30,0.05)' },
+}
+
+export function AiInsightCard({ title, description, timestamp, type }: AiInsightCardProps) {
+  const colors = colorMap[type]
+
+  return (
+    <div
+      data-testid="ai-insight-card"
+      style={{
+        borderLeft: `2px solid ${colors.border}`,
+        backgroundColor: colors.bg,
+        borderRadius: '0 8px 8px 0',
+        padding: '10px 12px',
+      }}
+    >
+      <h4 className="text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+        {title}
+      </h4>
+      <p className="mt-1 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+        {description}
+      </p>
+      <time className="mt-1 block text-xs" style={{ color: 'var(--color-outline)' }} dateTime={timestamp}>
+        {timestamp}
+      </time>
+    </div>
+  )
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,47 @@
+import type { LucideIcon } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+type EmptyStateProps = {
+  icon: LucideIcon
+  title: string
+  description: string
+  actionLabel?: string
+  actionRoute?: string
+}
+
+export function EmptyState({ icon: Icon, title, description, actionLabel, actionRoute }: EmptyStateProps) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center px-6 py-16 text-center"
+      data-testid="empty-state"
+    >
+      <Icon aria-hidden style={{ color: 'var(--color-outline)', width: 40, height: 40 }} />
+      <h3
+        className="mt-4 font-display text-lg font-semibold"
+        style={{ color: 'var(--color-on-surface)' }}
+        data-testid="empty-state-title"
+      >
+        {title}
+      </h3>
+      <p
+        className="mt-2 max-w-sm text-sm"
+        style={{ color: 'var(--color-on-surface-variant)' }}
+        data-testid="empty-state-description"
+      >
+        {description}
+      </p>
+      {actionLabel && actionRoute ? (
+        <Link
+          to={actionRoute}
+          className="mt-6 inline-flex items-center rounded-lg px-5 py-2.5 text-sm font-medium text-white no-underline transition-opacity hover:opacity-90"
+          style={{
+            background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+          }}
+          data-testid="empty-state-action"
+        >
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/OnboardingBanner.tsx
+++ b/frontend/src/components/OnboardingBanner.tsx
@@ -1,0 +1,78 @@
+import { Check, X } from 'lucide-react'
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+const STORAGE_KEY = 'ace-onboarding-dismissed'
+
+const steps = [
+  { label: 'Connect a data source', route: '/app/datasources/new' },
+  { label: 'Create your first dashboard', route: '/app/dashboards' },
+  { label: 'Set up alerts', route: '/app/alerts' },
+] as const
+
+export function OnboardingBanner() {
+  const [isDismissed, setIsDismissed] = useState(() => localStorage.getItem(STORAGE_KEY) === 'true')
+
+  if (isDismissed) return null
+
+  function dismiss() {
+    localStorage.setItem(STORAGE_KEY, 'true')
+    setIsDismissed(true)
+  }
+
+  return (
+    <div
+      data-testid="onboarding-banner"
+      className="relative rounded-xl p-5"
+      style={{
+        backgroundColor: 'var(--color-surface-container)',
+        border: '1px solid var(--color-outline-variant)',
+      }}
+    >
+      <button
+        type="button"
+        className="absolute top-3 right-3 cursor-pointer rounded-md border-none bg-transparent p-1 transition-opacity"
+        style={{ color: 'var(--color-on-surface-variant)' }}
+        data-testid="onboarding-dismiss"
+        onClick={dismiss}
+        aria-label="Dismiss onboarding"
+      >
+        <X size={16} aria-hidden />
+      </button>
+
+      <h2
+        className="mb-4 font-display text-lg font-semibold"
+        style={{ color: 'var(--color-on-surface)' }}
+      >
+        Get started with Ace
+      </h2>
+
+      <div className="flex flex-col gap-2">
+        {steps.map((step, index) => (
+          <Link
+            key={step.label}
+            to={step.route}
+            className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm no-underline transition-colors hover:opacity-90"
+            style={{
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface)',
+            }}
+          >
+            <span
+              className="flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold"
+              style={{
+                backgroundColor: 'var(--color-surface-container)',
+                color: 'var(--color-on-surface-variant)',
+                border: '1px solid var(--color-outline-variant)',
+              }}
+            >
+              {index + 1}
+            </span>
+            <span className="flex-1">{step.label}</span>
+            <Check size={14} aria-hidden style={{ color: 'var(--color-outline)', opacity: 0.4 }} />
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,0 +1,67 @@
+import { Database, Sparkles, X } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+const DISMISS_KEY = 'ace-setup-wizard-dismissed'
+
+type SetupWizardProps = {
+  onDismissed: () => void
+}
+
+export function SetupWizard({ onDismissed }: SetupWizardProps) {
+  function dismiss() {
+    localStorage.setItem(DISMISS_KEY, 'true')
+    onDismissed()
+  }
+
+  return (
+    <div
+      className="mx-auto flex max-w-lg flex-col items-center px-6 py-16 text-center"
+      data-testid="setup-wizard"
+    >
+      <button
+        type="button"
+        className="mb-6 self-end cursor-pointer rounded-md border-none bg-transparent p-1"
+        style={{ color: 'var(--color-on-surface-variant)' }}
+        onClick={dismiss}
+        aria-label="Dismiss setup wizard"
+      >
+        <X size={18} aria-hidden />
+      </button>
+
+      <Sparkles aria-hidden style={{ color: 'var(--color-primary)', width: 48, height: 48 }} />
+      <h1
+        className="mt-6 font-display text-2xl font-bold"
+        style={{ color: 'var(--color-on-surface)' }}
+      >
+        Welcome to Ace
+      </h1>
+      <p className="mt-3 max-w-md text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+        Connect your first data source to start exploring metrics, logs, and traces.
+      </p>
+
+      <Link
+        to="/app/settings/datasources"
+        className="mt-8 inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium text-white no-underline transition-opacity hover:opacity-90"
+        style={{
+          background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+        }}
+      >
+        <Database size={16} aria-hidden />
+        Add Data Source
+      </Link>
+
+      <button
+        type="button"
+        className="mt-4 cursor-pointer border-none bg-transparent text-sm underline"
+        style={{ color: 'var(--color-on-surface-variant)' }}
+        onClick={dismiss}
+      >
+        Skip for now
+      </button>
+    </div>
+  )
+}
+
+export function isSetupWizardDismissed(): boolean {
+  return localStorage.getItem(DISMISS_KEY) === 'true'
+}

--- a/frontend/src/components/StatusDot.tsx
+++ b/frontend/src/components/StatusDot.tsx
@@ -1,0 +1,38 @@
+type StatusDotProps = {
+  status: 'healthy' | 'warning' | 'critical' | 'info'
+  pulse?: boolean
+  size?: number
+}
+
+const colorMap: Record<StatusDotProps['status'], string> = {
+  healthy: 'var(--color-secondary)',
+  warning: 'var(--color-tertiary)',
+  critical: 'var(--color-error)',
+  info: 'var(--color-primary)',
+}
+
+const labelMap: Record<StatusDotProps['status'], string> = {
+  healthy: 'Healthy',
+  warning: 'Warning',
+  critical: 'Critical',
+  info: 'Info',
+}
+
+export function StatusDot({ status, size = 4 }: StatusDotProps) {
+  return (
+    <span
+      role="status"
+      aria-label={labelMap[status]}
+      data-testid="status-dot"
+      data-status={status}
+      style={{
+        width: `${size}px`,
+        height: `${size}px`,
+        backgroundColor: colorMap[status],
+        borderRadius: '9999px',
+        display: 'inline-block',
+        flexShrink: 0,
+      }}
+    />
+  )
+}

--- a/frontend/src/pages/HomePage.spec.tsx
+++ b/frontend/src/pages/HomePage.spec.tsx
@@ -1,0 +1,175 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as datasourcesApi from '@/api/datasources'
+import { HomePage } from '@/pages/HomePage'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+import type { DataSource } from '@/types/datasource'
+
+vi.mock('@/analytics', () => ({
+  identifyUser: vi.fn(),
+  resetUserAnalytics: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+const mockDatasource: DataSource = {
+  id: 'ds-1',
+  organization_id: 'org-1',
+  name: 'Prometheus Prod',
+  type: 'prometheus',
+  url: 'http://prometheus:9090',
+  is_default: true,
+  auth_type: 'none',
+  trace_id_field: 'trace_id',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+function renderHome(initialPath = '/app') {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [
+      { path: '/app', element: <HomePage /> },
+      { path: '/app/dashboards', element: <div>Dashboards</div> },
+      { path: '/app/dashboards/:id', element: <div>Dashboard</div> },
+      { path: '/app/explore/metrics', element: <div>Explore</div> },
+      { path: '/app/alerts', element: <div>Alerts</div> },
+      { path: '/app/settings', element: <div>Settings</div> },
+      { path: '/app/settings/datasources', element: <div>Datasources</div> },
+      { path: '/app/datasources/new', element: <div>New datasource</div> },
+    ],
+    { initialEntries: [initialPath] },
+  )
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  return router
+}
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    useOrgStore.setState({ currentOrgId: 'org-1' })
+    useFavoritesStore.setState({ favorites: [], recentDashboards: [] })
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([mockDatasource])
+  })
+
+  it('renders datasource summary cards with mocked datasource data', async () => {
+    renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('datasource-summary-grid')).toBeTruthy()
+    })
+
+    expect(screen.getByText('Configured Data Sources')).toBeTruthy()
+    expect(screen.getByText('Prometheus Prod')).toBeTruthy()
+    expect(screen.getByTestId('datasource-summary-note').textContent).toContain(
+      'not inferring live service health',
+    )
+
+    const cards = screen.getAllByTestId('datasource-summary-card')
+    expect(cards.length).toBeGreaterThanOrEqual(1)
+    expect(cards[0]?.textContent).toContain('Metrics')
+    expect(cards[0]?.textContent).toContain('Default source')
+  })
+
+  it('renders quick links to dashboards, explore, alerts, and settings', async () => {
+    renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quick-links')).toBeTruthy()
+    })
+
+    const links = screen.getByTestId('quick-links').querySelectorAll('a')
+    expect(links).toHaveLength(4)
+    expect(links[0]?.getAttribute('href')).toBe('/app/dashboards')
+    expect(links[1]?.getAttribute('href')).toBe('/app/explore/metrics')
+    expect(links[2]?.getAttribute('href')).toBe('/app/alerts')
+    expect(links[3]?.getAttribute('href')).toBe('/app/settings')
+  })
+
+  it('navigates via quick links', async () => {
+    const user = userEvent.setup()
+    const router = renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quick-links')).toBeTruthy()
+    })
+
+    await user.click(screen.getByRole('link', { name: 'Dashboards' }))
+    expect(router.state.location.pathname).toBe('/app/dashboards')
+  })
+
+  it('renders AI command input and sample insights', async () => {
+    renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-command-input')).toBeTruthy()
+    })
+
+    expect(screen.getByText('Ask Ace anything')).toBeTruthy()
+    expect(screen.getByText('Sample AI Insights')).toBeTruthy()
+    expect(screen.getByTestId('sample-ai-insights-note').textContent).toContain(
+      'Illustrative examples only',
+    )
+    expect(screen.getAllByTestId('ai-insight-card').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows onboarding banner when not dismissed', async () => {
+    renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('onboarding-banner')).toBeTruthy()
+    })
+  })
+
+  it('hides onboarding banner when dismissed', async () => {
+    localStorage.setItem('ace-onboarding-dismissed', 'true')
+    renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('datasource-summary-grid')).toBeTruthy()
+    })
+
+    expect(screen.queryByTestId('onboarding-banner')).toBeNull()
+  })
+
+  it('shows pinned dashboards when favorites exist', async () => {
+    useFavoritesStore.setState({
+      favorites: [{ id: 'dash-1', title: 'Dashboard 1', type: 'dashboard' }],
+      recentDashboards: [],
+    })
+
+    renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pinned-dashboards')).toBeTruthy()
+    })
+
+    expect(screen.getByText('Pinned Dashboards')).toBeTruthy()
+    expect(screen.getByText('Dashboard 1')).toBeTruthy()
+  })
+
+  it('shows empty state when no datasources and wizard dismissed', async () => {
+    localStorage.setItem('ace-setup-wizard-dismissed', 'true')
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([])
+
+    renderHome()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('empty-state-title').textContent).toBe('Welcome to Ace')
+    expect(screen.getByTestId('empty-state-action').textContent).toBe('Add Data Source')
+  })
+})

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,354 @@
+import { Sparkles } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AiInsightCard } from '@/components/AiInsightCard'
+import { EmptyState } from '@/components/EmptyState'
+import { OnboardingBanner } from '@/components/OnboardingBanner'
+import { isSetupWizardDismissed, SetupWizard } from '@/components/SetupWizard'
+import { StatusDot } from '@/components/StatusDot'
+import { useDatasources } from '@/hooks/useDatasources'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import {
+  dataSourceTypeLabels,
+  isAlertingType,
+  isLogsType,
+  isMetricsType,
+  isTracingType,
+  type DataSource,
+} from '@/types/datasource'
+
+const sampleAiInsights = [
+  {
+    title: 'Sample: anomaly triage',
+    description:
+      'Example only: Ace can summarize CPU spikes once telemetry queries and an AI provider are connected.',
+    timestamp: 'Example only',
+    type: 'anomaly' as const,
+  },
+  {
+    title: 'Sample: optimization suggestion',
+    description:
+      'Example only: recommendations are generated from real query results; no live insight is shown here.',
+    timestamp: 'Example only',
+    type: 'optimization' as const,
+  },
+  {
+    title: 'Sample: capacity forecast',
+    description:
+      'Example only: forecasts require historical metrics from your configured datasources.',
+    timestamp: 'Example only',
+    type: 'forecast' as const,
+  },
+]
+
+const quickLinks = [
+  { label: 'Dashboards', route: '/app/dashboards' },
+  { label: 'Explore', route: '/app/explore/metrics' },
+  { label: 'Alerts', route: '/app/alerts' },
+  { label: 'Settings', route: '/app/settings' },
+] as const
+
+function signalLabelForDataSource(source: DataSource): string {
+  const signals: string[] = []
+  if (isMetricsType(source.type)) signals.push('Metrics')
+  if (isLogsType(source.type)) signals.push('Logs')
+  if (isTracingType(source.type)) signals.push('Traces')
+  if (isAlertingType(source.type)) signals.push('Alerts')
+  return signals.length > 0 ? signals.join(' + ') : 'Configuration only'
+}
+
+export function HomePage() {
+  const currentOrgId = useOrgStore(state => state.currentOrgId)
+  const { data: datasources = [] } = useDatasources(currentOrgId)
+  const favorites = useFavoritesStore(state => state.favorites)
+  const recentDashboards = useFavoritesStore(state => state.recentDashboards)
+
+  const [wizardDismissedByUser, setWizardDismissedByUser] = useState(false)
+
+  const hasDataSources = datasources.length > 0
+  const showWizard =
+    !hasDataSources && !wizardDismissedByUser && !isSetupWizardDismissed()
+  const onboardingDismissed = localStorage.getItem('ace-onboarding-dismissed') === 'true'
+
+  const dataSourceSummaries = useMemo(
+    () =>
+      datasources.map(source => ({
+        id: source.id,
+        name: source.name || dataSourceTypeLabels[source.type],
+        typeLabel: dataSourceTypeLabels[source.type],
+        signalLabel: signalLabelForDataSource(source),
+        roleLabel: source.is_default ? 'Default source' : 'Configured',
+      })),
+    [datasources],
+  )
+
+  if (showWizard) {
+    return <SetupWizard onDismissed={() => setWizardDismissedByUser(true)} />
+  }
+
+  if (!hasDataSources) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <EmptyState
+          icon={Sparkles}
+          title="Welcome to Ace"
+          description="Connect your first data source to get started"
+          actionLabel="Add Data Source"
+          actionRoute="/app/settings/datasources"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative mx-auto max-w-[1600px] space-y-8 overflow-hidden px-6 py-8">
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          top: '-60px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: '600px',
+          height: '300px',
+          background:
+            'radial-gradient(ellipse 60% 50%, rgba(201,150,15,0.10), rgba(201,150,15,0.03) 50%, transparent 80%)',
+          zIndex: 0,
+        }}
+        aria-hidden
+      />
+
+      <div
+        data-testid="ai-command-input"
+        className="relative overflow-hidden rounded-2xl p-8 text-center"
+        style={{
+          background:
+            'linear-gradient(180deg, var(--color-surface-container-low) 0%, var(--color-surface) 100%)',
+          border: '1px solid rgba(229,160,13,0.12)',
+          zIndex: 1,
+        }}
+      >
+        <div
+          className="absolute top-0 left-1/2 h-[2px] w-[200px] -translate-x-1/2"
+          style={{
+            background: 'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
+          }}
+          aria-hidden
+        />
+
+        <h1
+          className="mb-4 font-display font-bold"
+          style={{
+            color: 'var(--color-on-surface)',
+            fontSize: '32px',
+            letterSpacing: '-0.04em',
+          }}
+        >
+          Ask Ace anything
+        </h1>
+        <div
+          className="mx-auto flex max-w-[480px] cursor-pointer items-center justify-between rounded-xl px-4 py-3 text-left text-sm transition-colors"
+          style={{
+            backgroundColor: 'var(--color-surface-container-high)',
+            color: 'var(--color-on-surface-variant)',
+            border: '1px solid var(--color-outline-variant)',
+          }}
+        >
+          <span className="opacity-60">Search services, query data, generate dashboards...</span>
+          <kbd
+            className="ml-3 shrink-0 rounded px-1.5 py-0.5 text-[9px]"
+            style={{
+              border: '1px solid var(--color-outline-variant)',
+              color: 'var(--color-outline)',
+            }}
+          >
+            ⌘K
+          </kbd>
+        </div>
+      </div>
+
+      <nav
+        data-testid="quick-links"
+        aria-label="Quick navigation"
+        className="flex flex-wrap gap-3"
+      >
+        {quickLinks.map(link => (
+          <Link
+            key={link.route}
+            to={link.route}
+            className="rounded-lg px-4 py-2 text-sm font-medium no-underline transition-colors hover:opacity-90"
+            style={{
+              backgroundColor: 'var(--color-surface-container)',
+              color: 'var(--color-on-surface)',
+              border: '1px solid var(--color-outline-variant)',
+            }}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+
+      {!onboardingDismissed ? <OnboardingBanner /> : null}
+
+      {favorites.length > 0 ? (
+        <section data-testid="pinned-dashboards">
+          <h2
+            className="mb-4 font-display text-lg font-semibold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            Pinned Dashboards
+          </h2>
+          <div className="flex gap-3 overflow-x-auto pb-2">
+            {favorites.map(fav => (
+              <Link
+                key={fav.id}
+                to={`/app/dashboards/${fav.id}`}
+                className="shrink-0 min-w-[160px] rounded-lg px-4 py-3 text-sm font-medium no-underline transition-colors hover:opacity-90"
+                style={{
+                  backgroundColor: 'var(--color-surface-container)',
+                  color: 'var(--color-on-surface)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+              >
+                {fav.title}
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {recentDashboards.length > 0 ? (
+        <section data-testid="recently-viewed">
+          <h2
+            className="mb-4 font-display text-lg font-semibold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            Recently Viewed
+          </h2>
+          <div className="flex gap-3 overflow-x-auto pb-2">
+            {recentDashboards.map(dashboard => (
+              <Link
+                key={dashboard.id}
+                to={`/app/dashboards/${dashboard.id}`}
+                className="shrink-0 min-w-[160px] rounded-lg px-4 py-3 text-sm font-medium no-underline transition-colors hover:opacity-90"
+                style={{
+                  backgroundColor: 'var(--color-surface-container)',
+                  color: 'var(--color-on-surface)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+              >
+                {dashboard.title}
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <section
+          data-testid="datasource-summary-grid"
+          className="rounded-xl p-5"
+          style={{
+            backgroundColor: 'var(--color-surface-container-low)',
+            border: '1px solid var(--color-outline-variant)',
+          }}
+        >
+          <div className="mb-2 flex items-center justify-between">
+            <span
+              className="text-[11px] font-semibold tracking-widest uppercase"
+              style={{ color: 'var(--color-secondary)' }}
+            >
+              Configured Data Sources
+            </span>
+            <span className="text-[11px]" style={{ color: 'var(--color-on-surface-variant)' }}>
+              {dataSourceSummaries.length} connected
+            </span>
+          </div>
+          <p
+            data-testid="datasource-summary-note"
+            className="mt-0 mb-4 text-xs"
+            style={{ color: 'var(--color-on-surface-variant)' }}
+          >
+            Inventory from your configured datasources. Ace is not inferring live service health here.
+          </p>
+          <div className="flex flex-col gap-1.5">
+            {dataSourceSummaries.map(source => (
+              <div
+                key={source.id}
+                data-testid="datasource-summary-card"
+                className="flex items-center gap-3 rounded-lg px-3 py-2"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  border: '1px solid transparent',
+                }}
+              >
+                <StatusDot status="info" size={6} />
+                <span className="flex-1 text-sm" style={{ color: 'var(--color-on-surface)' }}>
+                  {source.name}
+                </span>
+                <span
+                  className="font-mono text-[13px]"
+                  style={{ color: 'var(--color-on-surface-variant)' }}
+                >
+                  {source.typeLabel}
+                </span>
+                <span
+                  className="font-mono text-[13px]"
+                  style={{ color: 'var(--color-secondary)' }}
+                >
+                  {source.signalLabel} · {source.roleLabel}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section
+          data-testid="sample-ai-insights"
+          className="rounded-xl p-5"
+          style={{
+            backgroundColor: 'var(--color-surface-container-low)',
+            border: '1px solid rgba(229,160,13,0.08)',
+          }}
+        >
+          <div className="mb-2 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span
+                className="inline-block shrink-0"
+                style={{
+                  width: '10px',
+                  height: '10px',
+                  borderRadius: '3px',
+                  background:
+                    'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+                }}
+                aria-hidden
+              />
+              <span
+                className="text-[11px] font-semibold tracking-widest uppercase"
+                style={{ color: 'var(--color-primary)' }}
+              >
+                Sample AI Insights
+              </span>
+            </div>
+            <span className="text-[11px]" style={{ color: 'var(--color-outline)' }}>
+              Examples only
+            </span>
+          </div>
+          <p
+            data-testid="sample-ai-insights-note"
+            className="mt-0 mb-4 text-xs"
+            style={{ color: 'var(--color-on-surface-variant)' }}
+          >
+            Illustrative examples only — these cards are not generated from your current telemetry.
+          </p>
+          <div className="flex flex-col gap-2">
+            {sampleAiInsights.map(insight => (
+              <AiInsightCard key={insight.title} {...insight} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -7,6 +7,7 @@ import { createParamRedirect } from '@/lib/redirects'
 const PlaceholderPage = lazy(() =>
   import('@/pages/PlaceholderPage').then(m => ({ default: m.PlaceholderPage })),
 )
+const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })))
 const LoginPage = lazy(() => import('@/pages/LoginPage').then(m => ({ default: m.LoginPage })))
 const AuthCallbackPage = lazy(() =>
   import('@/pages/AuthCallbackPage').then(m => ({ default: m.AuthCallbackPage })),
@@ -53,7 +54,7 @@ const appRoutes: RouteObject[] = [
       'Ace — Command Center',
       'Your observability command center — dashboards, services, alerts, and insights at a glance.',
     ),
-    element: placeholder('Command Center'),
+    element: <HomePage />,
   },
   {
     path: '/app/dashboards',


### PR DESCRIPTION
Ports the Vue home landing page to React at `/app`.

**Delivered:**
- `HomePage` — AI command input hero, datasource inventory cards, sample AI insights, pinned/recent dashboards, onboarding banner, first-visit setup wizard
- Quick navigation links to dashboards, explore, alerts, and settings
- Supporting components: `StatusDot`, `EmptyState`, `AiInsightCard`, `OnboardingBanner`, `SetupWizard`
- Route SEO unchanged (`Ace — Command Center` via existing `AppLayout` + `useRouteSeo`)
- RTL tests: `pages/HomePage.spec.tsx`

**Parent:** [#292 Vue → React frontend rewrite](https://github.com/aceobservability/ace/issues/292) / closes [#297 Home command center](https://github.com/aceobservability/ace/issues/297)

**Stack:** based on `issue-296-app-shell-and-navigation`.