### PR TITLE
feat(frontend): logs explore (#299)

### DIFF
--- a/frontend/src/components/LogQLQueryBuilder.tsx
+++ b/frontend/src/components/LogQLQueryBuilder.tsx
@@ -1,0 +1,536 @@
+import { Code, Layers, Plus, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { fetchDataSourceLabelValues } from '@/api/datasources'
+import { MonacoQueryEditor } from '@/components/MonacoQueryEditor'
+
+const LOGQL_LABEL_OPERATORS = [
+  { value: '=', label: '=' },
+  { value: '!=', label: '!=' },
+  { value: '=~', label: '=~' },
+  { value: '!~', label: '!~' },
+] as const
+
+const LOGQL_LINE_FILTER_OPERATORS = [
+  { value: '|=', label: '|=' },
+  { value: '!=', label: '!=' },
+  { value: '|~', label: '|~' },
+  { value: '!~', label: '!~' },
+] as const
+
+const LOGSQL_FIELD_OPERATORS = [
+  { value: 'eq', label: ':=' },
+  { value: 'neq', label: 'NOT :=' },
+  { value: 'regex', label: ':~' },
+  { value: 'nregex', label: 'NOT :~' },
+] as const
+
+const LOGSQL_TEXT_OPERATORS = [
+  { value: 'contains', label: 'Contains' },
+  { value: 'not_contains', label: 'Not contains' },
+  { value: 'regex', label: 'Regex' },
+  { value: 'not_regex', label: 'Not regex' },
+] as const
+
+type QueryLanguage = 'logql' | 'logsql'
+
+type LabelFilter = {
+  id: string
+  label: string
+  operator: string
+  value: string
+}
+
+type LogQLQueryBuilderProps = {
+  value: string
+  onChange: (value: string) => void
+  onSubmit?: () => void
+  indexedLabels: string[]
+  datasourceId: string
+  queryLanguage?: QueryLanguage
+  disabled?: boolean
+  editorHeight?: number
+  placeholder?: string
+}
+
+let filterIdCounter = 0
+
+function generateFilterId() {
+  filterIdCounter += 1
+  return `logql-filter-${filterIdCounter}`
+}
+
+function quoteLogsQLField(value: string) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+function escapeLogQLValue(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function normalizeFieldOperator(
+  value: string,
+  operators: readonly { value: string; label: string }[],
+) {
+  if (operators.some(operator => operator.value === value)) {
+    return value
+  }
+  return operators[0].value
+}
+
+function normalizeTextOperator(
+  value: string,
+  operators: readonly { value: string; label: string }[],
+) {
+  if (operators.some(operator => operator.value === value)) {
+    return value
+  }
+  return operators[0].value
+}
+
+function buildLogsQLFieldFilter(filter: LabelFilter) {
+  const fieldName = quoteLogsQLField(filter.label)
+  const escapedValue = escapeLogQLValue(filter.value.trim())
+  const operator = filter.operator
+
+  if (operator === 'neq') {
+    return `NOT ${fieldName}:="${escapedValue}"`
+  }
+  if (operator === 'regex') {
+    return `${fieldName}:~"${escapedValue}"`
+  }
+  if (operator === 'nregex') {
+    return `NOT ${fieldName}:~"${escapedValue}"`
+  }
+  return `${fieldName}:="${escapedValue}"`
+}
+
+function buildLogsQLTextFilter(lineFilterOperator: string, lineFilterValue: string) {
+  const value = lineFilterValue.trim()
+  if (!value) {
+    return ''
+  }
+
+  const escapedValue = escapeLogQLValue(value)
+  const operator = lineFilterOperator
+
+  if (operator === 'not_contains') {
+    return `NOT "${escapedValue}"`
+  }
+  if (operator === 'regex') {
+    return `_msg:~"${escapedValue}"`
+  }
+  if (operator === 'not_regex') {
+    return `NOT _msg:~"${escapedValue}"`
+  }
+  return `"${escapedValue}"`
+}
+
+function buildLogQLQuery(
+  labelFilters: LabelFilter[],
+  lineFilterOperator: string,
+  lineFilterValue: string,
+  fieldOperators: readonly { value: string; label: string }[],
+  textOperators: readonly { value: string; label: string }[],
+) {
+  const selectorFilters = labelFilters
+    .filter(filter => filter.label && filter.value.trim())
+    .map(
+      filter =>
+        `${filter.label}${normalizeFieldOperator(filter.operator, fieldOperators)}"${escapeLogQLValue(filter.value.trim())}"`,
+    )
+
+  const hasLineFilter = lineFilterValue.trim().length > 0
+  if (selectorFilters.length === 0 && !hasLineFilter) {
+    return ''
+  }
+
+  const selector = selectorFilters.length > 0 ? `{${selectorFilters.join(',')}}` : '{}'
+  if (!hasLineFilter) {
+    return selector
+  }
+
+  return `${selector} ${normalizeTextOperator(lineFilterOperator, textOperators)} "${escapeLogQLValue(lineFilterValue.trim())}"`
+}
+
+function buildLogsSQLQuery(
+  labelFilters: LabelFilter[],
+  lineFilterOperator: string,
+  lineFilterValue: string,
+) {
+  const filters = labelFilters
+    .filter(filter => filter.label && filter.value.trim())
+    .map(buildLogsQLFieldFilter)
+
+  const textFilter = buildLogsQLTextFilter(lineFilterOperator, lineFilterValue)
+  if (filters.length === 0 && !textFilter) {
+    return '*'
+  }
+
+  const queryParts = ['*', ...filters]
+  if (textFilter) {
+    queryParts.push(textFilter)
+  }
+
+  return queryParts.join(' ')
+}
+
+export function LogQLQueryBuilder({
+  value,
+  onChange,
+  onSubmit,
+  indexedLabels,
+  datasourceId,
+  queryLanguage = 'logql',
+  disabled = false,
+  editorHeight = 130,
+  placeholder = '{job=~".+"} |= "error"',
+}: LogQLQueryBuilderProps) {
+  const isLogsQL = queryLanguage === 'logsql'
+  const fieldOperators = isLogsQL ? LOGSQL_FIELD_OPERATORS : LOGQL_LABEL_OPERATORS
+  const textOperators = isLogsQL ? LOGSQL_TEXT_OPERATORS : LOGQL_LINE_FILTER_OPERATORS
+
+  const [mode, setMode] = useState<'builder' | 'code'>('builder')
+  const [codeQuery, setCodeQuery] = useState(value)
+  const [labelFilters, setLabelFilters] = useState<LabelFilter[]>([])
+  const [lineFilterOperator, setLineFilterOperator] = useState<string>(textOperators[0].value)
+  const [lineFilterValue, setLineFilterValue] = useState('')
+  const [labelValuesCache, setLabelValuesCache] = useState<Map<string, string[]>>(new Map())
+  const [loadingLabelValues, setLoadingLabelValues] = useState<string | null>(null)
+  const isEmittingRef = useRef(false)
+
+  const generatedQuery = useMemo(() => {
+    if (isLogsQL) {
+      return buildLogsSQLQuery(labelFilters, lineFilterOperator, lineFilterValue)
+    }
+    return buildLogQLQuery(
+      labelFilters,
+      lineFilterOperator,
+      lineFilterValue,
+      fieldOperators,
+      textOperators,
+    )
+  }, [fieldOperators, isLogsQL, labelFilters, lineFilterOperator, lineFilterValue, textOperators])
+
+  const builderAvailable = useMemo(() => {
+    if (!codeQuery) return true
+    if (mode === 'builder' && generatedQuery) return true
+    if (codeQuery === generatedQuery) return true
+    return false
+  }, [codeQuery, generatedQuery, mode])
+
+  const activeQuery = mode === 'builder' ? generatedQuery : codeQuery
+
+  const generatedQueryLabel = isLogsQL ? 'Generated LogsQL' : 'Generated LogQL'
+  const codeEditorLabel = isLogsQL ? 'LogsQL Query' : 'LogQL Query'
+  const lineFilterLabel = isLogsQL ? 'Message Filter (Optional)' : 'Line Filter (Optional)'
+  const lineFilterPlaceholder = isLogsQL
+    ? 'Phrase or regex for _msg field'
+    : 'Contains text, regex, or exact match'
+
+  const loadLabelValues = useCallback(async (labelName: string) => {
+    if (!datasourceId || !labelName) return []
+
+    let cached: string[] | undefined
+    setLabelValuesCache(prev => {
+      cached = prev.get(labelName)
+      return prev
+    })
+    if (cached) {
+      return cached
+    }
+
+    setLoadingLabelValues(labelName)
+    try {
+      const values = await fetchDataSourceLabelValues(datasourceId, labelName)
+      setLabelValuesCache(prev => {
+        const next = new Map(prev)
+        next.set(labelName, values)
+        return next
+      })
+      return values
+    } catch (error) {
+      console.error(`Failed to load label values for ${labelName}:`, error)
+      setLabelValuesCache(prev => {
+        const next = new Map(prev)
+        next.set(labelName, [])
+        return next
+      })
+      return []
+    } finally {
+      setLoadingLabelValues(current => (current === labelName ? null : current))
+    }
+  }, [datasourceId])
+
+  function addLabelFilter() {
+    setLabelFilters(prev => [
+      ...prev,
+      {
+        id: generateFilterId(),
+        label: '',
+        operator: fieldOperators[0].value,
+        value: '',
+      },
+    ])
+  }
+
+  function removeLabelFilter(id: string) {
+    setLabelFilters(prev => prev.filter(filter => filter.id !== id))
+  }
+
+  function updateLabelFilter(id: string, updates: Partial<LabelFilter>) {
+    setLabelFilters(prev =>
+      prev.map(filter => (filter.id === id ? { ...filter, ...updates } : filter)),
+    )
+  }
+
+  async function handleLabelChange(filter: LabelFilter, newLabel: string) {
+    updateLabelFilter(filter.id, { label: newLabel, value: '' })
+    if (!newLabel) return
+    await loadLabelValues(newLabel)
+  }
+
+  function getLabelValues(labelName: string) {
+    return labelValuesCache.get(labelName) || []
+  }
+
+  useEffect(() => {
+    setLabelValuesCache(new Map())
+    setLoadingLabelValues(null)
+  }, [datasourceId])
+
+  useEffect(() => {
+    setLineFilterOperator(textOperators[0].value)
+    setLabelFilters(prev =>
+      prev.map(filter => ({
+        ...filter,
+        operator: normalizeFieldOperator(filter.operator, fieldOperators),
+      })),
+    )
+  }, [fieldOperators, textOperators])
+
+  useEffect(() => {
+    if (isEmittingRef.current) return
+    if (value === activeQuery) return
+
+    setCodeQuery(value)
+    if (value !== generatedQuery) {
+      setMode('code')
+    }
+  }, [value, activeQuery, generatedQuery])
+
+  useEffect(() => {
+    isEmittingRef.current = true
+    onChange(activeQuery)
+    queueMicrotask(() => {
+      isEmittingRef.current = false
+    })
+  }, [activeQuery, onChange])
+
+  return (
+    <div
+      className={`flex flex-col gap-4 ${disabled ? 'pointer-events-none opacity-60' : ''}`}
+      data-testid="logql-query-builder"
+    >
+      <div className="flex w-fit rounded-sm bg-[var(--color-surface-container-high)] p-1">
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 rounded-sm border-none bg-transparent px-3 py-1.5 text-xs font-medium text-[var(--color-on-surface-variant)] transition-all duration-200 hover:enabled:text-[var(--color-on-surface)] disabled:cursor-not-allowed disabled:opacity-40 ${
+            mode === 'builder'
+              ? 'bg-[var(--color-surface-container-low)] text-[var(--color-on-surface)] shadow-sm'
+              : ''
+          }`}
+          data-testid="logql-builder-mode-btn"
+          disabled={disabled || !builderAvailable}
+          title={!builderAvailable ? 'Query cannot be edited in builder mode' : ''}
+          onClick={() => setMode('builder')}
+        >
+          <Layers size={14} />
+          <span>Builder</span>
+        </button>
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 rounded-sm border-none bg-transparent px-3 py-1.5 text-xs font-medium text-[var(--color-on-surface-variant)] transition-all duration-200 hover:enabled:text-[var(--color-on-surface)] disabled:cursor-not-allowed disabled:opacity-40 ${
+            mode === 'code'
+              ? 'bg-[var(--color-surface-container-low)] text-[var(--color-on-surface)] shadow-sm'
+              : ''
+          }`}
+          data-testid="logql-code-mode-btn"
+          disabled={disabled}
+          onClick={() => setMode('code')}
+        >
+          <Code size={14} />
+          <span>Code</span>
+        </button>
+      </div>
+
+      {mode === 'builder' ? (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-[var(--color-on-surface)]">
+                Stream Filters
+              </label>
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-sm px-3 py-1.5 text-xs font-medium text-[var(--color-on-surface-variant)] transition-all duration-200 hover:enabled:bg-[var(--color-surface-container-high)] hover:enabled:text-[var(--color-on-surface)]"
+                data-testid="logql-add-filter-btn"
+                disabled={disabled}
+                onClick={addLabelFilter}
+              >
+                <Plus size={14} />
+                <span>Add Filter</span>
+              </button>
+            </div>
+
+            {labelFilters.length === 0 ? (
+              <div className="rounded-sm bg-[var(--color-surface-container-high)] p-4 text-center text-sm text-[var(--color-outline)]">
+                No filters yet. Add a field filter to build your selector.
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {labelFilters.map(filter => (
+                  <div key={filter.id} className="flex items-center gap-2">
+                    <select
+                      className="min-w-0 flex-1 cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                      value={filter.label}
+                      disabled={disabled}
+                      onChange={event => void handleLabelChange(filter, event.target.value)}
+                    >
+                      <option value="">Indexed field</option>
+                      {indexedLabels.map(label => (
+                        <option key={label} value={label}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+
+                    <select
+                      className="w-[120px] flex-none cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 font-mono text-sm text-[var(--color-on-surface-variant)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                      value={filter.operator}
+                      disabled={disabled}
+                      onChange={event =>
+                        updateLabelFilter(filter.id, { operator: event.target.value })
+                      }
+                    >
+                      {fieldOperators.map(operator => (
+                        <option key={operator.value} value={operator.value}>
+                          {operator.label}
+                        </option>
+                      ))}
+                    </select>
+
+                    {getLabelValues(filter.label).length > 0 ? (
+                      <select
+                        className="min-w-0 flex-1 cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                        value={filter.value}
+                        disabled={disabled || loadingLabelValues === filter.label}
+                        onChange={event =>
+                          updateLabelFilter(filter.id, { value: event.target.value })
+                        }
+                      >
+                        <option value="">Field value</option>
+                        {getLabelValues(filter.label).map(labelValue => (
+                          <option key={labelValue} value={labelValue}>
+                            {labelValue}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        className="min-w-0 flex-1 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                        type="text"
+                        placeholder="Field value"
+                        value={filter.value}
+                        disabled={disabled}
+                        onChange={event =>
+                          updateLabelFilter(filter.id, { value: event.target.value })
+                        }
+                      />
+                    )}
+
+                    <button
+                      type="button"
+                      className="flex h-7 w-7 items-center justify-center rounded border-none bg-transparent text-[var(--color-outline)] transition-all duration-200 hover:enabled:bg-[var(--color-error)]/10 hover:enabled:text-[var(--color-error)]"
+                      disabled={disabled}
+                      onClick={() => removeLabelFilter(filter.id)}
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                ))}
+
+                {loadingLabelValues ? (
+                  <span className="text-xs text-[var(--color-outline)]">
+                    Loading indexed values...
+                  </span>
+                ) : null}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-on-surface)]">
+              {lineFilterLabel}
+            </label>
+            <div className="flex items-center gap-2">
+              <select
+                data-testid="logql-line-filter-operator-select"
+                className="w-[120px] flex-none cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 font-mono text-sm text-[var(--color-on-surface-variant)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                value={lineFilterOperator}
+                disabled={disabled}
+                onChange={event => setLineFilterOperator(event.target.value)}
+              >
+                {textOperators.map(operator => (
+                  <option key={operator.value} value={operator.value}>
+                    {operator.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                data-testid="logql-line-filter-value-input"
+                className="min-w-0 flex-1 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                type="text"
+                placeholder={lineFilterPlaceholder}
+                value={lineFilterValue}
+                disabled={disabled}
+                onChange={event => setLineFilterValue(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="mt-2 flex flex-col gap-2 pt-4">
+            <label className="text-sm font-medium text-[var(--color-on-surface)]">
+              {generatedQueryLabel}
+            </label>
+            <div className="min-h-[48px] rounded-sm bg-[var(--color-surface-container-high)] px-4 py-3">
+              {generatedQuery ? (
+                <code className="break-all font-mono text-sm text-[var(--color-primary)]">
+                  {generatedQuery}
+                </code>
+              ) : (
+                <span className="text-sm text-[var(--color-outline)]">
+                  Add a field/value filter to generate a query
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <label className="text-sm font-medium text-[var(--color-on-surface)]">
+            {codeEditorLabel}
+          </label>
+          <MonacoQueryEditor
+            value={codeQuery}
+            onChange={setCodeQuery}
+            onSubmit={onSubmit}
+            disabled={disabled}
+            height={editorHeight}
+            placeholder={placeholder}
+            language={queryLanguage}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/LogQLQueryBuilder.tsx
+++ b/frontend/src/components/LogQLQueryBuilder.tsx
@@ -293,6 +293,7 @@ export function LogQLQueryBuilder({
     return labelValuesCache.get(labelName) || []
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset label cache when datasource changes
   useEffect(() => {
     setLabelValuesCache(new Map())
     setLoadingLabelValues(null)
@@ -367,9 +368,9 @@ export function LogQLQueryBuilder({
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
-              <label className="text-sm font-medium text-[var(--color-on-surface)]">
+              <span className="text-sm font-medium text-[var(--color-on-surface)]">
                 Stream Filters
-              </label>
+              </span>
               <button
                 type="button"
                 className="flex items-center gap-1.5 rounded-sm px-3 py-1.5 text-xs font-medium text-[var(--color-on-surface-variant)] transition-all duration-200 hover:enabled:bg-[var(--color-surface-container-high)] hover:enabled:text-[var(--color-on-surface)]"
@@ -469,7 +470,10 @@ export function LogQLQueryBuilder({
           </div>
 
           <div className="flex flex-col gap-2">
-            <label className="text-sm font-medium text-[var(--color-on-surface)]">
+            <label
+              htmlFor="logql-line-filter-value-input"
+              className="text-sm font-medium text-[var(--color-on-surface)]"
+            >
               {lineFilterLabel}
             </label>
             <div className="flex items-center gap-2">
@@ -487,6 +491,7 @@ export function LogQLQueryBuilder({
                 ))}
               </select>
               <input
+                id="logql-line-filter-value-input"
                 data-testid="logql-line-filter-value-input"
                 className="min-w-0 flex-1 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
                 type="text"
@@ -499,9 +504,9 @@ export function LogQLQueryBuilder({
           </div>
 
           <div className="mt-2 flex flex-col gap-2 pt-4">
-            <label className="text-sm font-medium text-[var(--color-on-surface)]">
+            <span className="text-sm font-medium text-[var(--color-on-surface)]">
               {generatedQueryLabel}
-            </label>
+            </span>
             <div className="min-h-[48px] rounded-sm bg-[var(--color-surface-container-high)] px-4 py-3">
               {generatedQuery ? (
                 <code className="break-all font-mono text-sm text-[var(--color-primary)]">
@@ -517,9 +522,9 @@ export function LogQLQueryBuilder({
         </div>
       ) : (
         <div className="flex flex-col gap-4">
-          <label className="text-sm font-medium text-[var(--color-on-surface)]">
+          <span className="text-sm font-medium text-[var(--color-on-surface)]">
             {codeEditorLabel}
-          </label>
+          </span>
           <MonacoQueryEditor
             value={codeQuery}
             onChange={setCodeQuery}

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -15,6 +15,18 @@ type LogViewerProps = {
   linkedTraceDatasourceId?: string | null
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function getLogKey(log: LogEntry): string {
+  const labels = Object.entries(log.labels || {})
+    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',')
+  return `${log.timestamp}|${labels}|${log.line}`
+}
+
 function extractTraceId(entry: LogEntry, traceIdField: string): string | null {
   const field = traceIdField || 'trace_id'
 
@@ -29,7 +41,7 @@ function extractTraceId(entry: LogEntry, traceIdField: string): string | null {
     // Not JSON
   }
 
-  const regex = new RegExp(`(?:${field}[=:]["']?)([a-f0-9]{16,64})`, 'i')
+  const regex = new RegExp(`(?:${escapeRegExp(field)}[=:]["']?)([a-f0-9]{16,64})`, 'i')
   const match = entry.line.match(regex)
   if (match) return match[1] ?? null
 
@@ -181,34 +193,29 @@ export function LogViewer({
   linkedTraceDatasourceId = null,
 }: LogViewerProps) {
   const navigate = useNavigate()
-  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
 
   const displayLogs = useMemo(() => logs.slice(0, 1000), [logs])
   const highlightedLogKeySet = useMemo(() => new Set(highlightedLogKeys), [highlightedLogKeys])
-  const detectedFieldsByRow = useMemo(
-    () => displayLogs.map(log => getMessageFields(log)),
-    [displayLogs],
-  )
-
-  function getLogKey(log: LogEntry): string {
-    const labels = Object.entries(log.labels || {})
-      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-      .map(([key, value]) => `${key}=${value}`)
-      .join(',')
-    return `${log.timestamp}|${labels}|${log.line}`
-  }
+  const detectedFieldsByLogKey = useMemo(() => {
+    const fieldsByLogKey = new Map<string, DetectedField[]>()
+    for (const log of displayLogs) {
+      fieldsByLogKey.set(getLogKey(log), getMessageFields(log))
+    }
+    return fieldsByLogKey
+  }, [displayLogs])
 
   function isHighlighted(log: LogEntry): boolean {
     return highlightedLogKeySet.has(getLogKey(log))
   }
 
-  function toggleRow(index: number) {
+  function toggleRow(logKey: string) {
     setExpandedRows(prev => {
       const next = new Set(prev)
-      if (next.has(index)) {
-        next.delete(index)
+      if (next.has(logKey)) {
+        next.delete(logKey)
       } else {
-        next.add(index)
+        next.add(logKey)
       }
       return next
     })
@@ -251,13 +258,14 @@ export function LogViewer({
       </div>
 
       <div className="flex-1 overflow-auto">
-        {displayLogs.map((log, index) => {
-          const expanded = expandedRows.has(index)
+        {displayLogs.map(log => {
+          const logKey = getLogKey(log)
+          const expanded = expandedRows.has(logKey)
           const traceId =
             linkedTraceDatasourceId && extractTraceId(log, traceIdField)
 
           return (
-            <div key={getLogKey(log)}>
+            <div key={logKey}>
               {/* biome-ignore lint/a11y/useSemanticElements: row contains nested trace link button */}
               <div
                 role="button"
@@ -266,11 +274,11 @@ export function LogViewer({
                   expanded ? 'bg-[var(--color-surface-container-high)]' : ''
                 } ${isHighlighted(log) ? 'animate-[row-highlight-fade_2.4s_ease-out]' : ''}`}
                 data-testid="log-viewer-row"
-                onClick={() => toggleRow(index)}
+                onClick={() => toggleRow(logKey)}
                 onKeyDown={event => {
                   if (event.key === 'Enter' || event.key === ' ') {
                     event.preventDefault()
-                    toggleRow(index)
+                    toggleRow(logKey)
                   }
                 }}
               >
@@ -348,9 +356,9 @@ export function LogViewer({
                   <div className="mb-2 text-[0.7rem] font-semibold uppercase tracking-[0.04em] text-[var(--color-outline)]">
                     Detected Fields
                   </div>
-                  {detectedFieldsByRow[index]?.length ? (
+                  {detectedFieldsByLogKey.get(logKey)?.length ? (
                     <div className="grid gap-1.5">
-                      {detectedFieldsByRow[index].map(field => (
+                      {detectedFieldsByLogKey.get(logKey)?.map(field => (
                         <div
                           key={field.key}
                           className="grid grid-cols-[minmax(120px,220px)_1fr] gap-2.5 max-sm:grid-cols-1 max-sm:gap-1"

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,0 +1,371 @@
+import { Activity } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { LogEntry } from '@/types/datasource'
+
+type DetectedField = {
+  key: string
+  value: string
+}
+
+type LogViewerProps = {
+  logs: LogEntry[]
+  highlightedLogKeys?: string[]
+  traceIdField?: string
+  linkedTraceDatasourceId?: string | null
+}
+
+function extractTraceId(entry: LogEntry, traceIdField: string): string | null {
+  const field = traceIdField || 'trace_id'
+
+  if (entry.labels?.[field]) {
+    return entry.labels[field]
+  }
+
+  try {
+    const parsed = JSON.parse(entry.line) as Record<string, unknown>
+    if (parsed[field]) return String(parsed[field])
+  } catch {
+    // Not JSON
+  }
+
+  const regex = new RegExp(`(?:${field}[=:]["']?)([a-f0-9]{16,64})`, 'i')
+  const match = entry.line.match(regex)
+  if (match) return match[1] ?? null
+
+  return null
+}
+
+function getLevelBadgeClasses(level?: string): string {
+  switch (level) {
+    case 'error':
+      return 'rounded-sm bg-[var(--color-error)]/10 px-2 py-0.5 text-[var(--color-error)] ring-1 ring-[var(--color-error)]/20 font-semibold'
+    case 'warning':
+    case 'warn':
+      return 'rounded-sm bg-[var(--color-tertiary)]/10 px-2 py-0.5 text-[var(--color-tertiary)] ring-1 ring-[var(--color-tertiary)]/20 font-semibold'
+    case 'info':
+      return 'rounded-sm bg-[var(--color-primary)]/10 px-2 py-0.5 text-[var(--color-primary)] ring-1 ring-[var(--color-primary)]/20 font-semibold'
+    case 'debug':
+      return 'rounded-sm bg-[var(--color-surface-container-high)] px-2 py-0.5 text-[var(--color-on-surface-variant)]'
+    default:
+      return 'rounded-sm bg-[var(--color-surface-container-high)] px-2 py-0.5 text-[var(--color-on-surface-variant)]'
+  }
+}
+
+function formatTimestamp(ts: string): string {
+  try {
+    const date = new Date(ts)
+    return date.toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      fractionalSecondDigits: 3,
+    })
+  } catch {
+    return ts
+  }
+}
+
+function formatFieldValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function flattenObject(value: unknown, prefix = '', depth = 0): DetectedField[] {
+  if (depth > 4) {
+    return [{ key: prefix || 'value', value: formatFieldValue(value) }]
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return [{ key: prefix || 'value', value: '[]' }]
+    }
+
+    const rows: DetectedField[] = []
+    for (let i = 0; i < value.length; i += 1) {
+      const childPrefix = prefix ? `${prefix}[${i}]` : `[${i}]`
+      rows.push(...flattenObject(value[i], childPrefix, depth + 1))
+    }
+    return rows
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) {
+      return [{ key: prefix || 'value', value: '{}' }]
+    }
+
+    const rows: DetectedField[] = []
+    for (const [key, child] of entries) {
+      const childPrefix = prefix ? `${prefix}.${key}` : key
+      rows.push(...flattenObject(child, childPrefix, depth + 1))
+    }
+    return rows
+  }
+
+  return [{ key: prefix || 'value', value: formatFieldValue(value) }]
+}
+
+function parseJsonFields(line: string): DetectedField[] {
+  const trimmed = line.trim()
+  const candidates: string[] = [trimmed]
+  const firstBrace = trimmed.indexOf('{')
+  if (firstBrace > 0) {
+    candidates.push(trimmed.slice(firstBrace))
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate.startsWith('{') || !candidate.endsWith('}')) {
+      continue
+    }
+
+    try {
+      const parsed = JSON.parse(candidate)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return flattenObject(parsed)
+      }
+    } catch {
+      // Not valid JSON
+    }
+  }
+
+  return []
+}
+
+function parseKeyValueFields(line: string): DetectedField[] {
+  const fields: DetectedField[] = []
+  const seenKeys = new Set<string>()
+  const pattern = /([a-zA-Z_][\w.-]*)=("[^"]*"|'[^']*'|[^,\s]+)/g
+
+  for (const match of line.matchAll(pattern)) {
+    const key = match[1]
+    if (!key || seenKeys.has(key)) {
+      continue
+    }
+
+    const rawValue = match[2] || ''
+    const value =
+      (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+      (rawValue.startsWith("'") && rawValue.endsWith("'"))
+        ? rawValue.slice(1, -1)
+        : rawValue
+
+    fields.push({ key, value })
+    seenKeys.add(key)
+  }
+
+  return fields
+}
+
+function getMessageFields(log: LogEntry): DetectedField[] {
+  const jsonFields = parseJsonFields(log.line)
+  if (jsonFields.length > 0) {
+    return jsonFields
+  }
+
+  return parseKeyValueFields(log.line)
+}
+
+export function LogViewer({
+  logs,
+  highlightedLogKeys = [],
+  traceIdField = 'trace_id',
+  linkedTraceDatasourceId = null,
+}: LogViewerProps) {
+  const navigate = useNavigate()
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+
+  const displayLogs = useMemo(() => logs.slice(0, 1000), [logs])
+  const highlightedLogKeySet = useMemo(() => new Set(highlightedLogKeys), [highlightedLogKeys])
+  const detectedFieldsByRow = useMemo(
+    () => displayLogs.map(log => getMessageFields(log)),
+    [displayLogs],
+  )
+
+  function getLogKey(log: LogEntry): string {
+    const labels = Object.entries(log.labels || {})
+      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+      .map(([key, value]) => `${key}=${value}`)
+      .join(',')
+    return `${log.timestamp}|${labels}|${log.line}`
+  }
+
+  function isHighlighted(log: LogEntry): boolean {
+    return highlightedLogKeySet.has(getLogKey(log))
+  }
+
+  function toggleRow(index: number) {
+    setExpandedRows(prev => {
+      const next = new Set(prev)
+      if (next.has(index)) {
+        next.delete(index)
+      } else {
+        next.add(index)
+      }
+      return next
+    })
+  }
+
+  function navigateToTrace(traceId: string) {
+    const params = new URLSearchParams()
+    if (linkedTraceDatasourceId) {
+      params.set('datasourceId', linkedTraceDatasourceId)
+    }
+    params.set('traceId', traceId)
+    navigate(`/app/explore/traces?${params.toString()}`)
+  }
+
+  if (logs.length === 0) {
+    return (
+      <div
+        className="flex h-full flex-col overflow-hidden rounded bg-[var(--color-surface-container-low)]"
+        data-testid="log-viewer"
+      >
+        <div className="text-center px-4 py-8 text-xs font-mono text-[var(--color-outline)]">
+          No log entries
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="flex h-full flex-col overflow-hidden rounded bg-[var(--color-surface-container-low)]"
+      data-testid="log-viewer"
+    >
+      <div className="flex items-center gap-4 bg-[var(--color-surface-container-high)] px-4 py-2.5 font-mono text-xs uppercase tracking-[0.07em] text-[var(--color-on-surface-variant)]">
+        <span className="w-44 shrink-0">Timestamp</span>
+        <span className="w-20 shrink-0">Level</span>
+        <span className="flex-1">Message</span>
+      </div>
+      <div className="shrink-0 bg-[var(--color-surface-container-high)] px-4 py-1 font-mono text-xs">
+        <span className="text-[var(--color-outline)]">{logs.length} log entries</span>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {displayLogs.map((log, index) => {
+          const expanded = expandedRows.has(index)
+          const traceId =
+            linkedTraceDatasourceId && extractTraceId(log, traceIdField)
+
+          return (
+            <div key={`${getLogKey(log)}-${index}`}>
+              <div
+                className={`group flex cursor-pointer items-start gap-4 px-4 py-2 font-mono text-xs transition hover:bg-[var(--color-surface-container-high)] ${
+                  expanded ? 'bg-[var(--color-surface-container-high)]' : ''
+                } ${isHighlighted(log) ? 'animate-[row-highlight-fade_2.4s_ease-out]' : ''}`}
+                data-testid="log-viewer-row"
+                onClick={() => toggleRow(index)}
+              >
+                <span className="w-44 shrink-0 text-[var(--color-outline)]">
+                  {formatTimestamp(log.timestamp)}
+                </span>
+
+                <span className="w-20 shrink-0">
+                  {log.level ? (
+                    <span
+                      className={`inline-block text-[0.7rem] uppercase ${getLevelBadgeClasses(log.level)}`}
+                    >
+                      {log.level}
+                    </span>
+                  ) : null}
+                </span>
+
+                <span className="w-40 shrink-0">
+                  {traceId ? (
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-primary)] transition-colors hover:bg-[var(--color-primary)]/10"
+                      title={`View trace ${traceId}`}
+                      onClick={event => {
+                        event.stopPropagation()
+                        navigateToTrace(traceId)
+                      }}
+                    >
+                      <Activity className="h-3 w-3" />
+                      {traceId.slice(0, 16)}…
+                    </button>
+                  ) : null}
+                </span>
+
+                <div className="flex-1 break-all text-[var(--color-on-surface)]">
+                  <div className="flex items-start gap-1.5">
+                    <svg
+                      className={`mt-0.5 shrink-0 transition-all duration-150 group-hover:!text-[var(--color-primary)] ${
+                        expanded ? 'rotate-90' : ''
+                      }`}
+                      style={{
+                        color: expanded ? 'var(--color-primary)' : 'var(--color-outline)',
+                      }}
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden
+                    >
+                      <polyline points="9 18 15 12 9 6" />
+                    </svg>
+                    <span className="flex-1 whitespace-pre-wrap">{log.line}</span>
+                  </div>
+                  {log.labels && Object.keys(log.labels).length > 0 ? (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {Object.entries(log.labels).map(([key, value]) => (
+                        <span
+                          key={key}
+                          className="mr-1 inline-flex rounded-sm bg-[var(--color-surface-container-high)] px-2 py-0.5 text-xs text-[var(--color-on-surface-variant)]"
+                        >
+                          {key}={value}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+
+              {expanded ? (
+                <div className="bg-[var(--color-surface-container-high)] px-6 py-4 font-mono text-xs">
+                  <div className="mb-2 text-[0.7rem] font-semibold uppercase tracking-[0.04em] text-[var(--color-outline)]">
+                    Detected Fields
+                  </div>
+                  {detectedFieldsByRow[index]?.length ? (
+                    <div className="grid gap-1.5">
+                      {detectedFieldsByRow[index].map(field => (
+                        <div
+                          key={field.key}
+                          className="grid grid-cols-[minmax(120px,220px)_1fr] gap-2.5 max-sm:grid-cols-1 max-sm:gap-1"
+                        >
+                          <span className="break-words text-[var(--color-outline)]">
+                            {field.key}
+                          </span>
+                          <span className="whitespace-pre-wrap break-words text-[var(--color-on-surface)]">
+                            {field.value}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-[var(--color-outline)]">
+                      No structured fields detected in this message.
+                    </div>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -257,13 +257,22 @@ export function LogViewer({
             linkedTraceDatasourceId && extractTraceId(log, traceIdField)
 
           return (
-            <div key={`${getLogKey(log)}-${index}`}>
+            <div key={getLogKey(log)}>
+              {/* biome-ignore lint/a11y/useSemanticElements: row contains nested trace link button */}
               <div
+                role="button"
+                tabIndex={0}
                 className={`group flex cursor-pointer items-start gap-4 px-4 py-2 font-mono text-xs transition hover:bg-[var(--color-surface-container-high)] ${
                   expanded ? 'bg-[var(--color-surface-container-high)]' : ''
                 } ${isHighlighted(log) ? 'animate-[row-highlight-fade_2.4s_ease-out]' : ''}`}
                 data-testid="log-viewer-row"
                 onClick={() => toggleRow(index)}
+                onKeyDown={event => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault()
+                    toggleRow(index)
+                  }
+                }}
               >
                 <span className="w-44 shrink-0 text-[var(--color-outline)]">
                   {formatTimestamp(log.timestamp)}
@@ -313,7 +322,7 @@ export function LogViewer({
                       strokeWidth="2.5"
                       strokeLinecap="round"
                       strokeLinejoin="round"
-                      aria-hidden
+                      aria-hidden="true"
                     >
                       <polyline points="9 18 15 12 9 6" />
                     </svg>

--- a/frontend/src/components/LogsExplorePanel.tsx
+++ b/frontend/src/components/LogsExplorePanel.tsx
@@ -241,6 +241,8 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
   const lastLiveTimestampSecRef = useRef<number | null>(null)
   const liveAbortControllerRef = useRef<AbortController | null>(null)
   const liveReconnectTimerRef = useRef<number | null>(null)
+  const isLiveRef = useRef(false)
+  const openLiveStreamRef = useRef<() => Promise<void>>(async () => {})
   const highlightTimeoutIdsRef = useRef<Map<string, number>>(new Map())
   const labelsCacheRef = useRef<Map<string, string[]>>(new Map())
   const pendingNavigationRef = useRef({
@@ -400,6 +402,7 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
 
   const stopLive = useCallback(
     (resetError = true) => {
+      isLiveRef.current = false
       setIsLive(false)
       setLiveState('idle')
       if (resetError) {
@@ -443,7 +446,7 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
         {
           onLog: appendStreamLog,
           onStatus: (status, message) => {
-            if (!isLive) return
+            if (!isLiveRef.current) return
 
             if (status === 'connected') {
               setLiveState('connected')
@@ -461,14 +464,14 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
             }
           },
           onError: message => {
-            if (!isLive) return
+            if (!isLiveRef.current) return
             setLiveError(message)
           },
         },
         liveAbortControllerRef.current.signal,
       )
 
-      if (!isLive) return
+      if (!isLiveRef.current) return
 
       setLiveError('Live stream disconnected')
       setLiveState('reconnecting')
@@ -478,10 +481,10 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
       )
       setLiveReconnectAttempt(prev => prev + 1)
       liveReconnectTimerRef.current = window.setTimeout(() => {
-        void openLiveStream()
+        void openLiveStreamRef.current()
       }, delayMs)
     } catch (e) {
-      if (!isLive) return
+      if (!isLiveRef.current) return
       if (e instanceof Error && e.name === 'AbortError') return
 
       setLiveError(e instanceof Error ? e.message : 'Live stream failed')
@@ -492,7 +495,7 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
       )
       setLiveReconnectAttempt(prev => prev + 1)
       liveReconnectTimerRef.current = window.setTimeout(() => {
-        void openLiveStream()
+        void openLiveStreamRef.current()
       }, delayMs)
     }
   }, [
@@ -506,6 +509,8 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
     query,
     selectedDatasourceId,
   ])
+
+  openLiveStreamRef.current = openLiveStream
 
   const runQuery = useCallback(async () => {
     const wasLive = isLive
@@ -563,6 +568,7 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
       addToHistory(query)
 
       if (wasLive) {
+        isLiveRef.current = true
         setIsLive(true)
         setLiveState('connecting')
         setLiveError(null)
@@ -608,6 +614,7 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
       return
     }
 
+    isLiveRef.current = true
     setIsLive(true)
     setLiveState('connecting')
     setLiveError(null)
@@ -1255,7 +1262,14 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
             <span>{error}</span>
           </div>
         ) : liveError && isLive ? (
-          <div className="flex items-center gap-2 rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+          <div
+            className="flex items-center gap-2 rounded border p-4 text-sm"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--color-tertiary) 25%, transparent)',
+              backgroundColor: 'color-mix(in srgb, var(--color-tertiary) 10%, transparent)',
+              color: 'var(--color-tertiary)',
+            }}
+          >
             <AlertCircle size={16} />
             <span>{liveError}</span>
           </div>

--- a/frontend/src/components/LogsExplorePanel.tsx
+++ b/frontend/src/components/LogsExplorePanel.tsx
@@ -814,6 +814,7 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
     }
   }, [activeDatasource, applyTraceLogsNavigationContext, checkDatasourceHealth, datasourceHealth])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset UI when datasource selection changes
   useEffect(() => {
     setShowDatasourceMenu(false)
     stopLive()
@@ -1118,9 +1119,9 @@ export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps)
                       <X size={14} />
                     </button>
                   </div>
-                  {queryHistory.map((historyQuery, index) => (
+                  {queryHistory.map(historyQuery => (
                     <button
-                      key={`${historyQuery}-${index}`}
+                      key={historyQuery}
                       type="button"
                       className="block w-full cursor-pointer border-none bg-transparent px-4 py-2.5 text-left transition hover:bg-[var(--color-surface-container-high)]"
                       onClick={() => selectHistoryQuery(historyQuery)}

--- a/frontend/src/components/LogsExplorePanel.tsx
+++ b/frontend/src/components/LogsExplorePanel.tsx
@@ -1,0 +1,1356 @@
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  CircleAlert,
+  HeartPulse,
+  History,
+  LayoutDashboard,
+  Loader2,
+  Play,
+  Star,
+  X,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import {
+  fetchDataSourceLabels,
+  queryDataSource,
+  streamDataSourceLogs,
+} from '@/api/datasources'
+import { ExportToDashboardModal } from '@/components/ExportToDashboardModal'
+import { LogQLQueryBuilder } from '@/components/LogQLQueryBuilder'
+import { LogViewer } from '@/components/LogViewer'
+import { MonacoQueryEditor } from '@/components/MonacoQueryEditor'
+import { TimeRangePicker } from '@/components/TimeRangePicker'
+import { useLogsDatasources } from '@/hooks/useLogsDatasources'
+import { useTimeRange } from '@/hooks/useTimeRange'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import {
+  dataSourceTypeLabels,
+  type DataSource,
+  type DataSourceType,
+  type LogEntry,
+} from '@/types/datasource'
+import { dataSourceTypeLogos } from '@/utils/datasourceLogos'
+
+type DatasourceHealthStatus = 'unknown' | 'checking' | 'healthy' | 'unhealthy'
+type LiveState = 'idle' | 'connecting' | 'connected' | 'reconnecting'
+
+type TraceLogsNavigationContext = {
+  traceId?: string
+  serviceName?: string
+  startMs?: number
+  endMs?: number
+  createdAt?: number
+}
+
+type LogsExplorePanelProps = {
+  onDatasourceChanged?: (payload: { id: string; name: string; type: string }) => void
+}
+
+const HISTORY_KEY = 'explore_logs_query_history'
+const MAX_HISTORY = 10
+const TRACE_LOGS_NAVIGATION_CONTEXT_KEY = 'trace_logs_navigation'
+const TRACE_NAVIGATION_MAX_AGE_MS = 5 * 60 * 1000
+const MAX_STREAM_LOGS = 2000
+const LIVE_RESUME_OVERLAP_SECONDS = 5
+const LIVE_RECONNECT_BASE_DELAY_MS = 1000
+const LIVE_RECONNECT_MAX_DELAY_MS = 15000
+const NEW_LOG_HIGHLIGHT_MS = 2500
+
+function escapeForDoubleQuotedValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function escapeForSingleQuotedValue(value: string): string {
+  return value.replace(/'/g, "''")
+}
+
+function getTypeLogo(type_: DataSourceType): string | undefined {
+  return dataSourceTypeLogos[type_]
+}
+
+function getDefaultLogsQuery(type_: DataSourceType): string {
+  switch (type_) {
+    case 'loki':
+      return '{job=~".+"}'
+    case 'victorialogs':
+      return '*'
+    case 'clickhouse':
+      return "SELECT\n  Timestamp AS timestamp,\n  Body AS message,\n  SeverityText AS level\nFROM ace_logs\nWHERE Timestamp >= toDateTime({start})\n  AND Timestamp <= toDateTime({end})\nORDER BY Timestamp DESC\nLIMIT 100"
+    case 'cloudwatch':
+      return 'fields @timestamp, @message\n| sort @timestamp desc\n| limit 100'
+    case 'elasticsearch':
+      return '*'
+    default:
+      return ''
+  }
+}
+
+function getSmokeQuery(type_: DataSourceType): string {
+  if (type_ === 'clickhouse') {
+    return "SELECT now() AS timestamp, 'healthcheck' AS message LIMIT 1"
+  }
+  if (type_ === 'cloudwatch') {
+    return 'fields @timestamp, @message | sort @timestamp desc | limit 1'
+  }
+  if (type_ === 'elasticsearch') {
+    return '*'
+  }
+  if (type_ === 'loki') {
+    return '{job=~".+"}'
+  }
+  return '*'
+}
+
+function buildTraceLogsQuery(type_: DataSourceType, traceId: string, serviceName: string): string {
+  const escapedTraceId = escapeForDoubleQuotedValue(traceId)
+  const escapedServiceName = escapeForDoubleQuotedValue(serviceName)
+  const escapedTraceIdSql = escapeForSingleQuotedValue(traceId)
+  const escapedServiceNameSql = escapeForSingleQuotedValue(serviceName)
+
+  if (type_ === 'loki') {
+    const selector = escapedServiceName ? `{service_name="${escapedServiceName}"}` : '{job=~".+"}'
+    return `${selector} |= "${escapedTraceId}"`
+  }
+
+  if (type_ === 'clickhouse') {
+    const serviceCondition = escapedServiceNameSql
+      ? `AND service_name = '${escapedServiceNameSql}'`
+      : ''
+    return `SELECT timestamp, message, level\nFROM logs\nWHERE message ILIKE '%${escapedTraceIdSql}%' ${serviceCondition}\nORDER BY timestamp DESC\nLIMIT 500`
+  }
+
+  if (type_ === 'cloudwatch') {
+    const serviceFilter = escapedServiceName
+      ? ` | filter service_name = "${escapedServiceName}"`
+      : ''
+    return `fields @timestamp, @message, @logStream\n| filter @message like /${escapedTraceId}/${serviceFilter}\n| sort @timestamp desc\n| limit 500`
+  }
+
+  if (type_ === 'elasticsearch') {
+    if (escapedServiceName) {
+      return `trace.id:"${escapedTraceId}" AND service.name:"${escapedServiceName}"`
+    }
+    return `trace.id:"${escapedTraceId}"`
+  }
+
+  if (escapedServiceName) {
+    return `"${escapedServiceName}" "${escapedTraceId}"`
+  }
+
+  return `"${escapedTraceId}"`
+}
+
+function sortLogsNewestFirst(entries: LogEntry[]): LogEntry[] {
+  return entries
+    .map((log, index) => {
+      const parsedTimestamp = Date.parse(log.timestamp)
+      return {
+        log,
+        index,
+        timestampMs: Number.isNaN(parsedTimestamp) ? null : parsedTimestamp,
+      }
+    })
+    .sort((a, b) => {
+      if (a.timestampMs === null && b.timestampMs === null) {
+        return a.index - b.index
+      }
+      if (a.timestampMs === null) {
+        return 1
+      }
+      if (b.timestampMs === null) {
+        return -1
+      }
+      if (a.timestampMs === b.timestampMs) {
+        return a.index - b.index
+      }
+      return b.timestampMs - a.timestampMs
+    })
+    .map(entry => entry.log)
+}
+
+function getLogKey(log: LogEntry): string {
+  const labels = Object.entries(log.labels || {})
+    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',')
+  return `${log.timestamp}|${labels}|${log.line}`
+}
+
+function toUnixSeconds(timestamp: string): number | null {
+  const parsed = Date.parse(timestamp)
+  if (Number.isNaN(parsed)) {
+    return null
+  }
+  return Math.floor(parsed / 1000)
+}
+
+function getLatestTimestampSeconds(entries: LogEntry[]): number | null {
+  let latest: number | null = null
+  for (const entry of entries) {
+    const ts = toUnixSeconds(entry.timestamp)
+    if (ts === null) {
+      continue
+    }
+    if (latest === null || ts > latest) {
+      latest = ts
+    }
+  }
+  return latest
+}
+
+function needsLogsSignal(type_: DataSourceType): boolean {
+  return type_ === 'clickhouse' || type_ === 'cloudwatch' || type_ === 'elasticsearch'
+}
+
+export function LogsExplorePanel({ onDatasourceChanged }: LogsExplorePanelProps) {
+  const currentOrgId = useOrgStore(state => state.currentOrgId)
+  const { logsDatasources } = useLogsDatasources(currentOrgId)
+  const { timeRange, onRefresh, setCustomRange } = useTimeRange()
+  const toggleFavorite = useFavoritesStore(state => state.toggleFavorite)
+  const isFavorite = useFavoritesStore(state => state.isFavorite)
+  const [searchParams] = useSearchParams()
+
+  const [selectedDatasourceId, setSelectedDatasourceId] = useState('')
+  const [query, setQuery] = useState('')
+  const [showExportModal, setShowExportModal] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const [hasSuccessfulQuery, setHasSuccessfulQuery] = useState(false)
+  const [isLive, setIsLive] = useState(false)
+  const [liveState, setLiveState] = useState<LiveState>('idle')
+  const [liveError, setLiveError] = useState<string | null>(null)
+  const [liveReconnectAttempt, setLiveReconnectAttempt] = useState(0)
+  const [queryHistory, setQueryHistory] = useState<string[]>([])
+  const [showHistory, setShowHistory] = useState(false)
+  const [showDatasourceMenu, setShowDatasourceMenu] = useState(false)
+  const [datasourceHealth, setDatasourceHealth] = useState<Record<string, DatasourceHealthStatus>>(
+    {},
+  )
+  const [datasourceHealthErrors, setDatasourceHealthErrors] = useState<Record<string, string>>({})
+  const [indexedLabels, setIndexedLabels] = useState<string[]>([])
+  const [highlightedLogKeys, setHighlightedLogKeys] = useState<Set<string>>(new Set())
+
+  const datasourceMenuRef = useRef<HTMLDivElement | null>(null)
+  const seenLogKeysRef = useRef<Set<string>>(new Set())
+  const lastLiveTimestampSecRef = useRef<number | null>(null)
+  const liveAbortControllerRef = useRef<AbortController | null>(null)
+  const liveReconnectTimerRef = useRef<number | null>(null)
+  const highlightTimeoutIdsRef = useRef<Map<string, number>>(new Map())
+  const labelsCacheRef = useRef<Map<string, string[]>>(new Map())
+  const pendingNavigationRef = useRef({
+    traceId: '',
+    serviceName: '',
+    startMs: null as number | null,
+    endMs: null as number | null,
+  })
+
+  const activeDatasource = useMemo(
+    () => logsDatasources.find(ds => ds.id === selectedDatasourceId) ?? null,
+    [logsDatasources, selectedDatasourceId],
+  )
+
+  const hasLogsDatasources = logsDatasources.length > 0
+  const hasResults = hasSuccessfulQuery && logs.length > 0
+  const newestFirstLogs = useMemo(() => sortLogsNewestFirst(logs), [logs])
+  const highlightedLogKeyList = useMemo(() => Array.from(highlightedLogKeys), [highlightedLogKeys])
+
+  const isClickHouseDatasource = activeDatasource?.type === 'clickhouse'
+  const isCloudWatchDatasource = activeDatasource?.type === 'cloudwatch'
+  const isElasticsearchDatasource = activeDatasource?.type === 'elasticsearch'
+  const supportsLabelDiscovery =
+    activeDatasource?.type === 'loki' || activeDatasource?.type === 'victorialogs'
+  const supportsLiveStreaming =
+    activeDatasource?.type === 'loki' || activeDatasource?.type === 'victorialogs'
+  const queryLanguage = activeDatasource?.type === 'victorialogs' ? 'logsql' : 'logql'
+  const queryPlaceholder =
+    queryLanguage === 'logsql' ? '*' : '{job=~".+"} |= "error"'
+
+  const activeDatasourceHealth = activeDatasource
+    ? datasourceHealth[activeDatasource.id] || 'unknown'
+    : 'unknown'
+
+  const activeDatasourceHealthLabel =
+    activeDatasourceHealth === 'healthy'
+      ? 'Healthy'
+      : activeDatasourceHealth === 'unhealthy'
+        ? 'Unhealthy'
+        : activeDatasourceHealth === 'checking'
+          ? 'Checking...'
+          : 'Unknown'
+
+  const liveStatusLabel =
+    liveState === 'connected'
+      ? 'Live'
+      : liveState === 'connecting'
+        ? 'Connecting...'
+        : liveState === 'reconnecting'
+          ? 'Reconnecting...'
+          : ''
+
+  const isLiveBusy = liveState === 'connecting' || liveState === 'reconnecting'
+
+  const addToHistory = useCallback((q: string) => {
+    if (!q.trim()) return
+    setQueryHistory(prev => {
+      const filtered = prev.filter(item => item !== q)
+      const next = [q, ...filtered].slice(0, MAX_HISTORY)
+      sessionStorage.setItem(HISTORY_KEY, JSON.stringify(next))
+      return next
+    })
+  }, [])
+
+  const clearLogHighlights = useCallback(() => {
+    for (const timeoutId of highlightTimeoutIdsRef.current.values()) {
+      window.clearTimeout(timeoutId)
+    }
+    highlightTimeoutIdsRef.current = new Map()
+    setHighlightedLogKeys(new Set())
+  }, [])
+
+  const markLogAsNew = useCallback((logKey: string) => {
+    setHighlightedLogKeys(prev => new Set(prev).add(logKey))
+
+    const existingTimeout = highlightTimeoutIdsRef.current.get(logKey)
+    if (existingTimeout !== undefined) {
+      window.clearTimeout(existingTimeout)
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setHighlightedLogKeys(prev => {
+        const next = new Set(prev)
+        next.delete(logKey)
+        return next
+      })
+      highlightTimeoutIdsRef.current.delete(logKey)
+    }, NEW_LOG_HIGHLIGHT_MS)
+
+    highlightTimeoutIdsRef.current.set(logKey, timeoutId)
+  }, [])
+
+  const resetLogCache = useCallback((entries: LogEntry[]) => {
+    seenLogKeysRef.current = new Set(entries.map(getLogKey))
+    lastLiveTimestampSecRef.current = getLatestTimestampSeconds(entries)
+  }, [])
+
+  const appendStreamLog = useCallback(
+    (entry: LogEntry) => {
+      const key = getLogKey(entry)
+      if (seenLogKeysRef.current.has(key)) {
+        return
+      }
+
+      seenLogKeysRef.current.add(key)
+      markLogAsNew(key)
+
+      const timestampSec = toUnixSeconds(entry.timestamp)
+      if (
+        timestampSec !== null &&
+        (lastLiveTimestampSecRef.current === null ||
+          timestampSec > lastLiveTimestampSecRef.current)
+      ) {
+        lastLiveTimestampSecRef.current = timestampSec
+      }
+
+      setLogs(prev => {
+        const next = [...prev, entry]
+        if (next.length <= MAX_STREAM_LOGS) {
+          return next
+        }
+
+        const trimmed = sortLogsNewestFirst(next).slice(0, MAX_STREAM_LOGS)
+        seenLogKeysRef.current = new Set(trimmed.map(getLogKey))
+
+        const remainingKeys = new Set(trimmed.map(getLogKey))
+        setHighlightedLogKeys(current =>
+          new Set(Array.from(current).filter(logKey => remainingKeys.has(logKey))),
+        )
+
+        for (const [logKey, timeoutId] of highlightTimeoutIdsRef.current.entries()) {
+          if (!remainingKeys.has(logKey)) {
+            window.clearTimeout(timeoutId)
+            highlightTimeoutIdsRef.current.delete(logKey)
+          }
+        }
+
+        return trimmed
+      })
+    },
+    [markLogAsNew],
+  )
+
+  const clearLiveReconnectTimer = useCallback(() => {
+    if (liveReconnectTimerRef.current !== null) {
+      window.clearTimeout(liveReconnectTimerRef.current)
+      liveReconnectTimerRef.current = null
+    }
+  }, [])
+
+  const cancelLiveStream = useCallback(() => {
+    if (liveAbortControllerRef.current) {
+      liveAbortControllerRef.current.abort()
+      liveAbortControllerRef.current = null
+    }
+  }, [])
+
+  const stopLive = useCallback(
+    (resetError = true) => {
+      setIsLive(false)
+      setLiveState('idle')
+      if (resetError) {
+        setLiveError(null)
+      }
+      setLiveReconnectAttempt(0)
+      clearLiveReconnectTimer()
+      cancelLiveStream()
+    },
+    [cancelLiveStream, clearLiveReconnectTimer],
+  )
+
+  const getLiveStreamStart = useCallback(() => {
+    if (lastLiveTimestampSecRef.current === null) {
+      return Math.floor(Date.now() / 1000) - LIVE_RESUME_OVERLAP_SECONDS
+    }
+    return Math.max(0, lastLiveTimestampSecRef.current - LIVE_RESUME_OVERLAP_SECONDS)
+  }, [])
+
+  const openLiveStream = useCallback(async () => {
+    if (!isLive || !selectedDatasourceId || !query.trim()) {
+      return
+    }
+
+    clearLiveReconnectTimer()
+    cancelLiveStream()
+
+    liveAbortControllerRef.current = new AbortController()
+    if (liveState !== 'reconnecting') {
+      setLiveState('connecting')
+    }
+
+    try {
+      await streamDataSourceLogs(
+        selectedDatasourceId,
+        {
+          query,
+          start: getLiveStreamStart(),
+          limit: 200,
+        },
+        {
+          onLog: appendStreamLog,
+          onStatus: (status, message) => {
+            if (!isLive) return
+
+            if (status === 'connected') {
+              setLiveState('connected')
+              setLiveError(null)
+              setLiveReconnectAttempt(0)
+              return
+            }
+
+            if (status === 'connecting') {
+              setLiveState('connecting')
+            }
+
+            if (message) {
+              setLiveError(message)
+            }
+          },
+          onError: message => {
+            if (!isLive) return
+            setLiveError(message)
+          },
+        },
+        liveAbortControllerRef.current.signal,
+      )
+
+      if (!isLive) return
+
+      setLiveError('Live stream disconnected')
+      setLiveState('reconnecting')
+      const delayMs = Math.min(
+        LIVE_RECONNECT_MAX_DELAY_MS,
+        LIVE_RECONNECT_BASE_DELAY_MS * 2 ** liveReconnectAttempt,
+      )
+      setLiveReconnectAttempt(prev => prev + 1)
+      liveReconnectTimerRef.current = window.setTimeout(() => {
+        void openLiveStream()
+      }, delayMs)
+    } catch (e) {
+      if (!isLive) return
+      if (e instanceof Error && e.name === 'AbortError') return
+
+      setLiveError(e instanceof Error ? e.message : 'Live stream failed')
+      setLiveState('reconnecting')
+      const delayMs = Math.min(
+        LIVE_RECONNECT_MAX_DELAY_MS,
+        LIVE_RECONNECT_BASE_DELAY_MS * 2 ** liveReconnectAttempt,
+      )
+      setLiveReconnectAttempt(prev => prev + 1)
+      liveReconnectTimerRef.current = window.setTimeout(() => {
+        void openLiveStream()
+      }, delayMs)
+    }
+  }, [
+    appendStreamLog,
+    cancelLiveStream,
+    clearLiveReconnectTimer,
+    getLiveStreamStart,
+    isLive,
+    liveReconnectAttempt,
+    liveState,
+    query,
+    selectedDatasourceId,
+  ])
+
+  const runQuery = useCallback(async () => {
+    const wasLive = isLive
+    if (wasLive) {
+      stopLive()
+    }
+
+    if (!selectedDatasourceId) {
+      setError('Select a logs datasource')
+      return
+    }
+
+    if (!query.trim()) {
+      setError('Query is required')
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    setLiveError(null)
+    clearLogHighlights()
+    setLogs([])
+    seenLogKeysRef.current = new Set()
+    lastLiveTimestampSecRef.current = null
+    setHasSuccessfulQuery(false)
+
+    try {
+      const start = Math.floor(timeRange.start / 1000)
+      const end = Math.floor(timeRange.end / 1000)
+      const dsType = activeDatasource?.type
+
+      const response = await queryDataSource(selectedDatasourceId, {
+        query,
+        signal: dsType && needsLogsSignal(dsType) ? 'logs' : undefined,
+        start,
+        end,
+        step: 15,
+        limit: 1000,
+      })
+
+      if (response.status === 'error') {
+        setError(response.error || 'Query failed')
+        return
+      }
+
+      if (response.resultType !== 'logs') {
+        setError('Selected datasource did not return log results')
+        return
+      }
+
+      const nextLogs = response.data?.logs || []
+      setLogs(nextLogs)
+      resetLogCache(nextLogs)
+      setHasSuccessfulQuery(true)
+      addToHistory(query)
+
+      if (wasLive) {
+        setIsLive(true)
+        setLiveState('connecting')
+        setLiveError(null)
+        setLiveReconnectAttempt(0)
+        void openLiveStream()
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to execute query')
+    } finally {
+      setLoading(false)
+    }
+  }, [
+    activeDatasource?.type,
+    addToHistory,
+    clearLogHighlights,
+    isLive,
+    openLiveStream,
+    query,
+    resetLogCache,
+    selectedDatasourceId,
+    stopLive,
+    timeRange.end,
+    timeRange.start,
+  ])
+
+  const startLive = useCallback(async () => {
+    if (isLive || isLiveBusy) {
+      return
+    }
+
+    if (!selectedDatasourceId) {
+      setError('Select a logs datasource')
+      return
+    }
+
+    if (!query.trim()) {
+      setError('Query is required')
+      return
+    }
+
+    if (!hasSuccessfulQuery) {
+      await runQuery()
+      return
+    }
+
+    setIsLive(true)
+    setLiveState('connecting')
+    setLiveError(null)
+    setLiveReconnectAttempt(0)
+    void openLiveStream()
+  }, [
+    hasSuccessfulQuery,
+    isLive,
+    isLiveBusy,
+    openLiveStream,
+    query,
+    runQuery,
+    selectedDatasourceId,
+  ])
+
+  const toggleLive = useCallback(() => {
+    if (isLive) {
+      stopLive()
+      return
+    }
+    void startLive()
+  }, [isLive, startLive, stopLive])
+
+  const checkDatasourceHealth = useCallback(async (datasourceId: string, type_: DataSourceType) => {
+    setDatasourceHealth(prev => ({ ...prev, [datasourceId]: 'checking' }))
+    setDatasourceHealthErrors(prev => {
+      const next = { ...prev }
+      delete next[datasourceId]
+      return next
+    })
+
+    const end = Math.floor(Date.now() / 1000)
+    const start = end - 15 * 60
+
+    try {
+      const healthResult = await queryDataSource(datasourceId, {
+        query: getSmokeQuery(type_),
+        signal: needsLogsSignal(type_) ? 'logs' : undefined,
+        start,
+        end,
+        step: 15,
+        limit: 100,
+      })
+
+      if (healthResult.status === 'error') {
+        throw new Error(healthResult.error || 'Health check failed')
+      }
+
+      setDatasourceHealth(prev => ({ ...prev, [datasourceId]: 'healthy' }))
+    } catch (e) {
+      setDatasourceHealth(prev => ({ ...prev, [datasourceId]: 'unhealthy' }))
+      setDatasourceHealthErrors(prev => ({
+        ...prev,
+        [datasourceId]: e instanceof Error ? e.message : 'Health check failed',
+      }))
+    }
+  }, [])
+
+  const applyTraceLogsNavigationContext = useCallback(() => {
+    const pending = pendingNavigationRef.current
+    if (!pending.traceId) {
+      return
+    }
+
+    setQuery(
+      buildTraceLogsQuery(activeDatasource?.type || 'loki', pending.traceId, pending.serviceName),
+    )
+
+    if (pending.startMs !== null && pending.endMs !== null) {
+      setCustomRange(pending.startMs, pending.endMs)
+    }
+
+    pendingNavigationRef.current = { traceId: '', serviceName: '', startMs: null, endMs: null }
+  }, [activeDatasource?.type, setCustomRange])
+
+  const loadIndexedLabels = useCallback(async (datasourceId: string) => {
+    if (labelsCacheRef.current.has(datasourceId)) {
+      setIndexedLabels(labelsCacheRef.current.get(datasourceId) || [])
+      return
+    }
+
+    try {
+      const labels = await fetchDataSourceLabels(datasourceId)
+      labelsCacheRef.current.set(datasourceId, labels)
+      if (selectedDatasourceId === datasourceId) {
+        setIndexedLabels(labels)
+      }
+    } catch {
+      if (selectedDatasourceId === datasourceId) {
+        setIndexedLabels([])
+      }
+    }
+  }, [selectedDatasourceId])
+
+  useEffect(() => {
+    const urlQuery = searchParams.get('q')
+    if (urlQuery) {
+      setQuery(urlQuery)
+    }
+
+    try {
+      const rawContext = localStorage.getItem(TRACE_LOGS_NAVIGATION_CONTEXT_KEY)
+      localStorage.removeItem(TRACE_LOGS_NAVIGATION_CONTEXT_KEY)
+      if (rawContext) {
+        const parsed = JSON.parse(rawContext) as TraceLogsNavigationContext
+        if (typeof parsed.traceId === 'string' && parsed.traceId.trim()) {
+          if (typeof parsed.createdAt !== 'number' || Date.now() - parsed.createdAt <= TRACE_NAVIGATION_MAX_AGE_MS) {
+            pendingNavigationRef.current = {
+              traceId: parsed.traceId.trim(),
+              serviceName:
+                typeof parsed.serviceName === 'string' ? parsed.serviceName.trim() : '',
+              startMs:
+                typeof parsed.startMs === 'number' &&
+                typeof parsed.endMs === 'number' &&
+                parsed.endMs > parsed.startMs
+                  ? parsed.startMs
+                  : null,
+              endMs:
+                typeof parsed.startMs === 'number' &&
+                typeof parsed.endMs === 'number' &&
+                parsed.endMs > parsed.startMs
+                  ? parsed.endMs
+                  : null,
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore malformed navigation context.
+    }
+
+    const stored = sessionStorage.getItem(HISTORY_KEY)
+    if (stored) {
+      try {
+        setQueryHistory(JSON.parse(stored))
+      } catch {
+        setQueryHistory([])
+      }
+    }
+  }, [searchParams])
+
+  const previousOrgIdRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!currentOrgId) return
+    if (previousOrgIdRef.current && previousOrgIdRef.current !== currentOrgId) {
+      setSelectedDatasourceId('')
+      setDatasourceHealth({})
+      setDatasourceHealthErrors({})
+      labelsCacheRef.current = new Map()
+      setQuery('')
+      setLogs([])
+      setError(null)
+      stopLive()
+    }
+    previousOrgIdRef.current = currentOrgId
+  }, [currentOrgId, stopLive])
+
+  useEffect(() => {
+    if (logsDatasources.length === 0) {
+      setSelectedDatasourceId('')
+      return
+    }
+
+    const hasSelected = logsDatasources.some(ds => ds.id === selectedDatasourceId)
+    if (!hasSelected) {
+      const defaultDatasource = logsDatasources.find(ds => ds.is_default)
+      const selected = defaultDatasource || logsDatasources[0]
+      if (!selected) return
+      setSelectedDatasourceId(selected.id)
+
+      if (!query.trim()) {
+        setQuery(getDefaultLogsQuery(selected.type))
+      }
+    }
+  }, [logsDatasources, query, selectedDatasourceId])
+
+  useEffect(() => {
+    const sourceIds = new Set(logsDatasources.map(ds => ds.id))
+    setDatasourceHealth(prev =>
+      Object.fromEntries(Object.entries(prev).filter(([id]) => sourceIds.has(id))),
+    )
+    setDatasourceHealthErrors(prev =>
+      Object.fromEntries(Object.entries(prev).filter(([id]) => sourceIds.has(id))),
+    )
+
+    const filteredCache = new Map<string, string[]>()
+    for (const [id, labels] of labelsCacheRef.current.entries()) {
+      if (sourceIds.has(id)) {
+        filteredCache.set(id, labels)
+      }
+    }
+    labelsCacheRef.current = filteredCache
+  }, [logsDatasources])
+
+  useEffect(() => {
+    if (!activeDatasource) return
+
+    if (pendingNavigationRef.current.traceId) {
+      applyTraceLogsNavigationContext()
+    }
+
+    if ((datasourceHealth[activeDatasource.id] || 'unknown') === 'unknown') {
+      void checkDatasourceHealth(activeDatasource.id, activeDatasource.type)
+    }
+  }, [activeDatasource, applyTraceLogsNavigationContext, checkDatasourceHealth, datasourceHealth])
+
+  useEffect(() => {
+    setShowDatasourceMenu(false)
+    stopLive()
+    clearLogHighlights()
+  }, [clearLogHighlights, selectedDatasourceId, stopLive])
+
+  useEffect(() => {
+    if (!supportsLiveStreaming && isLive) {
+      stopLive()
+    }
+  }, [isLive, stopLive, supportsLiveStreaming])
+
+  useEffect(() => {
+    if (!selectedDatasourceId || !supportsLabelDiscovery) {
+      setIndexedLabels([])
+      return
+    }
+
+    void loadIndexedLabels(selectedDatasourceId)
+  }, [loadIndexedLabels, selectedDatasourceId, supportsLabelDiscovery])
+
+  useEffect(() => {
+    const ds = logsDatasources.find(d => d.id === selectedDatasourceId)
+    if (ds) {
+      onDatasourceChanged?.({ id: ds.id, name: ds.name, type: ds.type })
+    }
+  }, [logsDatasources, onDatasourceChanged, selectedDatasourceId])
+
+  useEffect(() => {
+    function handleDocumentClick(event: MouseEvent) {
+      const target = event.target as Node
+      if (!datasourceMenuRef.current?.contains(target)) {
+        setShowDatasourceMenu(false)
+      }
+    }
+
+    document.addEventListener('click', handleDocumentClick)
+    return () => document.removeEventListener('click', handleDocumentClick)
+  }, [])
+
+  useEffect(() => {
+    return onRefresh(() => {
+      if (isLive) return
+      if (query.trim() && selectedDatasourceId && hasSuccessfulQuery) {
+        void runQuery()
+      }
+    })
+  }, [hasSuccessfulQuery, isLive, onRefresh, query, runQuery, selectedDatasourceId])
+
+  useEffect(() => {
+    return () => {
+      stopLive(false)
+      clearLogHighlights()
+    }
+  }, [clearLogHighlights, stopLive])
+
+  function handleKeydown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+      event.preventDefault()
+      void runQuery()
+    }
+  }
+
+  function selectDatasource(datasourceId: string) {
+    const prevDs = logsDatasources.find(d => d.id === selectedDatasourceId)
+    setSelectedDatasourceId(datasourceId)
+    setShowDatasourceMenu(false)
+
+    const newDs = logsDatasources.find(d => d.id === datasourceId)
+    if (newDs && (!query.trim() || (prevDs && prevDs.type !== newDs.type))) {
+      setQuery(getDefaultLogsQuery(newDs.type))
+    }
+  }
+
+  function selectHistoryQuery(q: string) {
+    setQuery(q)
+    setShowHistory(false)
+  }
+
+  function clearHistory() {
+    setQueryHistory([])
+    sessionStorage.removeItem(HISTORY_KEY)
+  }
+
+  function toggleDatasourceMenu() {
+    if (loading || !hasLogsDatasources) return
+    setShowDatasourceMenu(prev => !prev)
+  }
+
+  const favoriteId = `explore::logs::${query}`
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: panel-level Ctrl/Cmd+Enter to run query
+    <section className="flex flex-1 flex-col gap-6" onKeyDown={handleKeydown}>
+      <div
+        className="flex flex-col gap-4 rounded-lg p-4"
+        style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+      >
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+          <div className="flex flex-col gap-2.5">
+            <label
+              htmlFor="explore-logs-datasource-btn"
+              className="text-xs font-semibold tracking-wide uppercase"
+              style={{ color: 'var(--color-outline)' }}
+            >
+              Data Source
+            </label>
+            <div ref={datasourceMenuRef} className="relative">
+              <button
+                id="explore-logs-datasource-btn"
+                type="button"
+                className="flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 text-left transition disabled:cursor-not-allowed disabled:opacity-60"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  border: '1px solid var(--color-outline-variant)',
+                  color: 'var(--color-on-surface)',
+                }}
+                data-testid="explore-logs-datasource-btn"
+                disabled={loading || !hasLogsDatasources}
+                onClick={toggleDatasourceMenu}
+              >
+                {activeDatasource ? (
+                  <>
+                    <img
+                      src={getTypeLogo(activeDatasource.type)}
+                      alt={`${dataSourceTypeLabels[activeDatasource.type]} logo`}
+                      className="h-7 w-7 shrink-0 object-contain"
+                    />
+                    <div className="flex min-w-0 flex-col gap-px">
+                      <span
+                        className="text-[0.68rem] tracking-wide uppercase"
+                        style={{ color: 'var(--color-outline)' }}
+                      >
+                        Active Source
+                      </span>
+                      <strong
+                        className="truncate text-sm font-semibold"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        {activeDatasource.name}
+                      </strong>
+                      <span
+                        className="font-mono text-xs tracking-[0.07em] uppercase"
+                        style={{ color: 'var(--color-outline)' }}
+                      >
+                        {dataSourceTypeLabels[activeDatasource.type]}
+                      </span>
+                    </div>
+                    <span
+                      className="ml-auto inline-flex items-center gap-1.5 rounded-sm px-2.5 py-0.5 text-xs"
+                      style={{
+                        border: '1px solid var(--color-outline-variant)',
+                        color:
+                          activeDatasourceHealth === 'healthy'
+                            ? 'var(--color-secondary)'
+                            : activeDatasourceHealth === 'unhealthy'
+                              ? 'var(--color-error)'
+                              : 'var(--color-outline)',
+                      }}
+                      title={datasourceHealthErrors[activeDatasource.id]}
+                    >
+                      {activeDatasourceHealth === 'checking' ? (
+                        <Loader2 size={12} className="animate-spin" />
+                      ) : activeDatasourceHealth === 'healthy' ? (
+                        <HeartPulse size={12} />
+                      ) : activeDatasourceHealth === 'unhealthy' ? (
+                        <CircleAlert size={12} />
+                      ) : null}
+                      <span>{activeDatasourceHealthLabel}</span>
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-sm" style={{ color: 'var(--color-outline)' }}>
+                    No logs datasource configured
+                  </span>
+                )}
+                {showDatasourceMenu ? (
+                  <ChevronUp size={16} className="ml-1 shrink-0" style={{ color: 'var(--color-outline)' }} />
+                ) : (
+                  <ChevronDown size={16} className="ml-1 shrink-0" style={{ color: 'var(--color-outline)' }} />
+                )}
+              </button>
+
+              {showDatasourceMenu && hasLogsDatasources ? (
+                <div
+                  className="absolute top-full right-0 left-0 z-[110] mt-1.5 max-h-[280px] overflow-y-auto rounded-lg shadow-lg"
+                  style={{
+                    backgroundColor: 'var(--color-surface-bright)',
+                    border: '1px solid var(--color-outline-variant)',
+                  }}
+                >
+                  {logsDatasources.map((ds: DataSource) => (
+                    <button
+                      key={ds.id}
+                      type="button"
+                      className="flex w-full cursor-pointer items-center gap-2.5 border-none bg-transparent px-3 py-2.5 text-left transition"
+                      style={{
+                        color: 'var(--color-on-surface)',
+                        backgroundColor:
+                          ds.id === selectedDatasourceId
+                            ? 'color-mix(in srgb, var(--color-primary) 15%, transparent)'
+                            : 'transparent',
+                      }}
+                      onClick={() => selectDatasource(ds.id)}
+                    >
+                      <img
+                        src={getTypeLogo(ds.type)}
+                        alt={`${dataSourceTypeLabels[ds.type]} logo`}
+                        className="h-[18px] w-[18px] shrink-0 object-contain"
+                      />
+                      <div className="flex min-w-0 flex-col gap-px">
+                        <strong className="text-sm font-semibold">{ds.name}</strong>
+                        <span className="text-xs" style={{ color: 'var(--color-outline)' }}>
+                          {dataSourceTypeLabels[ds.type]}
+                        </span>
+                      </div>
+                      {ds.id === selectedDatasourceId ? (
+                        <Check size={14} className="ml-auto" style={{ color: 'var(--color-primary)' }} />
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2.5">
+            <span
+              className="text-xs font-semibold tracking-wide uppercase"
+              style={{ color: 'var(--color-outline)' }}
+            >
+              Query Range
+            </span>
+            <TimeRangePicker stacked />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {isClickHouseDatasource || isCloudWatchDatasource || isElasticsearchDatasource ? (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-[var(--color-on-surface)]">Query</span>
+              <MonacoQueryEditor
+                value={query}
+                onChange={setQuery}
+                onSubmit={() => void runQuery()}
+                disabled={loading || !hasLogsDatasources}
+                height={160}
+                placeholder={
+                  isClickHouseDatasource
+                    ? 'Enter SQL query...'
+                    : isCloudWatchDatasource
+                      ? 'fields @timestamp, @message | sort @timestamp desc | limit 100'
+                      : 'Enter Elasticsearch/Lucene query...'
+                }
+              />
+            </div>
+          ) : (
+            <LogQLQueryBuilder
+              value={query}
+              onChange={setQuery}
+              onSubmit={() => void runQuery()}
+              queryLanguage={queryLanguage}
+              datasourceId={selectedDatasourceId}
+              indexedLabels={indexedLabels}
+              disabled={loading || !hasLogsDatasources}
+              editorHeight={130}
+              placeholder={queryPlaceholder}
+            />
+          )}
+
+          {queryHistory.length > 0 ? (
+            <div className="relative">
+              <button
+                type="button"
+                data-testid="explore-logs-history-btn"
+                className="flex cursor-pointer items-center gap-1 border-none bg-transparent text-sm transition"
+                style={{ color: showHistory ? 'var(--color-on-surface)' : 'var(--color-outline)' }}
+                onClick={() => setShowHistory(prev => !prev)}
+                title="Query history"
+              >
+                <History size={16} />
+                <span>History</span>
+              </button>
+
+              {showHistory ? (
+                <div
+                  className="absolute top-full left-0 z-10 mt-1 max-h-[300px] w-80 overflow-y-auto rounded-lg shadow-lg max-md:w-full"
+                  style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+                >
+                  <div
+                    className="flex items-center justify-between px-4 py-3 text-xs font-semibold tracking-wide uppercase"
+                    style={{ color: 'var(--color-outline)' }}
+                  >
+                    <span>Recent Queries</span>
+                    <button
+                      type="button"
+                      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded border-none bg-transparent transition"
+                      style={{ color: 'var(--color-outline)' }}
+                      onClick={clearHistory}
+                      title="Clear history"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                  {queryHistory.map((historyQuery, index) => (
+                    <button
+                      key={`${historyQuery}-${index}`}
+                      type="button"
+                      className="block w-full cursor-pointer border-none bg-transparent px-4 py-2.5 text-left transition hover:bg-[var(--color-surface-container-high)]"
+                      onClick={() => selectHistoryQuery(historyQuery)}
+                    >
+                      <code
+                        className="block truncate font-mono text-xs"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      >
+                        {historyQuery}
+                      </code>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <button
+            type="button"
+            data-testid="explore-logs-run-query-btn"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-sm px-5 py-2.5 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ backgroundColor: 'var(--color-primary)' }}
+            disabled={loading || !query.trim() || !selectedDatasourceId || !hasLogsDatasources}
+            onClick={() => void runQuery()}
+          >
+            <Play size={16} />
+            <span>{loading ? 'Running...' : 'Run Query'}</span>
+          </button>
+
+          <button
+            type="button"
+            className={`inline-flex items-center gap-2 rounded-sm border px-4 py-2.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50 ${
+              isLive
+                ? 'border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 text-[var(--color-primary)]'
+                : 'border-[var(--color-outline-variant)] bg-[var(--color-surface-container-low)] text-[var(--color-on-surface)]'
+            }`}
+            data-testid="explore-logs-live-btn"
+            disabled={
+              loading ||
+              !supportsLiveStreaming ||
+              (!isLive && (!query.trim() || !selectedDatasourceId || !hasLogsDatasources))
+            }
+            onClick={toggleLive}
+            title={
+              supportsLiveStreaming
+                ? ''
+                : 'Live streaming is only available for Loki and Victoria Logs datasources'
+            }
+          >
+            {isLiveBusy ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : isLive ? (
+              <X size={16} />
+            ) : (
+              <HeartPulse size={16} />
+            )}
+            <span>{isLive ? 'Stop Live' : 'Start Live'}</span>
+          </button>
+
+          {query.trim() ? (
+            <button
+              type="button"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm border px-3 py-2.5 text-sm transition"
+              style={{
+                backgroundColor: isFavorite(favoriteId)
+                  ? 'var(--color-primary-muted)'
+                  : 'var(--color-surface-container-high)',
+                borderColor: isFavorite(favoriteId)
+                  ? 'var(--color-primary)'
+                  : 'var(--color-stroke-subtle)',
+                color: isFavorite(favoriteId)
+                  ? 'var(--color-primary)'
+                  : 'var(--color-on-surface-variant)',
+              }}
+              title={isFavorite(favoriteId) ? 'Remove from favorites' : 'Save to favorites'}
+              onClick={() =>
+                toggleFavorite({
+                  id: favoriteId,
+                  title: query.length > 40 ? `${query.slice(0, 40)}...` : query,
+                  type: 'explore',
+                })
+              }
+            >
+              <Star size={14} fill={isFavorite(favoriteId) ? 'currentColor' : 'none'} />
+            </button>
+          ) : null}
+
+          <button
+            type="button"
+            data-testid="explore-logs-export-btn"
+            className="inline-flex items-center gap-2 rounded-sm border border-[var(--color-outline-variant)] bg-transparent px-4 py-2.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
+            style={{
+              color: query.trim() ? 'var(--color-on-surface-variant)' : 'var(--color-outline)',
+            }}
+            disabled={!query.trim() || !selectedDatasourceId}
+            onClick={() => setShowExportModal(true)}
+          >
+            <LayoutDashboard size={16} />
+            <span>Add to Dashboard</span>
+          </button>
+
+          <span className="text-xs" style={{ color: 'var(--color-outline)' }}>
+            Ctrl+Enter to run
+          </span>
+
+          {liveStatusLabel ? (
+            <span
+              className={`inline-flex items-center rounded-sm border px-2.5 py-0.5 text-xs ${
+                liveState === 'connected'
+                  ? 'border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 text-[var(--color-primary)]'
+                  : 'border-[var(--color-outline-variant)] bg-[var(--color-surface)] text-[var(--color-outline)]'
+              }`}
+            >
+              {liveStatusLabel}
+            </span>
+          ) : null}
+        </div>
+
+        {error ? (
+          <div
+            className="flex items-center gap-2 rounded border p-4 text-sm"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--color-error) 25%, transparent)',
+              backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+              color: 'var(--color-error)',
+            }}
+          >
+            <AlertCircle size={16} />
+            <span>{error}</span>
+          </div>
+        ) : liveError && isLive ? (
+          <div className="flex items-center gap-2 rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+            <AlertCircle size={16} />
+            <span>{liveError}</span>
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        className="flex min-h-[400px] flex-1 flex-col overflow-hidden rounded-lg"
+        style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+      >
+        {loading ? (
+          <div
+            className="flex flex-1 flex-col items-center justify-center gap-4 py-12"
+            style={{ color: 'var(--color-outline)' }}
+          >
+            <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-t-[var(--color-primary)]" />
+            <span className="text-sm">Executing query...</span>
+          </div>
+        ) : hasResults ? (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div
+              className="flex items-center justify-between px-4 py-3"
+              style={{ backgroundColor: 'var(--color-surface-container-high)' }}
+            >
+              <span className="text-sm" style={{ color: 'var(--color-outline)' }}>
+                {logs.length} {logs.length === 1 ? 'entry' : 'entries'}
+              </span>
+              {liveStatusLabel ? (
+                <span
+                  className={`inline-flex items-center gap-1.5 rounded-sm border px-2.5 py-0.5 text-xs ${
+                    liveState === 'connected'
+                      ? 'border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 text-[var(--color-primary)]'
+                      : 'border-[var(--color-outline-variant)] bg-[var(--color-surface)] text-[var(--color-outline)]'
+                  }`}
+                >
+                  <span
+                    className={`h-1.5 w-1.5 rounded-full bg-current ${
+                      liveState === 'connected' ? 'animate-pulse' : ''
+                    }`}
+                  />
+                  {liveStatusLabel}
+                </span>
+              ) : null}
+            </div>
+            <div className="min-h-0 flex-1 p-4">
+              <LogViewer
+                logs={newestFirstLogs}
+                highlightedLogKeys={highlightedLogKeyList}
+                traceIdField={activeDatasource?.trace_id_field || 'trace_id'}
+                linkedTraceDatasourceId={activeDatasource?.linked_trace_datasource_id || null}
+              />
+            </div>
+          </div>
+        ) : hasSuccessfulQuery && logs.length === 0 ? (
+          <div
+            className="flex flex-1 flex-col items-center justify-center py-12 text-center text-sm"
+            style={{ color: 'var(--color-outline)' }}
+          >
+            <p className="m-0">No logs returned for the selected time range.</p>
+          </div>
+        ) : !hasLogsDatasources ? (
+          <div
+            className="flex flex-1 flex-col items-center justify-center py-12 text-center text-sm"
+            style={{ color: 'var(--color-outline)' }}
+          >
+            <p className="m-0">No logs datasource configured.</p>
+            <p className="m-0 text-xs">
+              Add a Loki, Victoria Logs, CloudWatch, or Elasticsearch datasource in Data Sources.
+            </p>
+          </div>
+        ) : (
+          <div
+            className="flex flex-1 flex-col items-center justify-center py-12 text-center text-sm"
+            style={{ color: 'var(--color-outline)' }}
+          >
+            <p className="m-0">
+              {isClickHouseDatasource
+                ? 'Write a SQL query and click "Run Query" to inspect logs.'
+                : isCloudWatchDatasource
+                  ? 'Write a CloudWatch Logs Insights query and click "Run Query" to inspect logs.'
+                  : isElasticsearchDatasource
+                    ? 'Write an Elasticsearch/Lucene query and click "Run Query" to inspect logs.'
+                    : 'Write a log query and click "Run Query" to inspect logs.'}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {showExportModal ? (
+        <ExportToDashboardModal
+          query={query}
+          signal="logs"
+          datasourceId={selectedDatasourceId}
+          onClose={() => setShowExportModal(false)}
+        />
+      ) : null}
+    </section>
+  )
+}

--- a/frontend/src/components/MetricsExplorePanel.tsx
+++ b/frontend/src/components/MetricsExplorePanel.tsx
@@ -444,7 +444,6 @@ export function MetricsExplorePanel({ onDatasourceChanged }: MetricsExplorePanel
     )
   }, [metricsDatasources])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: run when navigation/health context for active datasource changes
   useEffect(() => {
     if (!activeDatasource) return
 

--- a/frontend/src/hooks/useLogsDatasources.ts
+++ b/frontend/src/hooks/useLogsDatasources.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { useDatasources } from '@/hooks/useDatasources'
+import { isLogsType } from '@/types/datasource'
+
+export function useLogsDatasources(orgId: string | null) {
+  const query = useDatasources(orgId)
+
+  const logsDatasources = useMemo(
+    () => (query.data ?? []).filter(ds => isLogsType(ds.type)),
+    [query.data],
+  )
+
+  return {
+    ...query,
+    logsDatasources,
+  }
+}

--- a/frontend/src/pages/ExplorePage.spec.tsx
+++ b/frontend/src/pages/ExplorePage.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
@@ -55,6 +55,37 @@ vi.mock('@/components/QueryBuilder', () => ({
   ),
 }))
 
+vi.mock('@/components/LogQLQueryBuilder', () => ({
+  LogQLQueryBuilder: ({
+    value,
+    onChange,
+    disabled,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    disabled?: boolean
+  }) => (
+    <input
+      data-testid="logql-query-builder-mock"
+      value={value}
+      disabled={disabled}
+      onChange={event => onChange(event.target.value)}
+    />
+  ),
+}))
+
+vi.mock('@/components/LogViewer', () => ({
+  LogViewer: ({ logs }: { logs: Array<{ line: string }> }) => (
+    <div data-testid="log-viewer-mock" data-log-count={logs.length}>
+      {logs.map(log => (
+        <div key={log.line} data-testid="log-viewer-row-mock">
+          {log.line}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
 vi.mock('echarts/core', () => ({
   init: vi.fn(() => ({
     setOption: vi.fn(),
@@ -82,12 +113,25 @@ vi.mock('echarts/components', () => ({
   GridComponent: {},
 }))
 
-const mockDatasource: DataSource = {
+const mockMetricsDatasource: DataSource = {
   id: 'ds-1',
   organization_id: 'org-1',
   name: 'Prometheus Prod',
   type: 'prometheus',
   url: 'http://prometheus:9090',
+  is_default: true,
+  auth_type: 'none',
+  trace_id_field: 'trace_id',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const mockLogsDatasource: DataSource = {
+  id: 'ds-logs-1',
+  organization_id: 'org-1',
+  name: 'Loki Prod',
+  type: 'loki',
+  url: 'http://loki:3100',
   is_default: true,
   auth_type: 'none',
   trace_id_field: 'trace_id',
@@ -141,7 +185,7 @@ describe('ExplorePage', () => {
     useTimeRangeStore.getState()._reset()
 
     vi.spyOn(dashboardsApi, 'listDashboards').mockResolvedValue([])
-    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([mockDatasource])
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([mockMetricsDatasource])
     vi.spyOn(datasourcesApi, 'fetchDataSourceMetricNames').mockResolvedValue(['up', 'http_requests_total'])
     vi.spyOn(datasourcesApi, 'fetchDataSourceLabels').mockResolvedValue(['instance', 'job'])
     vi.spyOn(datasourcesApi, 'fetchDataSourceLabelValues').mockResolvedValue(['localhost:9090'])
@@ -170,19 +214,81 @@ describe('ExplorePage', () => {
     expect(screen.getByTestId('time-range-picker-btn')).toBeTruthy()
   })
 
-  it('shows placeholder for logs and traces tabs', async () => {
+  it('shows placeholder for traces tab', async () => {
     const user = userEvent.setup()
     renderExplore()
 
     await waitFor(() => {
-      expect(screen.getByTestId('explore-tab-logs')).toBeTruthy()
+      expect(screen.getByTestId('explore-tab-traces')).toBeTruthy()
     })
-
-    await user.click(screen.getByTestId('explore-tab-logs'))
-    expect(screen.getByTestId('explore-placeholder-logs')).toBeTruthy()
 
     await user.click(screen.getByTestId('explore-tab-traces'))
     expect(screen.getByTestId('explore-placeholder-traces')).toBeTruthy()
+  })
+
+  it('renders logs explore tab at /app/explore/logs', async () => {
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([mockLogsDatasource])
+    renderExplore('/app/explore/logs')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('explore-logs-datasource-btn')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('time-range-picker-btn')).toBeTruthy()
+    expect(screen.getByTestId('explore-logs-run-query-btn')).toBeTruthy()
+  })
+
+  it('executes a logs query and renders log rows with mocked API', async () => {
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([mockLogsDatasource])
+    vi.spyOn(datasourcesApi, 'queryDataSource').mockImplementation(async (_id, payload) => {
+      if (payload.query === '{job=~".+"}') {
+        return {
+          status: 'success',
+          resultType: 'logs',
+          data: {
+            resultType: 'logs',
+            logs: [
+              {
+                timestamp: '2026-01-01T12:00:00Z',
+                line: 'error connecting to database',
+                labels: { job: 'api' },
+                level: 'error',
+              },
+            ],
+          },
+        } satisfies DataSourceQueryResult
+      }
+      return {
+        status: 'success',
+        resultType: 'logs',
+        data: { resultType: 'logs', logs: [] },
+      } satisfies DataSourceQueryResult
+    })
+
+    renderExplore('/app/explore/logs')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('explore-logs-datasource-btn').textContent).toContain('Loki Prod')
+    })
+
+    const queryInput = await screen.findByTestId('logql-query-builder-mock')
+    fireEvent.change(queryInput, { target: { value: '{job=~".+"}' } })
+
+    fireEvent.click(screen.getByTestId('explore-logs-run-query-btn'))
+
+    await waitFor(() => {
+      expect(datasourcesApi.queryDataSource).toHaveBeenCalledWith(
+        'ds-logs-1',
+        expect.objectContaining({ query: '{job=~".+"}' }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('log-viewer-mock')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('log-viewer-mock').getAttribute('data-log-count')).toBe('1')
+    expect(screen.getByText('error connecting to database')).toBeTruthy()
   })
 
   it('executes a query and renders chart results with mocked API', async () => {

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { LogsExplorePanel } from '@/components/LogsExplorePanel'
 import { MetricsExplorePanel } from '@/components/MetricsExplorePanel'
 
 type ExploreType = 'metrics' | 'logs' | 'traces'
@@ -66,6 +67,8 @@ export function ExplorePage() {
 
       {activeType === 'metrics' ? (
         <MetricsExplorePanel key="metrics" />
+      ) : activeType === 'logs' ? (
+        <LogsExplorePanel key="logs" />
       ) : (
         <div
           className="flex flex-1 flex-col items-center justify-center rounded-lg py-16 text-center"
@@ -73,11 +76,9 @@ export function ExplorePage() {
             backgroundColor: 'var(--color-surface-container-low)',
             color: 'var(--color-outline)',
           }}
-          data-testid={`explore-placeholder-${activeType}`}
+          data-testid="explore-placeholder-traces"
         >
-          <p className="m-0 text-sm">
-            {activeType === 'logs' ? 'Logs explore' : 'Traces explore'} is coming soon.
-          </p>
+          <p className="m-0 text-sm">Traces explore is coming soon.</p>
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #299

Part of the [Vue → React frontend rewrite](https://github.com/aceobservability/ace/issues/292) map. Stacked on #321 (`issue-298-metrics-explore`).

## Summary

Ports the logs explore experience from Vue to React at `/app/explore/logs`.

## Delivered

- `LogsExplorePanel` — datasource picker with health checks, query history, favorites, run/live/export controls, time range with auto-refresh
- `LogQLQueryBuilder` — visual builder + Monaco code editor for Loki/Victoria Logs; Monaco fallback for ClickHouse/CloudWatch/Elasticsearch
- `LogViewer` — expandable rows with detected JSON/key-value fields, labels, timestamps, trace drill-down links
- `useLogsDatasources` — org-scoped logs datasource filtering
- Live tail streaming for Loki and Victoria Logs via SSE
- `ExplorePage` wired to render `LogsExplorePanel` on the logs tab

## Acceptance criteria

- [x] Logs explore tab reachable at `/app/explore/logs`
- [x] LogQL query builder and Monaco editor
- [x] Log viewer with expandable rows, labels, and timestamps
- [x] Time range picker and live tail / refresh
- [x] Datasource selector respects org scope
- [x] RTL tests cover search and log row rendering with mocked API

## Verification

- `npm run build` — green
- `npm run type-check` — green
- `npm run test` — 336 tests green