### PR TITLE
feat(frontend): traces explore and dashboard library (#300, #301)

### DIFF
--- a/frontend/src/components/ClickHouseSQLEditor.tsx
+++ b/frontend/src/components/ClickHouseSQLEditor.tsx
@@ -1,0 +1,134 @@
+type ClickHouseSignal = 'logs' | 'metrics' | 'traces'
+
+type ClickHouseSQLEditorProps = {
+  value: string
+  onChange: (value: string) => void
+  signal?: ClickHouseSignal
+  disabled?: boolean
+  showSignalSelector?: boolean
+  onSignalChange?: (signal: ClickHouseSignal) => void
+}
+
+const sqlExamples: Record<ClickHouseSignal, string> = {
+  logs: 'SELECT Timestamp AS timestamp, Body AS message, SeverityText AS level\nFROM ace_logs\nWHERE Timestamp >= toDateTime({start}) AND Timestamp <= toDateTime({end})\nORDER BY Timestamp DESC\nLIMIT 500',
+  metrics:
+    'SELECT toStartOfInterval(TimeUnix, INTERVAL 1 minute) AS timestamp, avg(Value) AS value, MetricName AS metric\nFROM otel_metrics_gauge\nWHERE TimeUnix >= fromUnixTimestamp({start}) AND TimeUnix <= fromUnixTimestamp({end})\nGROUP BY timestamp, metric\nORDER BY timestamp',
+  traces:
+    'SELECT SpanId AS span_id, ParentSpanId AS parent_span_id, SpanName AS operation_name, ServiceName AS service_name, toUnixTimestamp64Nano(Timestamp) AS start_time_unix_nano, Duration AS duration_nano, StatusCode AS status\nFROM ace_traces\nWHERE Timestamp BETWEEN fromUnixTimestamp64Nano({start_ns}) AND fromUnixTimestamp64Nano({end_ns})\nLIMIT 200',
+}
+
+const columnGuides: Record<ClickHouseSignal, string[]> = {
+  logs: ['timestamp', 'message', 'level (optional)'],
+  metrics: ['timestamp', 'value', 'metric (optional)'],
+  traces: [
+    'span_id',
+    'parent_span_id (optional)',
+    'operation_name',
+    'service_name',
+    'start_time_unix_nano',
+    'duration_nano',
+    'status (optional)',
+  ],
+}
+
+export function ClickHouseSQLEditor({
+  value,
+  onChange,
+  signal = 'metrics',
+  disabled = false,
+  showSignalSelector = false,
+  onSignalChange,
+}: ClickHouseSQLEditorProps) {
+  const placeholder = sqlExamples[signal]
+  const expectedColumns = columnGuides[signal]
+
+  return (
+    <div
+      className={`flex flex-col gap-3.5 ${disabled ? 'pointer-events-none opacity-60' : ''}`}
+    >
+      {showSignalSelector ? (
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="clickhouse-signal" className="text-sm font-medium text-[var(--color-on-surface)]">
+            Signal Type
+          </label>
+          <select
+            id="clickhouse-signal"
+            value={signal}
+            data-testid="clickhouse-signal-select"
+            disabled={disabled}
+            className="w-full cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-sm text-[var(--color-on-surface)] transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:bg-[var(--color-surface-container-high)] disabled:text-[var(--color-outline)]"
+            onChange={event => onSignalChange?.(event.target.value as ClickHouseSignal)}
+          >
+            <option value="logs">Logs</option>
+            <option value="metrics">Metrics</option>
+            <option value="traces">Traces</option>
+          </select>
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="clickhouse-query" className="text-sm font-medium text-[var(--color-on-surface)]">
+          SQL
+        </label>
+        <textarea
+          id="clickhouse-query"
+          value={value}
+          data-testid="clickhouse-query-input"
+          disabled={disabled}
+          placeholder={placeholder}
+          rows={7}
+          spellCheck={false}
+          className="min-h-[140px] w-full resize-y rounded-sm bg-[var(--color-surface-container-low)] px-3.5 py-3 font-mono text-sm leading-relaxed text-[var(--color-on-surface)] transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:bg-[var(--color-surface-container-high)] disabled:text-[var(--color-outline)]"
+          onChange={event => onChange(event.target.value)}
+        />
+      </div>
+
+      <div className="rounded-sm bg-[var(--color-surface-container-high)] px-3.5 py-3">
+        <p className="m-0 text-xs text-[var(--color-outline)]">
+          Expected columns for {signal} queries:
+        </p>
+        <p className="mb-0 mt-2 flex flex-wrap gap-1.5">
+          {expectedColumns.map(column => (
+            <code
+              key={column}
+              className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]"
+            >
+              {column}
+            </code>
+          ))}
+        </p>
+        <p className="mb-0 mt-2.5 text-xs leading-relaxed text-[var(--color-outline)]">
+          Time placeholders supported:{' '}
+          <code className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]">
+            {'{start}'}
+          </code>
+          ,{' '}
+          <code className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]">
+            {'{end}'}
+          </code>
+          ,{' '}
+          <code className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]">
+            {'{step}'}
+          </code>
+          ,{' '}
+          <code className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]">
+            {'{start_ms}'}
+          </code>
+          ,{' '}
+          <code className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]">
+            {'{end_ms}'}
+          </code>
+          ,{' '}
+          <code className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]">
+            {'{start_ns}'}
+          </code>
+          ,{' '}
+          <code className="inline-flex items-center rounded border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface-variant)]">
+            {'{end_ns}'}
+          </code>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/CreateDashboardModal.spec.tsx
+++ b/frontend/src/components/CreateDashboardModal.spec.tsx
@@ -1,0 +1,231 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as converterApi from '@/api/converter'
+import * as dashboardApi from '@/api/dashboards'
+import { CreateDashboardModal } from '@/components/CreateDashboardModal'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+
+vi.mock('@/hooks/useOrganization', () => ({
+  useOrganization: () => ({
+    currentOrgId: 'org-1',
+    currentOrg: {
+      id: 'org-1',
+      name: 'Acme',
+      slug: 'acme',
+      role: 'admin' as const,
+      created_at: '2026-02-08T00:00:00Z',
+      updated_at: '2026-02-08T00:00:00Z',
+    },
+  }),
+}))
+
+vi.mock('@/hooks/useDatasources', () => ({
+  useDatasources: () => ({ data: [] }),
+}))
+
+function renderModal(props: Partial<React.ComponentProps<typeof CreateDashboardModal>> = {}) {
+  const onClose = props.onClose ?? vi.fn()
+  const onCreated = props.onCreated ?? vi.fn()
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: (
+          <CreateDashboardModal
+            initialMode={props.initialMode}
+            onClose={onClose}
+            onCreated={onCreated}
+          />
+        ),
+      },
+      { path: '/app/dashboards/new/ai', element: <div>AI generation</div> },
+    ],
+    { initialEntries: ['/'] },
+  )
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  return { onClose, onCreated, router }
+}
+
+describe('CreateDashboardModal', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows both Blank Dashboard and Generate with AI options', () => {
+    renderModal()
+    expect(screen.getByText('Blank Dashboard')).toBeTruthy()
+    expect(screen.getByText('Generate with AI')).toBeTruthy()
+  })
+
+  it('navigates to AI generation route on Generate with AI click', async () => {
+    const { router, onClose } = renderModal()
+    await userEvent.click(screen.getByText('Generate with AI'))
+    expect(onClose).toHaveBeenCalled()
+    expect(router.state.location.pathname).toBe('/app/dashboards/new/ai')
+  })
+
+  it('renders form fields when Blank Dashboard is selected', async () => {
+    renderModal()
+    await userEvent.click(screen.getByText('Blank Dashboard'))
+    expect(screen.getByLabelText(/Title/)).toBeTruthy()
+    expect(screen.getByLabelText('Description')).toBeTruthy()
+  })
+
+  it('calls onClose when close button is clicked', async () => {
+    const { onClose } = renderModal()
+    await userEvent.click(screen.getByTestId('create-dashboard-close-btn'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows error when title is empty on blank dashboard submit', async () => {
+    renderModal()
+    await userEvent.click(screen.getByText('Blank Dashboard'))
+    await userEvent.click(screen.getByTestId('create-dashboard-submit-btn'))
+    expect(screen.getByText('Title is required')).toBeTruthy()
+  })
+
+  it('calls createDashboard API on blank dashboard submit', async () => {
+    vi.spyOn(dashboardApi, 'createDashboard').mockResolvedValue({
+      id: '123',
+      title: 'New Dashboard',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    })
+    const { onCreated } = renderModal()
+
+    await userEvent.click(screen.getByText('Blank Dashboard'))
+    await userEvent.type(screen.getByTestId('create-dashboard-title-input'), 'New Dashboard')
+    await userEvent.type(screen.getByTestId('create-dashboard-description-input'), 'Description')
+    await userEvent.click(screen.getByTestId('create-dashboard-submit-btn'))
+
+    await waitFor(() => {
+      expect(dashboardApi.createDashboard).toHaveBeenCalledWith('org-1', {
+        title: 'New Dashboard',
+        description: 'Description',
+      })
+      expect(onCreated).toHaveBeenCalled()
+    })
+  })
+
+  it('shows error on API failure', async () => {
+    vi.spyOn(dashboardApi, 'createDashboard').mockRejectedValue(
+      new Error('Failed to create dashboard'),
+    )
+    renderModal()
+
+    await userEvent.click(screen.getByText('Blank Dashboard'))
+    await userEvent.type(screen.getByTestId('create-dashboard-title-input'), 'New Dashboard')
+    await userEvent.click(screen.getByTestId('create-dashboard-submit-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create dashboard')).toBeTruthy()
+    })
+  })
+
+  it('imports dashboard from yaml file', async () => {
+    vi.spyOn(dashboardApi, 'importDashboardYaml').mockResolvedValue({
+      id: 'imported-1',
+      title: 'Imported Dashboard',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    })
+    const { onCreated } = renderModal()
+
+    await userEvent.click(screen.getByText('Blank Dashboard'))
+    await userEvent.click(screen.getByTestId('create-mode-import-btn'))
+
+    const file = new File(
+      [
+        'version: 2\ntitle: Imported Dashboard\npanels:\n  - title: Requests\n    type: line_chart\n  - title: Errors\n    type: stat\n',
+      ],
+      'dashboard.yaml',
+      { type: 'application/x-yaml' },
+    )
+
+    const input = document.getElementById('yaml-file') as HTMLInputElement
+    await userEvent.upload(input, file)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('yaml-preview')).toBeTruthy()
+      expect(screen.getByText(/2 panels/)).toBeTruthy()
+    })
+
+    await userEvent.click(screen.getByTestId('create-dashboard-submit-btn'))
+
+    await waitFor(() => {
+      expect(dashboardApi.importDashboardYaml).toHaveBeenCalledWith(
+        'org-1',
+        expect.stringContaining('title: Imported Dashboard'),
+      )
+      expect(onCreated).toHaveBeenCalled()
+    })
+  })
+
+  it('imports dashboard from grafana json conversion', async () => {
+    vi.spyOn(converterApi, 'convertGrafanaDashboard').mockResolvedValue({
+      format: 'yaml',
+      content: 'version: 2\ntitle: Converted Dashboard\npanels:\n  - title: Requests\n',
+      document: {
+        version: 2,
+        title: 'Converted Dashboard',
+        description: 'From Grafana',
+        panels: [
+          {
+            title: 'Requests',
+            type: 'line_chart',
+            position: { x: 0, y: 0, w: 24, h: 8 },
+          },
+        ],
+      },
+      warnings: ['Converted unsupported panel type'],
+    })
+    vi.spyOn(dashboardApi, 'importDashboardYaml').mockResolvedValue({
+      id: 'converted-1',
+      title: 'Converted Dashboard',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    })
+    const { onCreated } = renderModal()
+
+    await userEvent.click(screen.getByText('Blank Dashboard'))
+    await userEvent.click(screen.getByTestId('create-mode-grafana-btn'))
+    fireEvent.change(screen.getByTestId('grafana-source'), {
+      target: { value: '{"dashboard":{"title":"grafana"}}' },
+    })
+    await userEvent.click(screen.getByTestId('grafana-convert'))
+
+    await waitFor(() => {
+      expect(converterApi.convertGrafanaDashboard).toHaveBeenCalledWith(
+        '{"dashboard":{"title":"grafana"}}',
+        'yaml',
+      )
+      expect(screen.getByTestId('yaml-preview').textContent).toContain('Converted Dashboard')
+      expect(screen.getByTestId('grafana-warnings').textContent).toContain('unsupported panel type')
+    })
+
+    await userEvent.click(screen.getByTestId('create-dashboard-submit-btn'))
+
+    await waitFor(() => {
+      expect(dashboardApi.importDashboardYaml).toHaveBeenCalledWith(
+        'org-1',
+        expect.stringContaining('version: 2'),
+      )
+      expect(onCreated).toHaveBeenCalled()
+    })
+  })
+
+  it('has glassmorphic modal styling', () => {
+    renderModal()
+    expect(screen.getByTestId('create-dashboard-modal')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/CreateDashboardModal.tsx
+++ b/frontend/src/components/CreateDashboardModal.tsx
@@ -262,13 +262,16 @@ export function CreateDashboardModal({
     }
   }
 
-  async function convertGrafana() {
+  async function convertGrafana(sourceOverride?: string) {
     if (!currentOrgId) {
       setError('No organization selected')
       return
     }
 
-    if (!grafanaSource.trim()) {
+    // Prefer an explicit override so callers that just setGrafanaSource can
+    // convert immediately without waiting for the async state update.
+    const source = sourceOverride ?? grafanaSource
+    if (!source.trim()) {
       setError('Paste or upload Grafana JSON before converting')
       return
     }
@@ -278,12 +281,12 @@ export function CreateDashboardModal({
     clearImportState()
 
     try {
-      const response = await convertGrafanaDashboard(grafanaSource, 'yaml')
+      const response = await convertGrafanaDashboard(source, 'yaml')
       setYamlContent(response.content)
       setGrafanaWarnings(response.warnings)
       setConversionReport(response.report ?? null)
       setImportPreviewFromDocument(response.document)
-      extractGrafanaDatasources(grafanaSource)
+      extractGrafanaDatasources(source)
       setConvertedVariables([])
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to convert Grafana dashboard')
@@ -299,7 +302,7 @@ export function CreateDashboardModal({
       const dashJson = await getGrafanaDashboard(uid, grafanaUrl, grafanaApiKey)
       setGrafanaSource(dashJson)
       setGrafanaFileName(`${uid}.json`)
-      await convertGrafana()
+      await convertGrafana(dashJson)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to fetch dashboard')
     } finally {

--- a/frontend/src/components/CreateDashboardModal.tsx
+++ b/frontend/src/components/CreateDashboardModal.tsx
@@ -1,0 +1,1019 @@
+import { Globe, Loader2, Upload, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
+import { convertGrafanaDashboard } from '@/api/converter'
+import { createDashboard, importDashboardYaml } from '@/api/dashboards'
+import {
+  connectToGrafana,
+  getGrafanaDashboard,
+  listGrafanaDashboards,
+  type GrafanaDashboardSummary,
+} from '@/api/grafanaDiscovery'
+import { bulkCreateVariables } from '@/api/variables'
+import { useDatasources } from '@/hooks/useDatasources'
+import { useOrganization } from '@/hooks/useOrganization'
+import type { ConversionReport } from '@/types/converter'
+
+type CreationMode = 'create' | 'import' | 'grafana'
+type ModalStep = 'choice' | 'form'
+type GrafanaSubTab = 'upload' | 'connect'
+
+type ImportPreview = {
+  title: string
+  description: string
+  panelCount: number
+}
+
+type CreateDashboardModalProps = {
+  initialMode?: CreationMode
+  onClose: () => void
+  onCreated: () => void
+}
+
+function normalizeYamlValue(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+function buildYamlPreview(rawYaml: string): ImportPreview {
+  const versionMatch = rawYaml.match(/(?:^|\n)version:\s*(.+)/)
+  if (!versionMatch) {
+    throw new Error('Missing version')
+  }
+
+  const titleMatch = rawYaml.match(/(?:^|\n)title:\s*(.+)/)
+  if (!titleMatch) {
+    throw new Error('Missing dashboard title')
+  }
+
+  const extractedTitle = normalizeYamlValue(titleMatch[1] ?? '')
+  if (!extractedTitle) {
+    throw new Error('Dashboard title is empty')
+  }
+
+  const descriptionMatch = rawYaml.match(/(?:^|\n)description:\s*(.+)/)
+  const panelsSectionMatch = rawYaml.match(
+    /(?:^|\n)panels:\s*\n([\s\S]*?)(?=\n[a-zA-Z_][\w-]*:\s*|\s*$)/,
+  )
+  const panelCount = (panelsSectionMatch?.[1]?.match(/(?:^|\n)\s{2}-\s+/g) ?? []).length
+
+  return {
+    title: extractedTitle,
+    description: normalizeYamlValue(descriptionMatch?.[1] ?? ''),
+    panelCount,
+  }
+}
+
+export function CreateDashboardModal({
+  initialMode = 'create',
+  onClose,
+  onCreated,
+}: CreateDashboardModalProps) {
+  const navigate = useNavigate()
+  const { currentOrgId } = useOrganization()
+  const { data: aceDatasources = [] } = useDatasources(currentOrgId)
+
+  const [step, setStep] = useState<ModalStep>('choice')
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [mode, setMode] = useState<CreationMode>(initialMode)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [yamlFileName, setYamlFileName] = useState('')
+  const [yamlContent, setYamlContent] = useState('')
+  const [grafanaFileName, setGrafanaFileName] = useState('')
+  const [grafanaSource, setGrafanaSource] = useState('')
+  const [grafanaWarnings, setGrafanaWarnings] = useState<string[]>([])
+  const [convertingGrafana, setConvertingGrafana] = useState(false)
+  const [grafanaSubTab, setGrafanaSubTab] = useState<GrafanaSubTab>('upload')
+  const [conversionReport, setConversionReport] = useState<ConversionReport | null>(null)
+  const [grafanaUrl, setGrafanaUrl] = useState('')
+  const [grafanaApiKey, setGrafanaApiKey] = useState('')
+  const [grafanaConnecting, setGrafanaConnecting] = useState(false)
+  const [grafanaConnected, setGrafanaConnected] = useState(false)
+  const [grafanaVersion, setGrafanaVersion] = useState('')
+  const [remoteDashboards, setRemoteDashboards] = useState<GrafanaDashboardSummary[]>([])
+  const [loadingRemoteDashboard, setLoadingRemoteDashboard] = useState(false)
+  const [grafanaDatasourceNames, setGrafanaDatasourceNames] = useState<string[]>([])
+  const [datasourceMapping, setDatasourceMapping] = useState<Record<string, string>>({})
+  const [convertedVariables, setConvertedVariables] = useState<
+    Array<{
+      name: string
+      type: string
+      label?: string
+      query?: string
+      multi: boolean
+      include_all: boolean
+    }>
+  >([])
+  const [importPreview, setImportPreview] = useState<ImportPreview | null>(null)
+
+  const submitLabel = useMemo(() => {
+    if (loading) {
+      return mode === 'create' ? 'Creating...' : 'Importing...'
+    }
+    return mode === 'create' ? 'Create Dashboard' : 'Import Dashboard'
+  }, [loading, mode])
+
+  const canConvertGrafana =
+    grafanaSource.trim().length > 0 && !convertingGrafana && !loading
+
+  function setImportPreviewFromDocument(document: {
+    title: string
+    description?: string
+    panels: unknown[]
+  }) {
+    setImportPreview({
+      title: document.title,
+      description: document.description ?? '',
+      panelCount: document.panels.length,
+    })
+  }
+
+  function clearImportState() {
+    setYamlContent('')
+    setYamlFileName('')
+    setImportPreview(null)
+    setGrafanaWarnings([])
+  }
+
+  function chooseBlank() {
+    setStep('form')
+    setMode('create')
+  }
+
+  function chooseAI() {
+    onClose()
+    navigate('/app/dashboards/new/ai')
+  }
+
+  function setModeAndClearError(nextMode: CreationMode) {
+    setMode(nextMode)
+    setError(null)
+  }
+
+  async function handleYamlFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0]
+    clearImportState()
+    setError(null)
+
+    if (!file) return
+
+    const lowerName = file.name.toLowerCase()
+    if (!lowerName.endsWith('.yaml') && !lowerName.endsWith('.yml')) {
+      setError('Please upload a .yaml or .yml file')
+      return
+    }
+
+    try {
+      const content = await file.text()
+      if (!content.trim()) {
+        setError('YAML file is empty')
+        return
+      }
+
+      setImportPreview(buildYamlPreview(content))
+      setYamlContent(content)
+      setYamlFileName(file.name)
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : 'Expected dashboard document format'
+      setError(`Invalid YAML file. ${reason}`)
+    }
+  }
+
+  async function handleGrafanaFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0]
+    setGrafanaSource('')
+    setGrafanaFileName('')
+    clearImportState()
+    setError(null)
+
+    if (!file) return
+
+    const lowerName = file.name.toLowerCase()
+    if (!lowerName.endsWith('.json')) {
+      setError('Please upload a .json file')
+      return
+    }
+
+    try {
+      const content = await file.text()
+      if (!content.trim()) {
+        setError('Grafana JSON file is empty')
+        return
+      }
+      setGrafanaSource(content)
+      setGrafanaFileName(file.name)
+    } catch {
+      setError('Failed to read selected Grafana file')
+    }
+  }
+
+  async function handleGrafanaConnect() {
+    if (!grafanaUrl.trim()) {
+      setError('Grafana URL is required')
+      return
+    }
+    setGrafanaConnecting(true)
+    setError(null)
+    try {
+      const resp = await connectToGrafana(grafanaUrl, grafanaApiKey)
+      if (!resp.ok) {
+        setError(resp.error || 'Failed to connect to Grafana')
+        return
+      }
+      setGrafanaConnected(true)
+      setGrafanaVersion(resp.version || '')
+      setRemoteDashboards(await listGrafanaDashboards(grafanaUrl, grafanaApiKey))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Connection failed')
+    } finally {
+      setGrafanaConnecting(false)
+    }
+  }
+
+  function extractGrafanaDatasources(jsonContent: string) {
+    try {
+      const parsed = JSON.parse(jsonContent) as {
+        dashboard?: { panels?: Array<{ datasource?: string | { uid?: string; type?: string } }> }
+        panels?: Array<{ datasource?: string | { uid?: string; type?: string } }>
+      }
+      const panels = parsed.dashboard?.panels ?? parsed.panels ?? []
+      const names = new Set<string>()
+      for (const panel of panels) {
+        if (panel.datasource) {
+          const name =
+            typeof panel.datasource === 'string'
+              ? panel.datasource
+              : panel.datasource?.uid || panel.datasource?.type || ''
+          if (name && name !== '-- Mixed --') names.add(name)
+        }
+      }
+      setGrafanaDatasourceNames(Array.from(names))
+    } catch {
+      setGrafanaDatasourceNames([])
+    }
+  }
+
+  async function convertGrafana() {
+    if (!currentOrgId) {
+      setError('No organization selected')
+      return
+    }
+
+    if (!grafanaSource.trim()) {
+      setError('Paste or upload Grafana JSON before converting')
+      return
+    }
+
+    setConvertingGrafana(true)
+    setError(null)
+    clearImportState()
+
+    try {
+      const response = await convertGrafanaDashboard(grafanaSource, 'yaml')
+      setYamlContent(response.content)
+      setGrafanaWarnings(response.warnings)
+      setConversionReport(response.report ?? null)
+      setImportPreviewFromDocument(response.document)
+      extractGrafanaDatasources(grafanaSource)
+      setConvertedVariables([])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to convert Grafana dashboard')
+    } finally {
+      setConvertingGrafana(false)
+    }
+  }
+
+  async function importRemoteDashboard(uid: string) {
+    setLoadingRemoteDashboard(true)
+    setError(null)
+    try {
+      const dashJson = await getGrafanaDashboard(uid, grafanaUrl, grafanaApiKey)
+      setGrafanaSource(dashJson)
+      setGrafanaFileName(`${uid}.json`)
+      await convertGrafana()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch dashboard')
+    } finally {
+      setLoadingRemoteDashboard(false)
+    }
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+
+    if (!currentOrgId) {
+      setError('No organization selected')
+      return
+    }
+
+    if (mode === 'create' && !title.trim()) {
+      setError('Title is required')
+      return
+    }
+
+    if ((mode === 'import' || mode === 'grafana') && !importPreview) {
+      setError(
+        mode === 'grafana'
+          ? 'Convert Grafana JSON before importing'
+          : 'Upload a valid YAML file before importing',
+      )
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      if (mode === 'create') {
+        await createDashboard(currentOrgId, {
+          title: title.trim(),
+          description: description.trim() || undefined,
+        })
+      } else {
+        const result = await importDashboardYaml(currentOrgId, yamlContent)
+
+        if (mode === 'grafana' && convertedVariables.length > 0 && result?.id) {
+          try {
+            await bulkCreateVariables(
+              result.id,
+              convertedVariables.map((variable, index) => ({
+                name: variable.name,
+                type: variable.type,
+                label: variable.label,
+                query: variable.query,
+                multi: variable.multi,
+                include_all: variable.include_all,
+                sort_order: index,
+              })),
+            )
+          } catch {
+            console.warn('Failed to persist imported variables')
+          }
+        }
+      }
+      onCreated()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create dashboard')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      data-testid="create-dashboard-modal"
+      style={{ backgroundColor: 'rgba(0, 0, 0, 0.6)' }}
+      onClick={event => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="w-full max-w-lg rounded-xl shadow-2xl"
+        style={{
+          backgroundColor: 'color-mix(in srgb, var(--color-surface-container-highest) 85%, transparent)',
+          backdropFilter: 'blur(24px)',
+          WebkitBackdropFilter: 'blur(24px)',
+          border: '1px solid var(--color-outline-variant)',
+        }}
+      >
+        <header
+          className="flex items-center justify-between px-6 py-4"
+          style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
+        >
+          <h2
+            className="font-display text-lg font-semibold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            Create Dashboard
+          </h2>
+          <button
+            type="button"
+            className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition"
+            style={{ color: 'var(--color-on-surface-variant)' }}
+            data-testid="create-dashboard-close-btn"
+            onClick={onClose}
+          >
+            <X size={20} />
+          </button>
+        </header>
+
+        {step === 'choice' ? (
+          <div className="px-6 py-6">
+            <p className="mb-5 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+              Choose how to create your dashboard.
+            </p>
+            <div className="flex flex-col gap-3">
+              <button
+                type="button"
+                className="flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 text-left text-sm font-medium transition-colors"
+                style={{
+                  borderColor: 'var(--color-outline-variant)',
+                  color: 'var(--color-on-surface)',
+                  backgroundColor: 'var(--color-surface-container-low)',
+                }}
+                onClick={chooseBlank}
+              >
+                Blank Dashboard
+              </button>
+              <button
+                type="button"
+                className="flex cursor-pointer items-center gap-3 rounded-lg px-4 py-3 text-left text-sm font-medium text-white transition-opacity hover:opacity-90"
+                style={{
+                  background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+                }}
+                onClick={chooseAI}
+              >
+                Generate with AI
+              </button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="px-6 py-4">
+            <div
+              className="mb-4 flex gap-1 rounded-lg p-1"
+              style={{ backgroundColor: 'var(--color-surface-container)' }}
+              role="tablist"
+              aria-label="Creation mode"
+            >
+              <button
+                type="button"
+                className="cursor-pointer rounded-md px-4 py-2 text-sm font-medium transition"
+                style={{
+                  backgroundColor:
+                    mode === 'create' ? 'var(--color-surface-container-highest)' : 'transparent',
+                  color:
+                    mode === 'create'
+                      ? 'var(--color-on-surface)'
+                      : 'var(--color-on-surface-variant)',
+                }}
+                data-testid="create-mode-create-btn"
+                disabled={loading}
+                onClick={() => setModeAndClearError('create')}
+              >
+                Create New
+              </button>
+              <button
+                type="button"
+                className="cursor-pointer rounded-md px-4 py-2 text-sm font-medium transition"
+                style={{
+                  backgroundColor:
+                    mode === 'import' ? 'var(--color-surface-container-highest)' : 'transparent',
+                  color:
+                    mode === 'import'
+                      ? 'var(--color-on-surface)'
+                      : 'var(--color-on-surface-variant)',
+                }}
+                data-testid="create-mode-import-btn"
+                disabled={loading}
+                onClick={() => setModeAndClearError('import')}
+              >
+                Import YAML
+              </button>
+              <button
+                type="button"
+                className="cursor-pointer rounded-md px-4 py-2 text-sm font-medium transition"
+                style={{
+                  backgroundColor:
+                    mode === 'grafana' ? 'var(--color-surface-container-highest)' : 'transparent',
+                  color:
+                    mode === 'grafana'
+                      ? 'var(--color-on-surface)'
+                      : 'var(--color-on-surface-variant)',
+                }}
+                data-testid="create-mode-grafana-btn"
+                disabled={loading}
+                onClick={() => setModeAndClearError('grafana')}
+              >
+                Import Grafana
+              </button>
+            </div>
+
+            {mode === 'create' ? (
+              <>
+                <div className="mb-5">
+                  <label
+                    htmlFor="title"
+                    className="mb-2 block text-sm font-medium"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    Title <span style={{ color: 'var(--color-error)' }}>*</span>
+                  </label>
+                  <input
+                    id="title"
+                    data-testid="create-dashboard-title-input"
+                    value={title}
+                    onChange={event => setTitle(event.target.value)}
+                    type="text"
+                    placeholder="My Dashboard"
+                    disabled={loading}
+                    autoComplete="off"
+                    className="w-full rounded-lg border px-3 py-2.5 text-sm transition focus:outline-none focus:ring-2"
+                    style={{
+                      borderColor: 'var(--color-outline-variant)',
+                      backgroundColor: 'var(--color-surface-container-low)',
+                      color: 'var(--color-on-surface)',
+                    }}
+                  />
+                </div>
+                <div className="mb-5">
+                  <label
+                    htmlFor="description"
+                    className="mb-2 block text-sm font-medium"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    Description
+                  </label>
+                  <textarea
+                    id="description"
+                    data-testid="create-dashboard-description-input"
+                    value={description}
+                    onChange={event => setDescription(event.target.value)}
+                    placeholder="Dashboard description (optional)"
+                    rows={3}
+                    disabled={loading}
+                    className="min-h-[80px] w-full resize-y rounded-lg border px-3 py-2.5 text-sm transition focus:outline-none focus:ring-2"
+                    style={{
+                      borderColor: 'var(--color-outline-variant)',
+                      backgroundColor: 'var(--color-surface-container-low)',
+                      color: 'var(--color-on-surface)',
+                    }}
+                  />
+                </div>
+              </>
+            ) : null}
+
+            {mode === 'import' ? (
+              <>
+                <div className="mb-5">
+                  <label
+                    htmlFor="yaml-file"
+                    className="mb-2 block text-sm font-medium"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    YAML file <span style={{ color: 'var(--color-error)' }}>*</span>
+                  </label>
+                  <input
+                    id="yaml-file"
+                    type="file"
+                    accept=".yaml,.yml"
+                    disabled={loading}
+                    onChange={handleYamlFileChange}
+                    className="w-full text-sm file:mr-4 file:cursor-pointer file:rounded-lg file:border-0 file:px-4 file:py-2 file:text-sm file:font-medium file:transition"
+                    style={{ color: 'var(--color-on-surface-variant)' }}
+                  />
+                  <p className="mt-2 text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    Upload an exported dashboard YAML to import it into this organization.
+                  </p>
+                </div>
+                {importPreview ? (
+                  <div
+                    className="mb-5 rounded-lg p-3"
+                    data-testid="yaml-preview"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                  >
+                    <p className="text-[0.8125rem]" style={{ color: 'var(--color-on-surface-variant)' }}>
+                      <strong>Preview:</strong> {importPreview.title}
+                    </p>
+                    {importPreview.description ? (
+                      <p
+                        className="mt-1 text-[0.8125rem]"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      >
+                        {importPreview.description}
+                      </p>
+                    ) : null}
+                    <p className="mt-1 text-[0.8125rem]" style={{ color: 'var(--color-on-surface-variant)' }}>
+                      {importPreview.panelCount} panel{importPreview.panelCount === 1 ? '' : 's'}
+                    </p>
+                    {yamlFileName ? (
+                      <p className="mt-1 text-[0.8125rem]" style={{ color: 'var(--color-outline)' }}>
+                        File: {yamlFileName}
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+
+            {mode === 'grafana' ? (
+              <>
+                <div
+                  className="mb-4 flex gap-1 rounded-lg p-1"
+                  style={{ backgroundColor: 'var(--color-surface-container)' }}
+                >
+                  <button
+                    type="button"
+                    className="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition"
+                    style={{
+                      backgroundColor:
+                        grafanaSubTab === 'upload'
+                          ? 'var(--color-surface-container-highest)'
+                          : 'transparent',
+                      color:
+                        grafanaSubTab === 'upload'
+                          ? 'var(--color-on-surface)'
+                          : 'var(--color-on-surface-variant)',
+                    }}
+                    onClick={() => setGrafanaSubTab('upload')}
+                  >
+                    <Upload size={14} /> Upload JSON
+                  </button>
+                  <button
+                    type="button"
+                    className="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition"
+                    style={{
+                      backgroundColor:
+                        grafanaSubTab === 'connect'
+                          ? 'var(--color-surface-container-highest)'
+                          : 'transparent',
+                      color:
+                        grafanaSubTab === 'connect'
+                          ? 'var(--color-on-surface)'
+                          : 'var(--color-on-surface-variant)',
+                    }}
+                    onClick={() => setGrafanaSubTab('connect')}
+                  >
+                    <Globe size={14} /> Connect to Grafana
+                  </button>
+                </div>
+
+                {grafanaSubTab === 'upload' ? (
+                  <>
+                    <div className="mb-5">
+                      <label
+                        htmlFor="grafana-file"
+                        className="mb-2 block text-sm font-medium"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        Grafana JSON file
+                      </label>
+                      <input
+                        id="grafana-file"
+                        type="file"
+                        accept=".json,application/json"
+                        disabled={loading || convertingGrafana}
+                        onChange={handleGrafanaFileChange}
+                        className="w-full text-sm file:mr-4 file:cursor-pointer file:rounded-lg file:border-0 file:px-4 file:py-2 file:text-sm file:font-medium file:transition"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      />
+                    </div>
+                    <div className="mb-5">
+                      <label
+                        htmlFor="grafana-source"
+                        className="mb-2 block text-sm font-medium"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        Grafana JSON <span style={{ color: 'var(--color-error)' }}>*</span>
+                      </label>
+                      <textarea
+                        id="grafana-source"
+                        value={grafanaSource}
+                        onChange={event => setGrafanaSource(event.target.value)}
+                        rows={5}
+                        disabled={loading || convertingGrafana}
+                        placeholder="Paste Grafana dashboard JSON here"
+                        data-testid="grafana-source"
+                        className="min-h-[80px] w-full resize-y rounded-lg border px-3 py-2.5 text-sm transition focus:outline-none focus:ring-2"
+                        style={{
+                          borderColor: 'var(--color-outline-variant)',
+                          backgroundColor: 'var(--color-surface-container-low)',
+                          color: 'var(--color-on-surface)',
+                        }}
+                      />
+                      {grafanaFileName ? (
+                        <p className="mt-2 text-xs" style={{ color: 'var(--color-outline)' }}>
+                          File: {grafanaFileName}
+                        </p>
+                      ) : null}
+                    </div>
+                    <button
+                      type="button"
+                      className="mb-3 cursor-pointer rounded-lg border px-5 py-2.5 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50"
+                      style={{
+                        borderColor: 'var(--color-outline-variant)',
+                        color: 'var(--color-on-surface)',
+                      }}
+                      disabled={!canConvertGrafana}
+                      data-testid="grafana-convert"
+                      onClick={() => void convertGrafana()}
+                    >
+                      {convertingGrafana ? 'Converting...' : 'Convert to Ace'}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    {!grafanaConnected ? (
+                      <div className="mb-4 space-y-4">
+                        <div>
+                          <label
+                            className="mb-1.5 block text-sm font-medium"
+                            style={{ color: 'var(--color-on-surface)' }}
+                          >
+                            Grafana URL <span style={{ color: 'var(--color-error)' }}>*</span>
+                          </label>
+                          <input
+                            value={grafanaUrl}
+                            onChange={event => setGrafanaUrl(event.target.value)}
+                            type="url"
+                            placeholder="https://grafana.example.com"
+                            disabled={grafanaConnecting}
+                            className="w-full rounded-lg border px-3 py-2.5 text-sm focus:outline-none focus:ring-2"
+                            style={{
+                              borderColor: 'var(--color-outline-variant)',
+                              backgroundColor: 'var(--color-surface-container-low)',
+                              color: 'var(--color-on-surface)',
+                            }}
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="mb-1.5 block text-sm font-medium"
+                            style={{ color: 'var(--color-on-surface)' }}
+                          >
+                            API Key{' '}
+                            <span
+                              className="text-xs font-normal"
+                              style={{ color: 'var(--color-on-surface-variant)' }}
+                            >
+                              (optional)
+                            </span>
+                          </label>
+                          <input
+                            value={grafanaApiKey}
+                            onChange={event => setGrafanaApiKey(event.target.value)}
+                            type="password"
+                            placeholder="glsa_..."
+                            disabled={grafanaConnecting}
+                            className="w-full rounded-lg border px-3 py-2.5 text-sm focus:outline-none focus:ring-2"
+                            style={{
+                              borderColor: 'var(--color-outline-variant)',
+                              backgroundColor: 'var(--color-surface-container-low)',
+                              color: 'var(--color-on-surface)',
+                            }}
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          className="flex cursor-pointer items-center gap-2 rounded-lg border px-5 py-2.5 text-sm font-semibold transition disabled:opacity-50"
+                          style={{
+                            borderColor: 'var(--color-outline-variant)',
+                            color: 'var(--color-on-surface)',
+                          }}
+                          disabled={grafanaConnecting || !grafanaUrl.trim()}
+                          onClick={() => void handleGrafanaConnect()}
+                        >
+                          {grafanaConnecting ? (
+                            <Loader2 size={14} className="animate-spin" />
+                          ) : null}
+                          {grafanaConnecting ? 'Connecting...' : 'Connect'}
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="mb-4">
+                        <div
+                          className="mb-3 flex items-center gap-2 text-xs"
+                          style={{ color: 'var(--color-secondary)' }}
+                        >
+                          Connected to Grafana {grafanaVersion}
+                        </div>
+                        {remoteDashboards.length === 0 ? (
+                          <div
+                            className="py-4 text-center text-sm"
+                            style={{ color: 'var(--color-on-surface-variant)' }}
+                          >
+                            No dashboards found
+                          </div>
+                        ) : (
+                          <div className="max-h-48 space-y-1 overflow-y-auto">
+                            {remoteDashboards.map(dash => (
+                              <button
+                                key={dash.uid}
+                                type="button"
+                                className="flex w-full cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition"
+                                style={{
+                                  backgroundColor: 'var(--color-surface-container)',
+                                  color: 'var(--color-on-surface)',
+                                  border: '1px solid var(--color-outline-variant)',
+                                }}
+                                disabled={loadingRemoteDashboard}
+                                onClick={() => void importRemoteDashboard(dash.uid)}
+                              >
+                                <span className="flex-1 truncate">{dash.title}</span>
+                                {dash.tags?.length ? (
+                                  <span
+                                    className="shrink-0 text-[10px]"
+                                    style={{ color: 'var(--color-on-surface-variant)' }}
+                                  >
+                                    {dash.tags.slice(0, 2).join(', ')}
+                                  </span>
+                                ) : null}
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {conversionReport ? (
+                  <div
+                    className="mb-4 rounded-lg p-3"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                  >
+                    <div className="mb-2 flex items-center gap-3">
+                      <span
+                        className="rounded-full px-2 py-0.5 text-xs font-semibold"
+                        style={{
+                          backgroundColor:
+                            conversionReport.fidelity_percent >= 80
+                              ? 'rgba(79,175,120,0.12)'
+                              : conversionReport.fidelity_percent >= 50
+                                ? 'rgba(212,161,30,0.12)'
+                                : 'rgba(217,92,84,0.12)',
+                          color:
+                            conversionReport.fidelity_percent >= 80
+                              ? 'var(--color-secondary)'
+                              : conversionReport.fidelity_percent >= 50
+                                ? 'var(--color-tertiary)'
+                                : 'var(--color-error)',
+                        }}
+                      >
+                        {conversionReport.fidelity_percent}% fidelity
+                      </span>
+                      <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                        {conversionReport.mapped_panels}/{conversionReport.total_panels} panels mapped
+                      </span>
+                      {conversionReport.variables_found > 0 ? (
+                        <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                          {conversionReport.variables_found} variables
+                        </span>
+                      ) : null}
+                    </div>
+                    {conversionReport.unsupported_panels > 0 ? (
+                      <div className="text-xs" style={{ color: 'var(--color-tertiary)' }}>
+                        {conversionReport.unsupported_panels} unsupported panel
+                        {conversionReport.unsupported_panels > 1 ? 's' : ''} mapped to line chart
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                {grafanaWarnings.length > 0 && !conversionReport ? (
+                  <ul
+                    className="mb-4 list-disc pl-5 text-[0.8rem]"
+                    data-testid="grafana-warnings"
+                    style={{ color: 'var(--color-warning)' }}
+                  >
+                    {grafanaWarnings.map(warning => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                {grafanaDatasourceNames.length > 0 && importPreview ? (
+                  <div
+                    className="mb-4 rounded-lg p-3"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                  >
+                    <p
+                      className="mb-2 text-xs font-semibold"
+                      style={{ color: 'var(--color-on-surface)' }}
+                    >
+                      Datasource Mapping
+                    </p>
+                    <div className="space-y-2">
+                      {grafanaDatasourceNames.map(dsName => (
+                        <div key={dsName} className="flex items-center gap-2">
+                          <span
+                            className="w-1/3 truncate text-xs"
+                            style={{ color: 'var(--color-on-surface-variant)' }}
+                          >
+                            {dsName}
+                          </span>
+                          <span className="text-xs" style={{ color: 'var(--color-outline)' }}>
+                            →
+                          </span>
+                          <select
+                            value={datasourceMapping[dsName] ?? ''}
+                            onChange={event =>
+                              setDatasourceMapping(current => ({
+                                ...current,
+                                [dsName]: event.target.value,
+                              }))
+                            }
+                            className="flex-1 rounded border px-2 py-1 text-xs focus:outline-none"
+                            style={{
+                              borderColor: 'var(--color-outline-variant)',
+                              backgroundColor: 'var(--color-surface-container-low)',
+                              color: 'var(--color-on-surface)',
+                            }}
+                          >
+                            <option value="">Auto-detect</option>
+                            {aceDatasources.map(ds => (
+                              <option key={ds.id} value={ds.id}>
+                                {ds.name} ({ds.type})
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {importPreview ? (
+                  <div
+                    className="mb-5 rounded-lg p-3"
+                    data-testid="yaml-preview"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                  >
+                    <p className="text-[0.8125rem]" style={{ color: 'var(--color-on-surface-variant)' }}>
+                      <strong>Preview:</strong> {importPreview.title}
+                    </p>
+                    {importPreview.description ? (
+                      <p
+                        className="mt-1 text-[0.8125rem]"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      >
+                        {importPreview.description}
+                      </p>
+                    ) : null}
+                    <p className="mt-1 text-[0.8125rem]" style={{ color: 'var(--color-on-surface-variant)' }}>
+                      {importPreview.panelCount} panel{importPreview.panelCount === 1 ? '' : 's'}
+                    </p>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+
+            {error ? (
+              <div
+                className="mb-5 rounded-lg px-4 py-3 text-sm"
+                style={{
+                  backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+                  color: 'var(--color-error)',
+                }}
+              >
+                {error}
+              </div>
+            ) : null}
+
+            <div
+              className="flex justify-end gap-3 pt-4"
+              style={{ borderTop: '1px solid var(--color-outline-variant)' }}
+            >
+              <button
+                type="button"
+                data-testid="create-dashboard-cancel-btn"
+                className="cursor-pointer rounded-lg border px-5 py-2.5 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50"
+                style={{
+                  borderColor: 'var(--color-outline-variant)',
+                  color: 'var(--color-on-surface)',
+                }}
+                onClick={onClose}
+                disabled={loading}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                data-testid="create-dashboard-submit-btn"
+                className="cursor-pointer rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                style={{
+                  background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+                }}
+                disabled={loading}
+              >
+                {submitLabel}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/components/CreateDashboardModal.tsx
+++ b/frontend/src/components/CreateDashboardModal.tsx
@@ -369,16 +369,18 @@ export function CreateDashboardModal({
   }
 
   return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      data-testid="create-dashboard-modal"
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.6)' }}
-      onClick={event => {
-        if (event.target === event.currentTarget) onClose()
-      }}
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-center" data-testid="create-dashboard-modal">
+      <button
+        type="button"
+        aria-label="Close"
+        className="absolute inset-0 cursor-default border-none p-0"
+        style={{ backgroundColor: 'rgba(0, 0, 0, 0.6)' }}
+        onClick={onClose}
+      />
       <div
-        className="w-full max-w-lg rounded-xl shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-lg rounded-xl shadow-2xl"
         style={{
           backgroundColor: 'color-mix(in srgb, var(--color-surface-container-highest) 85%, transparent)',
           backdropFilter: 'blur(24px)',
@@ -713,18 +715,18 @@ export function CreateDashboardModal({
                       {convertingGrafana ? 'Converting...' : 'Convert to Ace'}
                     </button>
                   </>
-                ) : (
-                  <>
-                    {!grafanaConnected ? (
+                ) : !grafanaConnected ? (
                       <div className="mb-4 space-y-4">
                         <div>
                           <label
+                            htmlFor="create-dashboard-grafana-url"
                             className="mb-1.5 block text-sm font-medium"
                             style={{ color: 'var(--color-on-surface)' }}
                           >
                             Grafana URL <span style={{ color: 'var(--color-error)' }}>*</span>
                           </label>
                           <input
+                            id="create-dashboard-grafana-url"
                             value={grafanaUrl}
                             onChange={event => setGrafanaUrl(event.target.value)}
                             type="url"
@@ -740,6 +742,7 @@ export function CreateDashboardModal({
                         </div>
                         <div>
                           <label
+                            htmlFor="create-dashboard-grafana-api-key"
                             className="mb-1.5 block text-sm font-medium"
                             style={{ color: 'var(--color-on-surface)' }}
                           >
@@ -752,6 +755,7 @@ export function CreateDashboardModal({
                             </span>
                           </label>
                           <input
+                            id="create-dashboard-grafana-api-key"
                             value={grafanaApiKey}
                             onChange={event => setGrafanaApiKey(event.target.value)}
                             type="password"
@@ -826,8 +830,6 @@ export function CreateDashboardModal({
                         )}
                       </div>
                     )}
-                  </>
-                )}
 
                 {conversionReport ? (
                   <div

--- a/frontend/src/components/DashboardList.spec.tsx
+++ b/frontend/src/components/DashboardList.spec.tsx
@@ -1,0 +1,271 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as dashboardApi from '@/api/dashboards'
+import * as folderApi from '@/api/folders'
+import { DashboardList } from '@/components/DashboardList'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+
+vi.mock('@/hooks/useOrganization', () => ({
+  useOrganization: () => ({
+    currentOrgId: 'org-1',
+    currentOrg: {
+      id: 'org-1',
+      name: 'Acme',
+      slug: 'acme',
+      role: 'admin' as const,
+      created_at: '2026-02-08T00:00:00Z',
+      updated_at: '2026-02-08T00:00:00Z',
+    },
+  }),
+}))
+
+const mockDashboards = [
+  {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    folder_id: 'folder-a',
+    title: 'Test Dashboard',
+    description: 'Test description',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: '223e4567-e89b-12d3-a456-426614174001',
+    folder_id: null,
+    title: 'Another Dashboard',
+    created_at: '2024-01-02T00:00:00Z',
+    updated_at: '2024-01-02T00:00:00Z',
+  },
+  {
+    id: '323e4567-e89b-12d3-a456-426614174002',
+    folder_id: 'missing-folder',
+    title: 'Needs Reassignment',
+    description: 'Folder was deleted',
+    created_at: '2024-01-03T00:00:00Z',
+    updated_at: '2024-01-03T00:00:00Z',
+  },
+]
+
+const mockFolders = [
+  {
+    id: 'folder-a',
+    organization_id: 'org-1',
+    parent_id: null,
+    name: 'Operations',
+    sort_order: 0,
+    created_by: 'user-1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'folder-b',
+    organization_id: 'org-1',
+    parent_id: null,
+    name: 'Product',
+    sort_order: 1,
+    created_by: 'user-1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+function renderDashboardList(initialPath = '/app/dashboards', searchQuery = '') {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/app/dashboards',
+        element: <DashboardList searchQuery={searchQuery} />,
+      },
+      {
+        path: '/app/dashboards/:id',
+        element: <div>Dashboard detail</div>,
+      },
+      {
+        path: '/app/dashboards/new/ai',
+        element: <div>AI generation</div>,
+      },
+    ],
+    { initialEntries: [initialPath] },
+  )
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  return router
+}
+
+describe('DashboardList', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    useOrgStore.setState({ currentOrgId: 'org-1' })
+    useFavoritesStore.setState({ favorites: [], recentDashboards: [] })
+    vi.spyOn(dashboardApi, 'listDashboards').mockResolvedValue(mockDashboards)
+    vi.spyOn(folderApi, 'listFolders').mockResolvedValue(mockFolders)
+  })
+
+  it('displays loading state initially', () => {
+    vi.spyOn(dashboardApi, 'listDashboards').mockImplementation(() => new Promise(() => {}))
+    vi.spyOn(folderApi, 'listFolders').mockImplementation(() => new Promise(() => {}))
+    renderDashboardList()
+    expect(screen.getByText('Loading dashboards...')).toBeTruthy()
+  })
+
+  it('renders dashboard cards after loading', async () => {
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')).toBeTruthy()
+    })
+    expect(screen.getAllByTestId(/^dashboard-card-/).length).toBe(3)
+    expect(screen.getByText('Test Dashboard')).toBeTruthy()
+    expect(screen.getByText('Another Dashboard')).toBeTruthy()
+  })
+
+  it('shows folder name on cards for dashboards in folders', async () => {
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')).toBeTruthy()
+    })
+    const card = screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')
+    expect(card.textContent).toContain('Operations')
+  })
+
+  it('shows empty state when no dashboards and no folders', async () => {
+    vi.spyOn(dashboardApi, 'listDashboards').mockResolvedValue([])
+    vi.spyOn(folderApi, 'listFolders').mockResolvedValue([])
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByText('No dashboards yet')).toBeTruthy()
+    })
+    expect(screen.getByText('Create Dashboard')).toBeTruthy()
+    expect(screen.getByText('Generate with AI')).toBeTruthy()
+  })
+
+  it('displays error state on fetch failure', async () => {
+    vi.spyOn(dashboardApi, 'listDashboards').mockRejectedValue(new Error('Network error'))
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeTruthy()
+    })
+  })
+
+  it('navigates to dashboard on card click', async () => {
+    const router = renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')).toBeTruthy()
+    })
+    await userEvent.click(screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000'))
+    expect(router.state.location.pathname).toBe('/app/dashboards/123e4567-e89b-12d3-a456-426614174000')
+  })
+
+  it('calls toggleFavorite on star click', async () => {
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('favorite-btn-123e4567-e89b-12d3-a456-426614174000')).toBeTruthy()
+    })
+    await userEvent.click(screen.getByTestId('favorite-btn-123e4567-e89b-12d3-a456-426614174000'))
+    expect(useFavoritesStore.getState().favorites).toEqual([
+      expect.objectContaining({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        type: 'dashboard',
+      }),
+    ])
+  })
+
+  it('renders folder chips as filters', async () => {
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('folder-chip-folder-a')).toBeTruthy()
+    })
+    expect(screen.getByTestId('folder-chip-folder-a').textContent).toContain('Operations')
+    expect(screen.getByTestId('folder-chip-folder-b').textContent).toContain('Product')
+  })
+
+  it('filters dashboards by folder chip selection', async () => {
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('folder-chip-folder-a')).toBeTruthy()
+    })
+    await userEvent.click(screen.getByTestId('folder-chip-folder-a'))
+    expect(screen.getAllByTestId(/^dashboard-card-/).length).toBe(1)
+    expect(screen.getByText('Test Dashboard')).toBeTruthy()
+  })
+
+  it('filters dashboards by search query', async () => {
+    renderDashboardList('/app/dashboards', 'Another')
+    await waitFor(() => {
+      expect(screen.getByText('Another Dashboard')).toBeTruthy()
+    })
+    expect(screen.queryByText('Test Dashboard')).toBeNull()
+  })
+
+  it('opens create modal when Create Dashboard empty state button is clicked', async () => {
+    vi.spyOn(dashboardApi, 'listDashboards').mockResolvedValue([])
+    vi.spyOn(folderApi, 'listFolders').mockResolvedValue([])
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByText('Create Dashboard')).toBeTruthy()
+    })
+    await userEvent.click(screen.getByText('Create Dashboard'))
+    expect(screen.getByTestId('create-dashboard-modal')).toBeTruthy()
+  })
+
+  it('moves dashboard to a different folder via drag and drop', async () => {
+    vi.spyOn(dashboardApi, 'updateDashboard').mockImplementation(async (id, data) => {
+      const source = mockDashboards.find(dashboard => dashboard.id === id)
+      if (!source) throw new Error('Dashboard not found')
+      return { ...source, folder_id: data.folder_id ?? null }
+    })
+
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')).toBeTruthy()
+    })
+
+    const card = screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')
+    const dropZone = screen.getByTestId('folder-drop-folder-b')
+
+    fireEvent.dragStart(card)
+    fireEvent.dragOver(dropZone)
+    fireEvent.drop(dropZone)
+
+    await waitFor(() => {
+      expect(dashboardApi.updateDashboard).toHaveBeenCalledWith(
+        '123e4567-e89b-12d3-a456-426614174000',
+        { folder_id: 'folder-b' },
+      )
+    })
+  })
+
+  it('rolls back dashboard move on drag-and-drop API failure', async () => {
+    vi.spyOn(dashboardApi, 'updateDashboard').mockRejectedValue(
+      new Error('Not authorized to update this dashboard'),
+    )
+
+    renderDashboardList()
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')).toBeTruthy()
+    })
+
+    const card = screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000')
+    const dropZone = screen.getByTestId('folder-drop-folder-b')
+
+    fireEvent.dragStart(card)
+    fireEvent.dragOver(dropZone)
+    fireEvent.drop(dropZone)
+
+    await waitFor(() => {
+      expect(screen.getByText('Not authorized to update this dashboard')).toBeTruthy()
+    })
+    expect(screen.getByTestId('dashboard-card-123e4567-e89b-12d3-a456-426614174000').textContent).toContain(
+      'Operations',
+    )
+  })
+})

--- a/frontend/src/components/DashboardList.tsx
+++ b/frontend/src/components/DashboardList.tsx
@@ -1,0 +1,532 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertCircle, LayoutGrid, Star } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { listDashboards, updateDashboard } from '@/api/dashboards'
+import { listFolders } from '@/api/folders'
+import { CreateDashboardModal } from '@/components/CreateDashboardModal'
+import { EmptyState } from '@/components/EmptyState'
+import { useOrganization } from '@/hooks/useOrganization'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import type { Dashboard } from '@/types/dashboard'
+import type { Folder } from '@/types/folder'
+
+type DashboardListProps = {
+  searchQuery?: string
+}
+
+type CreateMode = 'create' | 'import' | 'grafana'
+
+function normalizeCreateMode(rawMode: string | null): CreateMode | null {
+  if (rawMode === 'create' || rawMode === 'import' || rawMode === 'grafana') {
+    return rawMode
+  }
+  return null
+}
+
+export function DashboardList({ searchQuery = '' }: DashboardListProps) {
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const queryClient = useQueryClient()
+  const { currentOrgId, currentOrg } = useOrganization()
+  const toggleFavorite = useFavoritesStore(state => state.toggleFavorite)
+  const isFavorite = useFavoritesStore(state => state.isFavorite)
+
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [createModalInitialMode, setCreateModalInitialMode] = useState<CreateMode>('create')
+  const [draggingDashboardId, setDraggingDashboardId] = useState<string | null>(null)
+  const [movingDashboardId, setMovingDashboardId] = useState<string | null>(null)
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null)
+  const [moveError, setMoveError] = useState<string | null>(null)
+  const [optimisticFolderIds, setOptimisticFolderIds] = useState<Record<string, string | null>>({})
+
+  const canManageDashboards =
+    currentOrg?.role === 'admin' || currentOrg?.role === 'editor'
+
+  const dashboardsQuery = useQuery({
+    queryKey: ['dashboards', currentOrgId],
+    queryFn: () => listDashboards(currentOrgId!),
+    enabled: Boolean(currentOrgId),
+  })
+
+  const foldersQuery = useQuery({
+    queryKey: ['folders', currentOrgId],
+    queryFn: () => listFolders(currentOrgId!),
+    enabled: Boolean(currentOrgId),
+  })
+
+  const dashboards = dashboardsQuery.data ?? []
+  const folders = foldersQuery.data ?? []
+  const loading = dashboardsQuery.isLoading || foldersQuery.isLoading
+  const error =
+    dashboardsQuery.error instanceof Error
+      ? dashboardsQuery.error.message
+      : foldersQuery.error instanceof Error
+        ? foldersQuery.error.message
+        : null
+
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+  const hasSearchQuery = normalizedSearchQuery.length > 0
+
+  const folderById = useMemo(() => {
+    const map = new Map<string, Folder>()
+    for (const folder of folders) {
+      map.set(folder.id, folder)
+    }
+    return map
+  }, [folders])
+
+  const dashboardsWithOptimistic = useMemo(
+    () =>
+      dashboards.map(dashboard => ({
+        ...dashboard,
+        folder_id:
+          dashboard.id in optimisticFolderIds
+            ? optimisticFolderIds[dashboard.id]
+            : dashboard.folder_id,
+      })),
+    [dashboards, optimisticFolderIds],
+  )
+
+  const isCompletelyEmpty = dashboards.length === 0 && folders.length === 0
+
+  function dashboardMatchesSearch(dashboard: Dashboard): boolean {
+    if (!hasSearchQuery) return true
+    return [dashboard.title, dashboard.description ?? '']
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedSearchQuery)
+  }
+
+  function getFolderName(dashboard: Dashboard): string | null {
+    if (!dashboard.folder_id) return null
+    return folderById.get(dashboard.folder_id)?.name ?? null
+  }
+
+  const filteredDashboards = useMemo(() => {
+    let result = dashboardsWithOptimistic.filter(dashboardMatchesSearch)
+
+    if (selectedFolderId !== null) {
+      if (selectedFolderId === '__unfiled__') {
+        const folderIds = new Set(folders.map(folder => folder.id))
+        result = result.filter(
+          dashboard => !dashboard.folder_id || !folderIds.has(dashboard.folder_id),
+        )
+      } else {
+        result = result.filter(dashboard => dashboard.folder_id === selectedFolderId)
+      }
+    }
+
+    return result.sort((a, b) => a.title.localeCompare(b.title))
+  }, [
+    dashboardsWithOptimistic,
+    folders,
+    selectedFolderId,
+    normalizedSearchQuery,
+    hasSearchQuery,
+  ])
+
+  useEffect(() => {
+    const modeFromQuery = normalizeCreateMode(searchParams.get('newDashboardMode'))
+    if (!modeFromQuery) return
+
+    setCreateModalInitialMode(modeFromQuery)
+    setShowCreateModal(true)
+
+    const nextParams = new URLSearchParams(searchParams)
+    nextParams.delete('newDashboardMode')
+    setSearchParams(nextParams, { replace: true })
+  }, [searchParams, setSearchParams])
+
+  function openCreateModalWithMode(initialMode: CreateMode) {
+    setCreateModalInitialMode(initialMode)
+    setShowCreateModal(true)
+  }
+
+  function closeCreateModal() {
+    setShowCreateModal(false)
+  }
+
+  function onDashboardCreated() {
+    closeCreateModal()
+    void queryClient.invalidateQueries({ queryKey: ['dashboards', currentOrgId] })
+  }
+
+  function openDashboard(dashboard: Dashboard) {
+    navigate(`/app/dashboards/${dashboard.id}`)
+  }
+
+  function selectFolder(folderId: string | null) {
+    setSelectedFolderId(current => (current === folderId ? null : folderId))
+  }
+
+  function onDashboardDragStart(dashboard: Dashboard) {
+    if (!canManageDashboards) return
+    setMoveError(null)
+    setDraggingDashboardId(dashboard.id)
+  }
+
+  function onDashboardDragEnd() {
+    setDraggingDashboardId(null)
+  }
+
+  async function onFolderDrop(folderId: string | null) {
+    if (!canManageDashboards || !draggingDashboardId || movingDashboardId) return
+
+    const dashboardId = draggingDashboardId
+    const dashboard = dashboardsWithOptimistic.find(item => item.id === dashboardId)
+    if (!dashboard) {
+      onDashboardDragEnd()
+      return
+    }
+
+    const currentFolderId = dashboard.folder_id ?? null
+    if (currentFolderId === folderId) {
+      onDashboardDragEnd()
+      return
+    }
+
+    setMoveError(null)
+    setMovingDashboardId(dashboardId)
+    setOptimisticFolderIds(current => ({ ...current, [dashboardId]: folderId }))
+
+    try {
+      await updateDashboard(dashboardId, { folder_id: folderId })
+      await queryClient.invalidateQueries({ queryKey: ['dashboards', currentOrgId] })
+      setOptimisticFolderIds(current => {
+        const next = { ...current }
+        delete next[dashboardId]
+        return next
+      })
+    } catch (e) {
+      setOptimisticFolderIds(current => {
+        const next = { ...current }
+        delete next[dashboardId]
+        return next
+      })
+      setMoveError(e instanceof Error ? e.message : 'Failed to move dashboard')
+    } finally {
+      setMovingDashboardId(null)
+      onDashboardDragEnd()
+    }
+  }
+
+  function refetch() {
+    void dashboardsQuery.refetch()
+    void foldersQuery.refetch()
+  }
+
+  if (!currentOrgId) {
+    return (
+      <div>
+        <EmptyState
+          icon={LayoutGrid}
+          title="No dashboards yet"
+          description="Create your first dashboard to start monitoring your metrics."
+        />
+        <div className="-mt-8 flex items-center justify-center gap-3">
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center rounded-lg border px-5 py-2.5 text-sm font-medium transition-colors hover:opacity-80"
+            style={{
+              borderColor: 'var(--color-outline-variant)',
+              color: 'var(--color-on-surface-variant)',
+            }}
+            onClick={() => openCreateModalWithMode('create')}
+          >
+            Create Dashboard
+          </button>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center rounded-lg px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+            }}
+            onClick={() => navigate('/app/dashboards/new/ai')}
+          >
+            Generate with AI
+          </button>
+        </div>
+        {showCreateModal ? (
+          <CreateDashboardModal
+            initialMode={createModalInitialMode}
+            onClose={closeCreateModal}
+            onCreated={onDashboardCreated}
+          />
+        ) : null}
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div
+        className="flex min-h-[320px] flex-col items-center justify-center rounded-lg py-16 text-center"
+        style={{ color: 'var(--color-on-surface-variant)' }}
+      >
+        <div
+          className="mb-4 h-10 w-10 animate-spin rounded-full border-3"
+          style={{
+            borderColor: 'var(--color-outline-variant)',
+            borderTopColor: 'var(--color-primary)',
+          }}
+        />
+        <p>Loading dashboards...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div
+        className="flex min-h-[320px] flex-col items-center justify-center rounded-lg py-16 text-center"
+        style={{ color: 'var(--color-error)' }}
+      >
+        <AlertCircle size={48} />
+        <p className="mb-5 mt-4">{error}</p>
+        <button
+          type="button"
+          className="cursor-pointer rounded-lg border px-5 py-2.5 text-sm font-medium transition-colors"
+          style={{
+            borderColor: 'var(--color-outline-variant)',
+            color: 'var(--color-on-surface)',
+            backgroundColor: 'var(--color-surface-container-low)',
+          }}
+          onClick={refetch}
+        >
+          Try Again
+        </button>
+      </div>
+    )
+  }
+
+  if (isCompletelyEmpty) {
+    return (
+      <div>
+        <EmptyState
+          icon={LayoutGrid}
+          title="No dashboards yet"
+          description="Create your first dashboard to start monitoring your metrics."
+        />
+        <div className="-mt-8 flex items-center justify-center gap-3">
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center rounded-lg border px-5 py-2.5 text-sm font-medium transition-colors hover:opacity-80"
+            style={{
+              borderColor: 'var(--color-outline-variant)',
+              color: 'var(--color-on-surface-variant)',
+            }}
+            onClick={() => openCreateModalWithMode('create')}
+          >
+            Create Dashboard
+          </button>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center rounded-lg px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+            }}
+            onClick={() => navigate('/app/dashboards/new/ai')}
+          >
+            Generate with AI
+          </button>
+        </div>
+        {showCreateModal ? (
+          <CreateDashboardModal
+            initialMode={createModalInitialMode}
+            onClose={closeCreateModal}
+            onCreated={onDashboardCreated}
+          />
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {moveError ? (
+        <p
+          className="mb-4 rounded-lg px-4 py-3 text-sm"
+          style={{
+            backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+            color: 'var(--color-error)',
+            border: '1px solid color-mix(in srgb, var(--color-error) 30%, transparent)',
+          }}
+        >
+          {moveError}
+        </p>
+      ) : null}
+
+      {folders.length > 0 ? (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {folders.map(folder => (
+            <button
+              key={folder.id}
+              type="button"
+              data-testid={`folder-chip-${folder.id}`}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
+              style={{
+                backgroundColor:
+                  selectedFolderId === folder.id
+                    ? 'var(--color-primary-container)'
+                    : 'var(--color-surface-container)',
+                color:
+                  selectedFolderId === folder.id
+                    ? 'var(--color-on-primary-container)'
+                    : 'var(--color-on-surface-variant)',
+                border: `1px solid ${
+                  selectedFolderId === folder.id
+                    ? 'var(--color-primary)'
+                    : 'var(--color-outline-variant)'
+                }`,
+              }}
+              onClick={() => selectFolder(folder.id)}
+              onDragOver={event => {
+                event.preventDefault()
+                if (canManageDashboards && draggingDashboardId) {
+                  event.dataTransfer.dropEffect = 'move'
+                }
+              }}
+              onDrop={event => {
+                event.preventDefault()
+                void onFolderDrop(folder.id)
+              }}
+            >
+              {folder.name}
+            </button>
+          ))}
+          <button
+            type="button"
+            data-testid="folder-chip-unfiled"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
+            style={{
+              backgroundColor:
+                selectedFolderId === '__unfiled__'
+                  ? 'var(--color-primary-container)'
+                  : 'var(--color-surface-container)',
+              color:
+                selectedFolderId === '__unfiled__'
+                  ? 'var(--color-on-primary-container)'
+                  : 'var(--color-on-surface-variant)',
+              border: `1px solid ${
+                selectedFolderId === '__unfiled__'
+                  ? 'var(--color-primary)'
+                  : 'var(--color-outline-variant)'
+              }`,
+            }}
+            onClick={() => selectFolder('__unfiled__')}
+            onDragOver={event => {
+              event.preventDefault()
+              if (canManageDashboards && draggingDashboardId) {
+                event.dataTransfer.dropEffect = 'move'
+              }
+            }}
+            onDrop={event => {
+              event.preventDefault()
+              void onFolderDrop(null)
+            }}
+          >
+            Unfiled
+          </button>
+        </div>
+      ) : null}
+
+      {folders.map(folder => (
+        <div
+          key={`drop-${folder.id}`}
+          data-testid={`folder-drop-${folder.id}`}
+          className="hidden"
+          onDragOver={event => event.preventDefault()}
+          onDrop={event => {
+            event.preventDefault()
+            void onFolderDrop(folder.id)
+          }}
+        />
+      ))}
+
+      <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+        {filteredDashboards.map(dashboard => (
+          <div
+            key={dashboard.id}
+            data-testid={`dashboard-card-${dashboard.id}`}
+            role="button"
+            tabIndex={0}
+            className="group relative cursor-pointer rounded-lg p-4 transition-colors"
+            style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+            draggable={canManageDashboards}
+            onDragStart={() => onDashboardDragStart(dashboard)}
+            onDragEnd={onDashboardDragEnd}
+            onClick={() => openDashboard(dashboard)}
+            onKeyDown={event => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                openDashboard(dashboard)
+              }
+            }}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 flex-1">
+                <h3
+                  className="truncate font-display text-sm font-semibold leading-snug"
+                  style={{ color: 'var(--color-on-surface)' }}
+                >
+                  {dashboard.title}
+                </h3>
+                {getFolderName(dashboard) ? (
+                  <p className="mt-1 text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    {getFolderName(dashboard)}
+                  </p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                data-testid={`favorite-btn-${dashboard.id}`}
+                className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors"
+                style={{
+                  color: isFavorite(dashboard.id)
+                    ? 'var(--color-primary)'
+                    : 'var(--color-outline)',
+                }}
+                onClick={event => {
+                  event.stopPropagation()
+                  toggleFavorite({
+                    id: dashboard.id,
+                    title: dashboard.title,
+                    type: 'dashboard',
+                  })
+                }}
+              >
+                <Star size={16} fill={isFavorite(dashboard.id) ? 'currentColor' : 'none'} />
+              </button>
+            </div>
+            {dashboard.description ? (
+              <p
+                className="mt-2 line-clamp-2 text-xs leading-relaxed"
+                style={{ color: 'var(--color-on-surface-variant)' }}
+              >
+                {dashboard.description}
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      {filteredDashboards.length === 0 ? (
+        <p
+          className="mt-6 text-center text-sm"
+          style={{ color: 'var(--color-on-surface-variant)' }}
+        >
+          No dashboards match your search.
+        </p>
+      ) : null}
+
+      {showCreateModal ? (
+        <CreateDashboardModal
+          initialMode={createModalInitialMode}
+          onClose={closeCreateModal}
+          onCreated={onDashboardCreated}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/DashboardList.tsx
+++ b/frontend/src/components/DashboardList.tsx
@@ -104,7 +104,13 @@ export function DashboardList({ searchQuery = '' }: DashboardListProps) {
   }
 
   const filteredDashboards = useMemo(() => {
-    let result = dashboardsWithOptimistic.filter(dashboardMatchesSearch)
+    let result = dashboardsWithOptimistic.filter(dashboard => {
+      if (!hasSearchQuery) return true
+      return [dashboard.title, dashboard.description ?? '']
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedSearchQuery)
+    })
 
     if (selectedFolderId !== null) {
       if (selectedFolderId === '__unfiled__') {
@@ -118,13 +124,7 @@ export function DashboardList({ searchQuery = '' }: DashboardListProps) {
     }
 
     return result.sort((a, b) => a.title.localeCompare(b.title))
-  }, [
-    dashboardsWithOptimistic,
-    folders,
-    selectedFolderId,
-    normalizedSearchQuery,
-    hasSearchQuery,
-  ])
+  }, [dashboardsWithOptimistic, folders, selectedFolderId, normalizedSearchQuery, hasSearchQuery])
 
   useEffect(() => {
     const modeFromQuery = normalizeCreateMode(searchParams.get('newDashboardMode'))
@@ -432,6 +432,7 @@ export function DashboardList({ searchQuery = '' }: DashboardListProps) {
       ) : null}
 
       {folders.map(folder => (
+        // biome-ignore lint/a11y/noStaticElementInteractions: hidden drag-and-drop target
         <div
           key={`drop-${folder.id}`}
           data-testid={`folder-drop-${folder.id}`}
@@ -446,6 +447,7 @@ export function DashboardList({ searchQuery = '' }: DashboardListProps) {
 
       <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
         {filteredDashboards.map(dashboard => (
+          // biome-ignore lint/a11y/useSemanticElements: card is draggable; native button breaks HTML5 drag
           <div
             key={dashboard.id}
             data-testid={`dashboard-card-${dashboard.id}`}

--- a/frontend/src/components/DashboardList.tsx
+++ b/frontend/src/components/DashboardList.tsx
@@ -90,14 +90,6 @@ export function DashboardList({ searchQuery = '' }: DashboardListProps) {
 
   const isCompletelyEmpty = dashboards.length === 0 && folders.length === 0
 
-  function dashboardMatchesSearch(dashboard: Dashboard): boolean {
-    if (!hasSearchQuery) return true
-    return [dashboard.title, dashboard.description ?? '']
-      .join(' ')
-      .toLowerCase()
-      .includes(normalizedSearchQuery)
-  }
-
   function getFolderName(dashboard: Dashboard): string | null {
     if (!dashboard.folder_id) return null
     return folderById.get(dashboard.folder_id)?.name ?? null

--- a/frontend/src/components/TraceListPanel.tsx
+++ b/frontend/src/components/TraceListPanel.tsx
@@ -1,0 +1,123 @@
+import { useMemo, useState } from 'react'
+import type { TraceSummary } from '@/types/datasource'
+import { formatDurationNano, formatTraceStartFull } from '@/utils/traceFormat'
+
+type TraceSortField =
+  | 'traceId'
+  | 'startTimeUnixNano'
+  | 'durationNano'
+  | 'spanCount'
+  | 'errorSpanCount'
+type TraceSortDirection = 'asc' | 'desc'
+
+type TraceListPanelProps = {
+  traces: TraceSummary[]
+  onOpenTrace?: (traceId: string) => void
+}
+
+export function TraceListPanel({ traces, onOpenTrace }: TraceListPanelProps) {
+  const [sortField, setSortField] = useState<TraceSortField>('startTimeUnixNano')
+  const [sortDirection, setSortDirection] = useState<TraceSortDirection>('desc')
+
+  const sortedTraces = useMemo(() => {
+    const directionFactor = sortDirection === 'asc' ? 1 : -1
+    return [...traces].sort((left, right) => {
+      const leftValue = left[sortField]
+      const rightValue = right[sortField]
+
+      if (typeof leftValue === 'string' && typeof rightValue === 'string') {
+        return leftValue.localeCompare(rightValue) * directionFactor
+      }
+
+      return ((leftValue as number) - (rightValue as number)) * directionFactor
+    })
+  }, [traces, sortDirection, sortField])
+
+  function toggleSort(field: TraceSortField) {
+    if (sortField === field) {
+      setSortDirection(current => (current === 'asc' ? 'desc' : 'asc'))
+      return
+    }
+
+    setSortField(field)
+    setSortDirection(field === 'traceId' ? 'asc' : 'desc')
+  }
+
+  function sortIndicator(field: TraceSortField): string {
+    if (sortField !== field) {
+      return ''
+    }
+    return sortDirection === 'asc' ? '\u2191' : '\u2193'
+  }
+
+  return (
+    <div className="h-full overflow-auto rounded bg-[var(--color-surface-container-low)]">
+      <table className="w-full border-collapse text-sm">
+        <thead className="sticky top-0 z-10 bg-[var(--color-surface-container-high)]">
+          <tr>
+            {(
+              [
+                ['traceId', 'Trace'],
+                ['startTimeUnixNano', 'Start'],
+                ['durationNano', 'Duration'],
+                ['spanCount', 'Spans'],
+                ['errorSpanCount', 'Errors'],
+              ] as const
+            ).map(([field, label]) => (
+              <th
+                key={field}
+                className="border-b border-[var(--color-stroke-subtle)] px-4 py-3 text-left align-middle"
+              >
+                <button
+                  type="button"
+                  className="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)]"
+                  onClick={() => toggleSort(field)}
+                >
+                  {label} {sortIndicator(field)}
+                </button>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedTraces.map(trace => (
+            <tr
+              key={trace.traceId}
+              className="transition hover:bg-[var(--color-surface-container-high)]"
+            >
+              <td className="max-w-[220px] border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle">
+                <button
+                  type="button"
+                  className="inline-block w-full cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap border-none bg-transparent p-0 text-left font-mono text-xs text-[var(--color-primary)] transition hover:text-[var(--color-primary)] hover:underline"
+                  onClick={() => onOpenTrace?.(trace.traceId)}
+                >
+                  {trace.traceId}
+                </button>
+              </td>
+              <td className="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle text-sm text-[var(--color-on-surface-variant)]">
+                {formatTraceStartFull(trace.startTimeUnixNano)}
+              </td>
+              <td className="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle font-mono text-xs text-[var(--color-outline)]">
+                {formatDurationNano(trace.durationNano)}
+              </td>
+              <td className="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle text-sm text-[var(--color-on-surface-variant)]">
+                {trace.spanCount}
+              </td>
+              <td className="border-b border-[var(--color-stroke-subtle)] px-4 py-3 align-middle">
+                <span
+                  className={
+                    trace.errorSpanCount > 0
+                      ? 'font-semibold text-[var(--color-error)]'
+                      : 'text-[var(--color-on-surface-variant)]'
+                  }
+                >
+                  {trace.errorSpanCount}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/TraceServiceGraph.tsx
+++ b/frontend/src/components/TraceServiceGraph.tsx
@@ -313,6 +313,7 @@ export function TraceServiceGraph({ graph, onSelectService, onSelectEdge }: Trac
 
           <g transform={canvasTransform}>
             {positionedEdges.map(edge => (
+              // biome-ignore lint/a11y/noStaticElementInteractions: SVG path click target
               <path
                 key={edge.key}
                 d={edgePath(edge)}
@@ -335,6 +336,7 @@ export function TraceServiceGraph({ graph, onSelectService, onSelectEdge }: Trac
             {positionedNodes.map(node => {
               const isSelected = selectedService === node.serviceName
               return (
+                // biome-ignore lint/a11y/noStaticElementInteractions: SVG group click target
                 <g
                   key={node.serviceName}
                   className="cursor-pointer"

--- a/frontend/src/components/TraceServiceGraph.tsx
+++ b/frontend/src/components/TraceServiceGraph.tsx
@@ -1,0 +1,403 @@
+import { useMemo, useState } from 'react'
+import type {
+  TraceServiceGraph as TraceServiceGraphModel,
+  TraceServiceGraphEdge,
+  TraceServiceGraphNode,
+} from '@/types/datasource'
+import { formatDurationNano } from '@/utils/traceFormat'
+
+interface PositionedNode extends TraceServiceGraphNode {
+  x: number
+  y: number
+}
+
+interface PositionedEdge extends TraceServiceGraphEdge {
+  key: string
+  sourceX: number
+  sourceY: number
+  targetX: number
+  targetY: number
+}
+
+type TraceServiceGraphProps = {
+  graph: TraceServiceGraphModel
+  onSelectService?: (serviceName: string) => void
+  onSelectEdge?: (edge: { source: string; target: string }) => void
+}
+
+const graphWidth = 940
+const graphHeight = 340
+const nodePaddingX = 80
+const nodePaddingY = 46
+
+function edgePath(edge: PositionedEdge): string {
+  const horizontalDistance = Math.abs(edge.targetX - edge.sourceX)
+  const controlX = (edge.sourceX + edge.targetX) / 2
+  const controlY = (edge.sourceY + edge.targetY) / 2 - Math.max(24, horizontalDistance * 0.08)
+  return `M ${edge.sourceX} ${edge.sourceY} Q ${controlX} ${controlY} ${edge.targetX} ${edge.targetY}`
+}
+
+function edgeWidth(edge: TraceServiceGraphEdge, maxEdgeRequests: number): number {
+  const ratio = edge.requestCount / Math.max(maxEdgeRequests, 1)
+  return 1 + ratio * 7
+}
+
+function edgeColor(edge: TraceServiceGraphEdge): string {
+  if (edge.errorRate >= 0.4) {
+    return 'var(--color-error)'
+  }
+  if (edge.errorRate >= 0.15) {
+    return 'var(--color-tertiary)'
+  }
+  return 'var(--color-secondary)'
+}
+
+function nodeRadius(node: TraceServiceGraphNode, maxNodeRequests: number): number {
+  const ratio = node.requestCount / Math.max(maxNodeRequests, 1)
+  return 14 + ratio * 17
+}
+
+function nodeColor(node: TraceServiceGraphNode): string {
+  return node.errorRate >= 0.25 ? 'var(--color-error)' : 'var(--color-secondary)'
+}
+
+function nodeStroke(node: TraceServiceGraphNode, isSelected: boolean): string {
+  if (isSelected) {
+    return 'var(--color-primary)'
+  }
+  return node.errorRate >= 0.25
+    ? 'color-mix(in srgb, var(--color-error) 50%, white)'
+    : 'color-mix(in srgb, var(--color-secondary) 50%, white)'
+}
+
+function nodeStrokeWidth(isSelected: boolean): number {
+  return isSelected ? 2.5 : 1.5
+}
+
+export function TraceServiceGraph({ graph, onSelectService, onSelectEdge }: TraceServiceGraphProps) {
+  const [zoomPercent, setZoomPercent] = useState(100)
+  const [panX, setPanX] = useState(0)
+  const [panY, setPanY] = useState(0)
+  const [selectedService, setSelectedService] = useState<string | null>(null)
+  const [selectedEdgeKey, setSelectedEdgeKey] = useState<string | null>(null)
+
+  const nodeByService = useMemo(() => {
+    return new Map(graph.nodes.map(node => [node.serviceName, node]))
+  }, [graph.nodes])
+
+  const maxNodeRequests = useMemo(() => {
+    return graph.nodes.reduce((max, node) => Math.max(max, node.requestCount), 1)
+  }, [graph.nodes])
+
+  const maxEdgeRequests = useMemo(() => {
+    return graph.edges.reduce((max, edge) => Math.max(max, edge.requestCount), 1)
+  }, [graph.edges])
+
+  const positionedNodes = useMemo<PositionedNode[]>(() => {
+    if (graph.nodes.length === 0) {
+      return []
+    }
+
+    const sortedServices = graph.nodes
+      .map(node => node.serviceName)
+      .sort((a, b) => a.localeCompare(b))
+
+    const levelByService = new Map<string, number>()
+    for (const serviceName of sortedServices) {
+      levelByService.set(serviceName, 0)
+    }
+
+    for (let i = 0; i < sortedServices.length; i += 1) {
+      let changed = false
+      for (const edge of graph.edges) {
+        if (edge.source === edge.target) {
+          continue
+        }
+
+        if (!levelByService.has(edge.source) || !levelByService.has(edge.target)) {
+          continue
+        }
+
+        const sourceLevel = levelByService.get(edge.source) || 0
+        const targetLevel = levelByService.get(edge.target) || 0
+        if (targetLevel <= sourceLevel) {
+          levelByService.set(edge.target, sourceLevel + 1)
+          changed = true
+        }
+      }
+
+      if (!changed) {
+        break
+      }
+    }
+
+    const maxLevel = Math.max(...levelByService.values(), 0)
+    const levelCount = maxLevel + 1
+
+    const levels = new Map<number, TraceServiceGraphNode[]>()
+    for (const node of graph.nodes) {
+      const level = levelByService.get(node.serviceName) || 0
+      const list = levels.get(level) || []
+      list.push(node)
+      levels.set(level, list)
+    }
+
+    const positioned: PositionedNode[] = []
+    for (let level = 0; level <= maxLevel; level += 1) {
+      const list = levels.get(level) || []
+      list.sort(
+        (a, b) => b.requestCount - a.requestCount || a.serviceName.localeCompare(b.serviceName),
+      )
+
+      const x =
+        levelCount > 1
+          ? nodePaddingX + (level * (graphWidth - nodePaddingX * 2)) / (levelCount - 1)
+          : graphWidth / 2
+
+      if (list.length <= 1) {
+        const node = list[0]
+        if (node) {
+          positioned.push({ ...node, x, y: graphHeight / 2 })
+        }
+        continue
+      }
+
+      const ySpacing = (graphHeight - nodePaddingY * 2) / (list.length - 1)
+      list.forEach((node, index) => {
+        positioned.push({
+          ...node,
+          x,
+          y: nodePaddingY + ySpacing * index,
+        })
+      })
+    }
+
+    return positioned
+  }, [graph.nodes, graph.edges])
+
+  const positionedNodeByService = useMemo(() => {
+    return new Map(positionedNodes.map(node => [node.serviceName, node]))
+  }, [positionedNodes])
+
+  const positionedEdges = useMemo<PositionedEdge[]>(() => {
+    const positioned: PositionedEdge[] = []
+
+    for (const edge of graph.edges) {
+      const source = positionedNodeByService.get(edge.source)
+      const target = positionedNodeByService.get(edge.target)
+      if (!source || !target) {
+        continue
+      }
+
+      positioned.push({
+        ...edge,
+        key: `${edge.source}->${edge.target}`,
+        sourceX: source.x,
+        sourceY: source.y,
+        targetX: target.x,
+        targetY: target.y,
+      })
+    }
+
+    return positioned
+  }, [graph.edges, positionedNodeByService])
+
+  const canvasTransform = `translate(${panX} ${panY}) scale(${zoomPercent / 100})`
+
+  function handleSelectService(serviceName: string) {
+    setSelectedService(serviceName)
+    setSelectedEdgeKey(null)
+    onSelectService?.(serviceName)
+  }
+
+  function handleSelectEdge(edge: PositionedEdge) {
+    setSelectedEdgeKey(edge.key)
+    setSelectedService(null)
+    onSelectEdge?.({ source: edge.source, target: edge.target })
+  }
+
+  const selectedNode = selectedService ? nodeByService.get(selectedService) : undefined
+
+  return (
+    <div
+      className="flex flex-col gap-2.5 rounded bg-[var(--color-surface-container-low)] p-4"
+      data-testid="trace-service-graph"
+    >
+      <div className="flex flex-wrap gap-2.5">
+        <label className="inline-flex items-center gap-2 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1 text-xs text-[var(--color-outline)] max-sm:w-full max-sm:justify-between">
+          <span>Zoom</span>
+          <input
+            type="range"
+            min={80}
+            max={180}
+            step={5}
+            value={zoomPercent}
+            onChange={event => setZoomPercent(Number(event.target.value))}
+            className="w-28 max-sm:w-30"
+          />
+          <strong className="min-w-[2.4rem] text-right text-xs font-semibold text-[var(--color-on-surface)]">
+            {zoomPercent}%
+          </strong>
+        </label>
+
+        <label className="inline-flex items-center gap-2 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1 text-xs text-[var(--color-outline)] max-sm:w-full max-sm:justify-between">
+          <span>Pan X</span>
+          <input
+            type="range"
+            min={-220}
+            max={220}
+            step={10}
+            value={panX}
+            onChange={event => setPanX(Number(event.target.value))}
+            className="w-28 max-sm:w-30"
+          />
+          <strong className="min-w-[2.4rem] text-right text-xs font-semibold text-[var(--color-on-surface)]">
+            {panX}
+          </strong>
+        </label>
+
+        <label className="inline-flex items-center gap-2 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1 text-xs text-[var(--color-outline)] max-sm:w-full max-sm:justify-between">
+          <span>Pan Y</span>
+          <input
+            type="range"
+            min={-140}
+            max={140}
+            step={10}
+            value={panY}
+            onChange={event => setPanY(Number(event.target.value))}
+            className="w-28 max-sm:w-30"
+          />
+          <strong className="min-w-[2.4rem] text-right text-xs font-semibold text-[var(--color-on-surface)]">
+            {panY}
+          </strong>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <span className="rounded-sm bg-[var(--color-surface-container-high)] px-2.5 py-1 text-xs text-[var(--color-outline)]">
+          {graph.nodes.length} services
+        </span>
+        <span className="rounded-sm bg-[var(--color-surface-container-high)] px-2.5 py-1 text-xs text-[var(--color-outline)]">
+          {graph.edges.length} dependencies
+        </span>
+        <span className="rounded-sm bg-[var(--color-surface-container-high)] px-2.5 py-1 text-xs text-[var(--color-outline)]">
+          {graph.totalRequests} spans
+        </span>
+        <span className="rounded-sm bg-[var(--color-surface-container-high)] px-2.5 py-1 text-xs text-[var(--color-outline)]">
+          {graph.totalErrorCount} errors
+        </span>
+      </div>
+
+      <div className="overflow-auto rounded-sm bg-[var(--color-surface-container-high)]">
+        <svg
+          width={graphWidth}
+          height={graphHeight}
+          viewBox="0 0 940 340"
+          className="block"
+          role="img"
+          aria-label="Service dependency graph"
+        >
+          <defs>
+            <marker
+              id="service-graph-arrow"
+              markerUnits="userSpaceOnUse"
+              markerWidth={5}
+              markerHeight={5}
+              refX={4.5}
+              refY={2.5}
+              orient="auto"
+            >
+              <path d="M0,0 L5,2.5 L0,5 z" fill="var(--color-outline)" />
+            </marker>
+          </defs>
+
+          <g transform={canvasTransform}>
+            {positionedEdges.map(edge => (
+              <path
+                key={edge.key}
+                d={edgePath(edge)}
+                fill="none"
+                className="cursor-pointer transition-opacity"
+                style={{
+                  stroke: edgeColor(edge),
+                  strokeWidth: edgeWidth(edge, maxEdgeRequests),
+                  strokeOpacity: selectedEdgeKey === edge.key ? 1 : 0.84,
+                  filter:
+                    selectedEdgeKey === edge.key
+                      ? 'drop-shadow(0 0 4px color-mix(in srgb, var(--color-primary) 30%, transparent))'
+                      : 'none',
+                }}
+                markerEnd="url(#service-graph-arrow)"
+                onClick={() => handleSelectEdge(edge)}
+              />
+            ))}
+
+            {positionedNodes.map(node => {
+              const isSelected = selectedService === node.serviceName
+              return (
+                <g
+                  key={node.serviceName}
+                  className="cursor-pointer"
+                  onClick={() => handleSelectService(node.serviceName)}
+                >
+                  <circle
+                    cx={node.x}
+                    cy={node.y}
+                    r={nodeRadius(node, maxNodeRequests)}
+                    style={{
+                      fill: nodeColor(node),
+                      stroke: nodeStroke(node, isSelected),
+                      strokeWidth: nodeStrokeWidth(isSelected),
+                    }}
+                    className="transition-[stroke]"
+                  />
+                  <text
+                    x={node.x}
+                    y={node.y - 2}
+                    className="pointer-events-none fill-[var(--color-on-surface)] text-[11px] font-bold"
+                    textAnchor="middle"
+                  >
+                    {node.serviceName}
+                  </text>
+                  <text
+                    x={node.x}
+                    y={node.y + 11}
+                    className="pointer-events-none fill-[var(--color-outline)] text-[9px]"
+                    textAnchor="middle"
+                  >
+                    {node.requestCount} req
+                  </text>
+                </g>
+              )
+            })}
+          </g>
+        </svg>
+      </div>
+
+      <div className="border-t border-[var(--color-stroke-subtle)] pt-2 text-xs text-[var(--color-outline)]">
+        {selectedService ? (
+          <p className="m-0 flex flex-wrap gap-1.5">
+            <strong className="text-[var(--color-on-surface)]">{selectedService}</strong>
+            <span>
+              {selectedNode?.requestCount} spans, error rate{' '}
+              {Math.round((selectedNode?.errorRate || 0) * 100)}%, avg{' '}
+              {formatDurationNano(selectedNode?.averageDurationNano || 0)}
+            </span>
+          </p>
+        ) : selectedEdgeKey ? (
+          <p className="m-0 flex flex-wrap gap-1.5">
+            <strong className="text-[var(--color-on-surface)]">{selectedEdgeKey}</strong>
+            <span>Dependency selected. Trace search filtered to the target service.</span>
+          </p>
+        ) : (
+          <p className="m-0 flex flex-wrap gap-1.5">
+            <span>
+              Select a node to filter traces by service, or select an edge to filter by downstream
+              service.
+            </span>
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TraceSpanDetailsPanel.tsx
+++ b/frontend/src/components/TraceSpanDetailsPanel.tsx
@@ -402,12 +402,12 @@ export function TraceSpanDetailsPanel({
         </h4>
         {sortedLogs.length > 0 ? (
           <div className="flex flex-col gap-2">
-            {sortedLogs.map((log, index) => {
+            {sortedLogs.map(log => {
               const logFields = formatLogFields(log)
 
               return (
                 <article
-                  key={`${log.timestampUnixNano}-${index}`}
+                  key={`${log.timestampUnixNano}-${log.body ?? ''}-${JSON.stringify(log.fields ?? {})}`}
                   className="flex flex-col gap-2 rounded-sm p-2.5"
                 >
                   <div className="flex items-center justify-between gap-2 text-xs text-[var(--color-outline)]">

--- a/frontend/src/components/TraceSpanDetailsPanel.tsx
+++ b/frontend/src/components/TraceSpanDetailsPanel.tsx
@@ -1,0 +1,443 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { Trace, TraceLog, TraceSpan } from '@/types/datasource'
+import { formatDurationNano, formatTraceStartFull } from '@/utils/traceFormat'
+
+type TraceSpanDetailsPanelProps = {
+  trace: Trace
+  span: TraceSpan
+  onSelectSpan?: (span: TraceSpan) => void
+  onOpenTraceLogs?: (payload: {
+    traceId: string
+    serviceName: string
+    startTimeUnixNano: number
+    endTimeUnixNano: number
+  }) => void
+  onOpenServiceMetrics?: (payload: {
+    serviceName: string
+    startTimeUnixNano: number
+    endTimeUnixNano: number
+  }) => void
+}
+
+function formatLogFields(log: TraceLog): Array<[string, string]> {
+  return Object.entries(log.fields || {}).sort(([leftKey], [rightKey]) =>
+    leftKey.localeCompare(rightKey),
+  )
+}
+
+function copyWithTextArea(value: string): boolean {
+  if (typeof document === 'undefined') {
+    return false
+  }
+
+  const textArea = document.createElement('textarea')
+  textArea.value = value
+  textArea.setAttribute('readonly', 'true')
+  textArea.style.position = 'fixed'
+  textArea.style.opacity = '0'
+  document.body.appendChild(textArea)
+  textArea.select()
+
+  let copied = false
+  try {
+    copied = document.execCommand('copy')
+  } catch {
+    copied = false
+  }
+
+  document.body.removeChild(textArea)
+  return copied
+}
+
+function sanitizeFileName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/-+/g, '-')
+}
+
+export function TraceSpanDetailsPanel({
+  trace,
+  span,
+  onSelectSpan,
+  onOpenTraceLogs,
+  onOpenServiceMetrics,
+}: TraceSpanDetailsPanelProps) {
+  const [feedbackMessage, setFeedbackMessage] = useState('')
+  const feedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const spanMap = useMemo(() => {
+    const map = new Map<string, TraceSpan>()
+    for (const entry of trace.spans) {
+      map.set(entry.spanId, entry)
+    }
+    return map
+  }, [trace.spans])
+
+  const parentSpan = useMemo(() => {
+    if (!span.parentSpanId) {
+      return null
+    }
+    return spanMap.get(span.parentSpanId) || null
+  }, [span.parentSpanId, spanMap])
+
+  const childSpans = useMemo(() => {
+    return trace.spans
+      .filter(entry => entry.parentSpanId === span.spanId)
+      .sort((left, right) => {
+        if (left.startTimeUnixNano === right.startTimeUnixNano) {
+          return right.durationNano - left.durationNano
+        }
+        return left.startTimeUnixNano - right.startTimeUnixNano
+      })
+  }, [span.spanId, trace.spans])
+
+  const sortedTags = useMemo(() => {
+    const tags = span.tags || {}
+    return Object.entries(tags).sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+  }, [span.tags])
+
+  const sortedLogs = useMemo(() => {
+    return [...(span.logs || [])].sort(
+      (left, right) => left.timestampUnixNano - right.timestampUnixNano,
+    )
+  }, [span.logs])
+
+  const formatTraceOffset = useCallback(
+    (unixNanoTimestamp: number): string => {
+      const duration = Math.max(unixNanoTimestamp - trace.startTimeUnixNano, 0)
+      return `+${formatDurationNano(duration)}`
+    },
+    [trace.startTimeUnixNano],
+  )
+
+  const setFeedback = useCallback((message: string) => {
+    setFeedbackMessage(message)
+    if (feedbackTimeoutRef.current) {
+      clearTimeout(feedbackTimeoutRef.current)
+    }
+    feedbackTimeoutRef.current = setTimeout(() => {
+      setFeedbackMessage('')
+    }, 2000)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimeoutRef.current) {
+        clearTimeout(feedbackTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const copyToClipboard = useCallback(
+    async (value: string, label: string) => {
+      if (!value) {
+        return
+      }
+
+      try {
+        if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(value)
+          setFeedback(`${label} copied`)
+          return
+        }
+
+        if (copyWithTextArea(value)) {
+          setFeedback(`${label} copied`)
+          return
+        }
+
+        setFeedback(`Unable to copy ${label.toLowerCase()}`)
+      } catch {
+        setFeedback(`Unable to copy ${label.toLowerCase()}`)
+      }
+    },
+    [setFeedback],
+  )
+
+  const openTraceLogs = useCallback(() => {
+    onOpenTraceLogs?.({
+      traceId: trace.traceId,
+      serviceName: span.serviceName || '',
+      startTimeUnixNano: span.startTimeUnixNano,
+      endTimeUnixNano: span.startTimeUnixNano + span.durationNano,
+    })
+  }, [onOpenTraceLogs, span.durationNano, span.serviceName, span.startTimeUnixNano, trace.traceId])
+
+  const openServiceMetrics = useCallback(() => {
+    onOpenServiceMetrics?.({
+      serviceName: span.serviceName || '',
+      startTimeUnixNano: span.startTimeUnixNano,
+      endTimeUnixNano: span.startTimeUnixNano + span.durationNano,
+    })
+  }, [onOpenServiceMetrics, span.durationNano, span.serviceName, span.startTimeUnixNano])
+
+  const exportSpanJson = useCallback(() => {
+    if (typeof document === 'undefined' || typeof URL === 'undefined' || !URL.createObjectURL) {
+      setFeedback('Unable to export JSON in this environment')
+      return
+    }
+
+    const payload = {
+      traceId: trace.traceId,
+      span,
+      parentSpan,
+      childSpans,
+    }
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+    const objectUrl = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    const traceId = sanitizeFileName(trace.traceId || 'trace')
+    const spanId = sanitizeFileName(span.spanId || 'span')
+    anchor.href = objectUrl
+    anchor.download = `${traceId}-${spanId}.json`
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(objectUrl)
+    setFeedback('Span JSON exported')
+  }, [childSpans, parentSpan, setFeedback, span, trace.traceId])
+
+  return (
+    <aside
+      className="flex min-w-0 flex-col gap-3 rounded bg-[var(--color-surface-container-low)] p-4"
+      aria-label="Span details panel"
+      data-testid="trace-span-details-panel"
+    >
+      <header className="flex items-start justify-between gap-3 pb-3">
+        <div>
+          <h3 className="m-0 text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Span details
+          </h3>
+          <p className="mt-1 text-sm font-semibold text-[var(--color-on-surface)]">
+            {span.operationName || '(unnamed span)'}
+          </p>
+        </div>
+        <span
+          className={
+            span.status === 'error'
+              ? 'shrink-0 rounded-sm border border-[var(--color-error)]/20 bg-[var(--color-error)]/10 px-2.5 py-0.5 text-xs font-medium uppercase tracking-wide text-[var(--color-error)]'
+              : 'shrink-0 rounded-sm border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-2.5 py-0.5 text-xs font-medium uppercase tracking-wide text-[var(--color-primary)]'
+          }
+        >
+          {span.status === 'error' ? 'Error' : 'OK'}
+        </span>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1.5 text-xs text-[var(--color-on-surface-variant)] transition hover:border-[var(--color-primary)]/20 hover:text-[var(--color-primary)]"
+          onClick={() => copyToClipboard(span.spanId, 'Span ID')}
+        >
+          Copy span ID
+        </button>
+        <button
+          type="button"
+          className="cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1.5 text-xs text-[var(--color-on-surface-variant)] transition hover:border-[var(--color-primary)]/20 hover:text-[var(--color-primary)]"
+          onClick={() => copyToClipboard(trace.traceId, 'Trace ID')}
+        >
+          Copy trace ID
+        </button>
+        <button
+          type="button"
+          className="cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1.5 text-xs text-[var(--color-on-surface-variant)] transition hover:border-[var(--color-primary)]/20 hover:text-[var(--color-primary)]"
+          onClick={openTraceLogs}
+        >
+          View Logs
+        </button>
+        <button
+          type="button"
+          className="cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1.5 text-xs text-[var(--color-on-surface-variant)] transition hover:border-[var(--color-primary)]/20 hover:text-[var(--color-primary)]"
+          onClick={openServiceMetrics}
+        >
+          View Service Metrics
+        </button>
+        <button
+          type="button"
+          className="cursor-pointer rounded-sm bg-[var(--color-surface-container-high)] px-3 py-1.5 text-xs text-[var(--color-on-surface-variant)] transition hover:border-[var(--color-primary)]/20 hover:text-[var(--color-primary)]"
+          onClick={exportSpanJson}
+        >
+          Export JSON
+        </button>
+      </div>
+      {feedbackMessage ? (
+        <p className="-mt-1 text-xs font-medium text-[var(--color-primary)]">{feedbackMessage}</p>
+      ) : null}
+
+      <section className="grid grid-cols-2 gap-x-3 gap-y-2 rounded-sm p-3 max-md:grid-cols-1">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Service
+          </span>
+          <code className="break-all font-mono text-sm text-[var(--color-on-surface)]">
+            {span.serviceName || 'unknown'}
+          </code>
+        </div>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Duration
+          </span>
+          <code className="break-all font-mono text-sm text-[var(--color-on-surface)]">
+            {formatDurationNano(span.durationNano)}
+          </code>
+        </div>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Start
+          </span>
+          <span className="text-sm text-[var(--color-on-surface-variant)]">
+            {formatTraceStartFull(span.startTimeUnixNano)}
+          </span>
+        </div>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            End
+          </span>
+          <span className="text-sm text-[var(--color-on-surface-variant)]">
+            {formatTraceStartFull(span.startTimeUnixNano + span.durationNano)}
+          </span>
+        </div>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Offset
+          </span>
+          <code className="break-all font-mono text-sm text-[var(--color-on-surface)]">
+            {formatTraceOffset(span.startTimeUnixNano)}
+          </code>
+        </div>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Span ID
+          </span>
+          <code className="break-all font-mono text-sm text-[var(--color-on-surface)]">
+            {span.spanId}
+          </code>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2.5 rounded-sm p-3">
+        <h4 className="m-0 text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+          Relationships
+        </h4>
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Parent
+          </span>
+          {parentSpan ? (
+            <button
+              type="button"
+              className="cursor-pointer rounded-sm border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-3 py-1.5 text-left text-sm text-[var(--color-primary)] transition hover:border-[var(--color-primary)]/20 hover:text-[var(--color-primary)]"
+              onClick={() => onSelectSpan?.(parentSpan)}
+            >
+              {parentSpan.operationName || '(unnamed span)'}
+            </button>
+          ) : (
+            <span className="text-sm text-[var(--color-outline)]">Root span</span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+            Children
+          </span>
+          {childSpans.length > 0 ? (
+            <div className="flex flex-col gap-1">
+              {childSpans.map(child => (
+                <button
+                  key={child.spanId}
+                  type="button"
+                  className="cursor-pointer rounded-sm border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-3 py-1.5 text-left text-sm text-[var(--color-primary)] transition hover:border-[var(--color-primary)]/20 hover:text-[var(--color-primary)]"
+                  onClick={() => onSelectSpan?.(child)}
+                >
+                  {child.operationName || '(unnamed span)'}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <span className="text-sm text-[var(--color-outline)]">No child spans</span>
+          )}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2 rounded-sm p-3">
+        <h4 className="m-0 text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+          Attributes
+        </h4>
+        {sortedTags.length > 0 ? (
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                <th className="border-b border-[var(--color-stroke-subtle)] pb-1.5 text-left text-xs text-[var(--color-outline)]">
+                  Key
+                </th>
+                <th className="border-b border-[var(--color-stroke-subtle)] pb-1.5 text-left text-xs text-[var(--color-outline)]">
+                  Value
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedTags.map(([key, value]) => (
+                <tr key={key}>
+                  <td className="border-b border-[var(--color-stroke-subtle)] py-1.5 align-top">
+                    <code className="rounded-sm bg-[var(--color-surface-container-high)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-outline)]">
+                      {key}
+                    </code>
+                  </td>
+                  <td className="border-b border-[var(--color-stroke-subtle)] py-1.5 align-top">
+                    <code className="rounded-sm bg-[var(--color-surface-container-high)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface)]">
+                      {value}
+                    </code>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="m-0 text-sm text-[var(--color-outline)]">No span attributes.</p>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2 rounded-sm p-3">
+        <h4 className="m-0 text-xs font-semibold uppercase tracking-wider text-[var(--color-outline)]">
+          Logs and events
+        </h4>
+        {sortedLogs.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            {sortedLogs.map((log, index) => {
+              const logFields = formatLogFields(log)
+
+              return (
+                <article
+                  key={`${log.timestampUnixNano}-${index}`}
+                  className="flex flex-col gap-2 rounded-sm p-2.5"
+                >
+                  <div className="flex items-center justify-between gap-2 text-xs text-[var(--color-outline)]">
+                    <span>{formatTraceStartFull(log.timestampUnixNano)}</span>
+                    <code className="font-mono">{formatTraceOffset(log.timestampUnixNano)}</code>
+                  </div>
+                  {logFields.length > 0 ? (
+                    <div className="flex flex-col gap-1">
+                      {logFields.map(([fieldKey, fieldValue]) => (
+                        <div key={fieldKey} className="flex items-start gap-2">
+                          <code className="rounded-sm bg-[var(--color-surface-container-high)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-outline)]">
+                            {fieldKey}
+                          </code>
+                          <code className="rounded-sm bg-[var(--color-surface-container-high)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-on-surface)]">
+                            {fieldValue}
+                          </code>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="m-0 text-sm text-[var(--color-outline)]">No log fields</p>
+                  )}
+                </article>
+              )
+            })}
+          </div>
+        ) : (
+          <p className="m-0 text-sm text-[var(--color-outline)]">No logs or events for this span.</p>
+        )}
+      </section>
+    </aside>
+  )
+}

--- a/frontend/src/components/TraceSpanDetailsPanel.tsx
+++ b/frontend/src/components/TraceSpanDetailsPanel.tsx
@@ -407,7 +407,7 @@ export function TraceSpanDetailsPanel({
 
               return (
                 <article
-                  key={`${log.timestampUnixNano}-${log.body ?? ''}-${JSON.stringify(log.fields ?? {})}`}
+                  key={`${log.timestampUnixNano}-${JSON.stringify(log.fields ?? {})}`}
                   className="flex flex-col gap-2 rounded-sm p-2.5"
                 >
                   <div className="flex items-center justify-between gap-2 text-xs text-[var(--color-outline)]">

--- a/frontend/src/components/TraceTimeline.tsx
+++ b/frontend/src/components/TraceTimeline.tsx
@@ -1,0 +1,465 @@
+import { useMemo, useState } from 'react'
+import type { Trace, TraceSpan } from '@/types/datasource'
+import { chartPalette, thresholdColors } from '@/utils/chartTheme'
+import { formatDurationNano } from '@/utils/traceFormat'
+
+interface SpanRow {
+  span: TraceSpan
+  depth: number
+}
+
+interface LongestPathResult {
+  score: number
+  path: string[]
+}
+
+type TraceTimelineProps = {
+  trace: Trace
+  selectedSpanId?: string | null
+  onSelectSpan?: (span: TraceSpan) => void
+}
+
+const axisHeight = 34
+const rowHeight = 30
+const labelWidth = 300
+const barsWidth = 880
+const markerCount = 6
+const serviceColorPalette = chartPalette
+
+function spanSort(a: TraceSpan, b: TraceSpan): number {
+  if (a.startTimeUnixNano === b.startTimeUnixNano) {
+    return b.durationNano - a.durationNano
+  }
+  return a.startTimeUnixNano - b.startTimeUnixNano
+}
+
+function clamped(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function TraceTimeline({ trace, selectedSpanId, onSelectSpan }: TraceTimelineProps) {
+  const [zoomPercent, setZoomPercent] = useState(100)
+  const [panPercent, setPanPercent] = useState(0)
+
+  const spanMap = useMemo(() => {
+    const byId = new Map<string, TraceSpan>()
+    for (const span of trace.spans) {
+      byId.set(span.spanId, span)
+    }
+    return byId
+  }, [trace.spans])
+
+  const childMap = useMemo(() => {
+    const children = new Map<string, TraceSpan[]>()
+    for (const span of trace.spans) {
+      if (!span.parentSpanId) {
+        continue
+      }
+
+      const list = children.get(span.parentSpanId) || []
+      list.push(span)
+      children.set(span.parentSpanId, list)
+    }
+
+    for (const [parentSpanId, spans] of children.entries()) {
+      spans.sort(spanSort)
+      children.set(parentSpanId, spans)
+    }
+
+    return children
+  }, [trace.spans])
+
+  const orderedRows = useMemo<SpanRow[]>(() => {
+    const rows: SpanRow[] = []
+    const visited = new Set<string>()
+
+    const roots = trace.spans
+      .filter(
+        (span) =>
+          !span.parentSpanId || !spanMap.has(span.parentSpanId) || span.parentSpanId === span.spanId,
+      )
+      .sort(spanSort)
+
+    const walk = (span: TraceSpan, depth: number) => {
+      if (visited.has(span.spanId)) {
+        return
+      }
+
+      visited.add(span.spanId)
+      rows.push({ span, depth })
+
+      const children = childMap.get(span.spanId) || []
+      for (const child of children) {
+        walk(child, depth + 1)
+      }
+    }
+
+    for (const root of roots) {
+      walk(root, 0)
+    }
+
+    const leftovers = trace.spans.filter((span) => !visited.has(span.spanId)).sort(spanSort)
+    for (const span of leftovers) {
+      walk(span, 0)
+    }
+
+    return rows
+  }, [trace.spans, spanMap, childMap])
+
+  const traceBounds = useMemo(() => {
+    if (trace.spans.length === 0) {
+      return {
+        start: 0,
+        end: 1,
+        totalDuration: 1,
+      }
+    }
+
+    const spanStarts = trace.spans.map((span) => span.startTimeUnixNano)
+    const spanEnds = trace.spans.map(
+      (span) => span.startTimeUnixNano + Math.max(span.durationNano, 1),
+    )
+
+    const minStart = Math.min(...spanStarts)
+    const maxEnd = Math.max(...spanEnds)
+    const traceStart =
+      trace.startTimeUnixNano > 0 ? Math.min(trace.startTimeUnixNano, minStart) : minStart
+    const traceEndFromDuration = traceStart + Math.max(trace.durationNano, 1)
+    const traceEnd = Math.max(maxEnd, traceEndFromDuration)
+
+    return {
+      start: traceStart,
+      end: traceEnd,
+      totalDuration: Math.max(traceEnd - traceStart, 1),
+    }
+  }, [trace])
+
+  const zoomScale = useMemo(() => Math.max(1, zoomPercent / 100), [zoomPercent])
+  const windowDuration = useMemo(
+    () => traceBounds.totalDuration / zoomScale,
+    [traceBounds.totalDuration, zoomScale],
+  )
+  const maxPanDuration = useMemo(
+    () => Math.max(traceBounds.totalDuration - windowDuration, 0),
+    [traceBounds.totalDuration, windowDuration],
+  )
+  const windowStart = useMemo(
+    () => traceBounds.start + maxPanDuration * (panPercent / 100),
+    [traceBounds.start, maxPanDuration, panPercent],
+  )
+  const windowEnd = useMemo(
+    () => windowStart + windowDuration,
+    [windowStart, windowDuration],
+  )
+
+  const visibleRows = useMemo(() => {
+    return orderedRows.filter((row) => {
+      const spanStart = row.span.startTimeUnixNano
+      const spanEnd = spanStart + Math.max(row.span.durationNano, 1)
+      return spanStart <= windowEnd && spanEnd >= windowStart
+    })
+  }, [orderedRows, windowStart, windowEnd])
+
+  const svgHeight = useMemo(
+    () => axisHeight + Math.max(visibleRows.length, 1) * rowHeight + 10,
+    [visibleRows.length],
+  )
+  const svgWidth = labelWidth + barsWidth + 12
+
+  const serviceColorMap = useMemo(() => {
+    const services = [
+      ...new Set(trace.spans.map((span) => span.serviceName || 'unknown')),
+    ].sort()
+    const map = new Map<string, string>()
+    services.forEach((service, index) => {
+      map.set(service, serviceColorPalette[index % serviceColorPalette.length])
+    })
+    return map
+  }, [trace.spans])
+
+  const timeMarkers = useMemo(() => {
+    const markers: Array<{ x: number; label: string }> = []
+    for (let i = 0; i <= markerCount; i += 1) {
+      const ratio = i / markerCount
+      const timestamp = windowStart + windowDuration * ratio
+      markers.push({
+        x: labelWidth + barsWidth * ratio,
+        label: `+${formatDurationNano(Math.max(timestamp - traceBounds.start, 0))}`,
+      })
+    }
+    return markers
+  }, [windowStart, windowDuration, traceBounds.start])
+
+  const criticalPathSpanIds = useMemo(() => {
+    const memo = new Map<string, LongestPathResult>()
+
+    const longestPath = (spanId: string, stack: Set<string>): LongestPathResult => {
+      if (memo.has(spanId)) {
+        return memo.get(spanId) as LongestPathResult
+      }
+
+      if (stack.has(spanId)) {
+        const loopSpan = spanMap.get(spanId)
+        const fallback = {
+          score: Math.max(loopSpan?.durationNano || 0, 1),
+          path: loopSpan ? [loopSpan.spanId] : [],
+        }
+        memo.set(spanId, fallback)
+        return fallback
+      }
+
+      const span = spanMap.get(spanId)
+      if (!span) {
+        const empty = { score: 0, path: [] }
+        memo.set(spanId, empty)
+        return empty
+      }
+
+      stack.add(spanId)
+      let bestChild: LongestPathResult = { score: 0, path: [] }
+      const children = childMap.get(spanId) || []
+      for (const child of children) {
+        const candidate = longestPath(child.spanId, stack)
+        if (candidate.score > bestChild.score) {
+          bestChild = candidate
+        }
+      }
+      stack.delete(spanId)
+
+      const result = {
+        score: Math.max(span.durationNano, 1) + bestChild.score,
+        path: [span.spanId, ...bestChild.path],
+      }
+      memo.set(spanId, result)
+      return result
+    }
+
+    const roots = orderedRows.filter((row) => row.depth === 0).map((row) => row.span)
+
+    let best: LongestPathResult = { score: 0, path: [] }
+    for (const root of roots) {
+      const candidate = longestPath(root.spanId, new Set<string>())
+      if (candidate.score > best.score) {
+        best = candidate
+      }
+    }
+
+    if (best.path.length === 0) {
+      for (const span of trace.spans) {
+        const candidate = longestPath(span.spanId, new Set<string>())
+        if (candidate.score > best.score) {
+          best = candidate
+        }
+      }
+    }
+
+    return new Set(best.path)
+  }, [orderedRows, spanMap, childMap, trace.spans])
+
+  function getServiceColor(serviceName: string): string {
+    return serviceColorMap.get(serviceName || 'unknown') || chartPalette[7]
+  }
+
+  function spanStartToX(startTimeUnixNano: number): number {
+    const ratio = (startTimeUnixNano - windowStart) / windowDuration
+    return labelWidth + clamped(ratio, 0, 1) * barsWidth
+  }
+
+  function spanWidth(durationNano: number, startTimeUnixNano: number): number {
+    const startX = spanStartToX(startTimeUnixNano)
+    const endX = spanStartToX(startTimeUnixNano + Math.max(durationNano, 1))
+    return Math.max(endX - startX, 3)
+  }
+
+  function rowY(rowIndex: number): number {
+    return axisHeight + rowIndex * rowHeight
+  }
+
+  function spanBarStroke(span: TraceSpan): string {
+    if (span.status === 'error') return thresholdColors.critical
+    if (criticalPathSpanIds.has(span.spanId)) return thresholdColors.warning
+    if (span.spanId === selectedSpanId) return 'var(--color-outline-variant)'
+    return 'transparent'
+  }
+
+  function spanBarStrokeWidth(span: TraceSpan): number {
+    if (span.status === 'error') return 2
+    if (span.spanId === selectedSpanId) return 2
+    if (criticalPathSpanIds.has(span.spanId)) return 1.5
+    return 1.5
+  }
+
+  function spanBarOpacity(span: TraceSpan): number {
+    return span.spanId === selectedSpanId ? 1 : 0.85
+  }
+
+  function rowBgFill(rowIndex: number): string {
+    return rowIndex % 2 === 0
+      ? 'var(--color-surface-container-low)'
+      : 'var(--color-surface-container-high)'
+  }
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="trace-timeline">
+      <div className="flex flex-wrap gap-3">
+        <label className="inline-flex items-center gap-2 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-xs text-[var(--color-outline)] max-sm:w-full max-sm:justify-between">
+          <span>Zoom</span>
+          <input
+            type="range"
+            min={100}
+            max={400}
+            step={25}
+            value={zoomPercent}
+            onChange={(event) => setZoomPercent(Number(event.target.value))}
+            className="w-36 max-sm:w-30"
+          />
+          <strong className="min-w-[3.1rem] text-right text-xs font-semibold text-[var(--color-on-surface)]">
+            {zoomPercent}%
+          </strong>
+        </label>
+
+        <label
+          className={`inline-flex items-center gap-2 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2 text-xs text-[var(--color-outline)] max-sm:w-full max-sm:justify-between${maxPanDuration === 0 ? ' opacity-60' : ''}`}
+        >
+          <span>Pan</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={panPercent}
+            disabled={maxPanDuration === 0}
+            onChange={(event) => setPanPercent(Number(event.target.value))}
+            className="w-36 max-sm:w-30"
+          />
+          <strong className="min-w-[3.1rem] text-right text-xs font-semibold text-[var(--color-on-surface)]">
+            {panPercent}%
+          </strong>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {Array.from(serviceColorMap.entries()).map(([serviceName, color]) => (
+          <span
+            key={serviceName}
+            className="inline-flex items-center gap-1.5 rounded-sm bg-[var(--color-surface-container-high)] px-2.5 py-1 text-xs text-[var(--color-outline)]"
+          >
+            <i
+              className="inline-block h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            {serviceName}
+          </span>
+        ))}
+        <span className="inline-flex items-center gap-1.5 rounded-sm border border-[var(--color-tertiary)]/20 bg-[var(--color-tertiary)]/10 px-2.5 py-1 text-xs text-[var(--color-tertiary)]">
+          <i className="inline-block h-2.5 w-2.5 rounded-full bg-[var(--color-tertiary)]" />
+          Critical path
+        </span>
+      </div>
+
+      <div className="overflow-x-auto rounded bg-[var(--color-surface-container-low)]">
+        {visibleRows.length > 0 ? (
+          <svg
+            width={svgWidth}
+            height={svgHeight}
+            className="block"
+            role="img"
+            aria-label="Trace timeline waterfall"
+          >
+            <g>
+              {timeMarkers.map((marker) => (
+                <line
+                  key={`axis-${marker.x}`}
+                  x1={marker.x}
+                  y1={0}
+                  x2={marker.x}
+                  y2={svgHeight}
+                  stroke="var(--color-stroke-subtle)"
+                  strokeWidth={1}
+                />
+              ))}
+              {timeMarkers.map((marker) => (
+                <text
+                  key={`axis-label-${marker.x}`}
+                  x={marker.x}
+                  y={14}
+                  textAnchor="middle"
+                  fill="var(--color-outline)"
+                  fontSize={10}
+                  fontFamily="JetBrains Mono, monospace"
+                >
+                  {marker.label}
+                </text>
+              ))}
+            </g>
+
+            <g>
+              <line
+                x1={labelWidth}
+                y1={0}
+                x2={labelWidth}
+                y2={svgHeight}
+                stroke="var(--color-stroke-strong)"
+                strokeWidth={1}
+              />
+            </g>
+
+            {visibleRows.map((row, rowIndex) => (
+              <g key={row.span.spanId}>
+                <rect
+                  x={0}
+                  y={rowY(rowIndex)}
+                  width={svgWidth}
+                  height={rowHeight}
+                  fill={rowBgFill(rowIndex)}
+                />
+
+                <text
+                  x={12 + row.depth * 14}
+                  y={rowY(rowIndex) + 19}
+                  fill="var(--color-on-surface)"
+                  fontSize={11}
+                  className="select-none"
+                >
+                  <title>{`${row.span.operationName} (${row.span.serviceName})`}</title>
+                  {row.span.operationName || '(unnamed span)'}
+                </text>
+
+                <rect
+                  x={spanStartToX(row.span.startTimeUnixNano)}
+                  y={rowY(rowIndex) + 6}
+                  width={spanWidth(row.span.durationNano, row.span.startTimeUnixNano)}
+                  height={rowHeight - 12}
+                  rx={4}
+                  className="cursor-pointer"
+                  fill={getServiceColor(row.span.serviceName)}
+                  fillOpacity={spanBarOpacity(row.span)}
+                  stroke={spanBarStroke(row.span)}
+                  strokeWidth={spanBarStrokeWidth(row.span)}
+                  onClick={() => onSelectSpan?.(row.span)}
+                />
+
+                <text
+                  x={
+                    spanStartToX(row.span.startTimeUnixNano) +
+                    spanWidth(row.span.durationNano, row.span.startTimeUnixNano) +
+                    6
+                  }
+                  y={rowY(rowIndex) + 19}
+                  fill="var(--color-on-surface-variant)"
+                  fontSize={10}
+                  fontFamily="JetBrains Mono, monospace"
+                >
+                  {formatDurationNano(row.span.durationNano)}
+                </text>
+              </g>
+            ))}
+          </svg>
+        ) : (
+          <div className="p-4 text-sm text-[var(--color-outline)]">
+            No spans visible in the current zoom window.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TraceTimeline.tsx
+++ b/frontend/src/components/TraceTimeline.tsx
@@ -424,6 +424,7 @@ export function TraceTimeline({ trace, selectedSpanId, onSelectSpan }: TraceTime
                   {row.span.operationName || '(unnamed span)'}
                 </text>
 
+                {/* biome-ignore lint/a11y/noStaticElementInteractions: SVG rect span selector */}
                 <rect
                   x={spanStartToX(row.span.startTimeUnixNano)}
                   y={rowY(rowIndex) + 6}

--- a/frontend/src/components/TraceTimeline.tsx
+++ b/frontend/src/components/TraceTimeline.tsx
@@ -115,13 +115,20 @@ export function TraceTimeline({ trace, selectedSpanId, onSelectSpan }: TraceTime
       }
     }
 
-    const spanStarts = trace.spans.map((span) => span.startTimeUnixNano)
-    const spanEnds = trace.spans.map(
-      (span) => span.startTimeUnixNano + Math.max(span.durationNano, 1),
-    )
+    // Loop instead of Math.min/max(...arr) to avoid call-stack argument limits
+    // on dense traces (spread can exceed engine arg caps ~65k–500k).
+    let minStart = Number.POSITIVE_INFINITY
+    let maxEnd = Number.NEGATIVE_INFINITY
+    for (const span of trace.spans) {
+      if (span.startTimeUnixNano < minStart) {
+        minStart = span.startTimeUnixNano
+      }
+      const spanEnd = span.startTimeUnixNano + Math.max(span.durationNano, 1)
+      if (spanEnd > maxEnd) {
+        maxEnd = spanEnd
+      }
+    }
 
-    const minStart = Math.min(...spanStarts)
-    const maxEnd = Math.max(...spanEnds)
     const traceStart =
       trace.startTimeUnixNano > 0 ? Math.min(trace.startTimeUnixNano, minStart) : minStart
     const traceEndFromDuration = traceStart + Math.max(trace.durationNano, 1)

--- a/frontend/src/components/TracesExplorePanel.tsx
+++ b/frontend/src/components/TracesExplorePanel.tsx
@@ -1,0 +1,1105 @@
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  CircleAlert,
+  HeartPulse,
+  Loader2,
+  Search,
+  Star,
+  Waypoints,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import {
+  fetchDataSourceTrace,
+  fetchDataSourceTraceServiceGraph,
+  fetchDataSourceTraceServices,
+  queryDataSource,
+  searchDataSourceTraces,
+} from '@/api/datasources'
+import { ClickHouseSQLEditor } from '@/components/ClickHouseSQLEditor'
+import { TimeRangePicker } from '@/components/TimeRangePicker'
+import { TraceListPanel } from '@/components/TraceListPanel'
+import { TraceServiceGraph } from '@/components/TraceServiceGraph'
+import { TraceSpanDetailsPanel } from '@/components/TraceSpanDetailsPanel'
+import { TraceTimeline } from '@/components/TraceTimeline'
+import { useTimeRange } from '@/hooks/useTimeRange'
+import { useTracingDatasources } from '@/hooks/useTracingDatasources'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import {
+  dataSourceTypeLabels,
+  type DataSourceType,
+  type Trace,
+  type TraceServiceGraph as TraceServiceGraphModel,
+  type TraceSpan,
+  type TraceSummary,
+} from '@/types/datasource'
+import { convertClickHouseSpansToTraceSummaries } from '@/utils/traceClickHouse'
+import { dataSourceTypeLogos } from '@/utils/datasourceLogos'
+import { formatDurationNano, formatTraceStart } from '@/utils/traceFormat'
+
+type DatasourceHealthStatus = 'unknown' | 'checking' | 'healthy' | 'unhealthy'
+
+type TracesExplorePanelProps = {
+  onDatasourceChanged?: (payload: { id: string; name: string; type: string }) => void
+}
+
+const CLICKHOUSE_DEFAULT_QUERY =
+  "SELECT\n  SpanId AS span_id,\n  ParentSpanId AS parent_span_id,\n  SpanName AS operation_name,\n  ServiceName AS service_name,\n  toUnixTimestamp64Nano(Timestamp) AS start_time_unix_nano,\n  Duration AS duration_nano,\n  StatusCode AS status\nFROM ace_traces\nWHERE Timestamp BETWEEN fromUnixTimestamp64Nano({start_ns}) AND fromUnixTimestamp64Nano({end_ns})\nLIMIT 200"
+
+const TRACE_NAVIGATION_CONTEXT_KEY = 'dashboard_trace_navigation'
+const TRACE_LOGS_NAVIGATION_CONTEXT_KEY = 'trace_logs_navigation'
+const TRACE_METRICS_NAVIGATION_CONTEXT_KEY = 'trace_metrics_navigation'
+const TRACE_NAVIGATION_MAX_AGE_MS = 5 * 60 * 1000
+const TRACE_TO_X_PADDING_MS = 5 * 60 * 1000
+
+function getTypeLogo(type_: DataSourceType): string | undefined {
+  return dataSourceTypeLogos[type_]
+}
+
+function toMilliseconds(unixNanoTimestamp: number): number {
+  return Math.floor(unixNanoTimestamp / 1_000_000)
+}
+
+export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelProps) {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const currentOrgId = useOrgStore(state => state.currentOrgId)
+  const { tracingDatasources } = useTracingDatasources(currentOrgId)
+  const { timeRange, isCustomRange, onRefresh } = useTimeRange()
+  const toggleFavorite = useFavoritesStore(state => state.toggleFavorite)
+  const isFavorite = useFavoritesStore(state => state.isFavorite)
+
+  const [selectedDatasourceId, setSelectedDatasourceId] = useState('')
+  const [showDatasourceMenu, setShowDatasourceMenu] = useState(false)
+  const [datasourceHealth, setDatasourceHealth] = useState<Record<string, DatasourceHealthStatus>>({})
+  const [datasourceHealthErrors, setDatasourceHealthErrors] = useState<Record<string, string>>({})
+
+  const [query, setQuery] = useState('')
+  const [selectedService, setSelectedService] = useState('')
+  const [limit, setLimit] = useState(20)
+  const [traceIdInput, setTraceIdInput] = useState('')
+
+  const [loadingSearch, setLoadingSearch] = useState(false)
+  const [loadingTrace, setLoadingTrace] = useState(false)
+  const [loadingServices, setLoadingServices] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [serviceGraphError, setServiceGraphError] = useState<string | null>(null)
+
+  const [services, setServices] = useState<string[]>([])
+  const [traceSummaries, setTraceSummaries] = useState<TraceSummary[]>([])
+  const [selectedTraceId, setSelectedTraceId] = useState('')
+  const [activeTrace, setActiveTrace] = useState<Trace | null>(null)
+  const [activeServiceGraph, setActiveServiceGraph] = useState<TraceServiceGraphModel | null>(null)
+  const [selectedSpan, setSelectedSpan] = useState<TraceSpan | null>(null)
+  const [loadingServiceGraph, setLoadingServiceGraph] = useState(false)
+  const [hasSearched, setHasSearched] = useState(false)
+
+  const datasourceMenuRef = useRef<HTMLDivElement | null>(null)
+  const pendingTraceDatasourceIdRef = useRef('')
+  const pendingTraceIdRef = useRef('')
+
+  const hasTracingDatasources = tracingDatasources.length > 0
+  const activeDatasource = useMemo(
+    () => tracingDatasources.find(ds => ds.id === selectedDatasourceId) ?? null,
+    [tracingDatasources, selectedDatasourceId],
+  )
+  const isClickHouseDatasource = activeDatasource?.type === 'clickhouse'
+
+  const activeDatasourceHealth = activeDatasource
+    ? datasourceHealth[activeDatasource.id] || 'unknown'
+    : 'unknown'
+
+  const activeDatasourceHealthLabel =
+    activeDatasourceHealth === 'healthy'
+      ? 'Healthy'
+      : activeDatasourceHealth === 'unhealthy'
+        ? 'Unhealthy'
+        : activeDatasourceHealth === 'checking'
+          ? 'Checking...'
+          : 'Unknown'
+
+  const activeDatasourceHealthError = activeDatasource
+    ? datasourceHealthErrors[activeDatasource.id] || ''
+    : ''
+
+  const checkDatasourceHealth = useCallback(async (datasourceId: string, type_: DataSourceType) => {
+    setDatasourceHealth(prev => ({ ...prev, [datasourceId]: 'checking' }))
+    setDatasourceHealthErrors(prev => {
+      const next = { ...prev }
+      delete next[datasourceId]
+      return next
+    })
+
+    try {
+      if (type_ === 'clickhouse') {
+        const end = Math.floor(Date.now() / 1000)
+        const start = end - 15 * 60
+        const healthResult = await queryDataSource(datasourceId, {
+          query: "SELECT now() AS timestamp, 'up' AS status LIMIT 1",
+          signal: 'traces',
+          start,
+          end,
+          step: 15,
+          limit: 1,
+        })
+
+        if (healthResult.status === 'error') {
+          throw new Error(healthResult.error || 'Health check failed')
+        }
+      } else {
+        await fetchDataSourceTraceServices(datasourceId)
+      }
+
+      setDatasourceHealth(prev => ({ ...prev, [datasourceId]: 'healthy' }))
+    } catch (e) {
+      setDatasourceHealth(prev => ({ ...prev, [datasourceId]: 'unhealthy' }))
+      setDatasourceHealthErrors(prev => ({
+        ...prev,
+        [datasourceId]: e instanceof Error ? e.message : 'Health check failed',
+      }))
+    }
+  }, [])
+
+  const runClickHouseTraceQuery = useCallback(async () => {
+    if (!query.trim()) {
+      setError('Query is required')
+      return
+    }
+
+    if (!selectedDatasourceId) {
+      setError('Select a tracing datasource')
+      return
+    }
+
+    setHasSearched(true)
+    setLoadingSearch(true)
+    setError(null)
+    setActiveTrace(null)
+    setActiveServiceGraph(null)
+    setServiceGraphError(null)
+    setSelectedTraceId('')
+    setSelectedSpan(null)
+
+    try {
+      const start = Math.floor(timeRange.start / 1000)
+      const end = Math.floor(timeRange.end / 1000)
+
+      const response = await queryDataSource(selectedDatasourceId, {
+        query,
+        signal: 'traces',
+        start,
+        end,
+        step: 15,
+        limit,
+      })
+
+      if (response.status === 'error') {
+        setError(response.error || 'Query failed')
+        setTraceSummaries([])
+        return
+      }
+
+      if (response.resultType !== 'traces') {
+        setError('Selected datasource did not return trace results')
+        setTraceSummaries([])
+        return
+      }
+
+      setTraceSummaries(convertClickHouseSpansToTraceSummaries(response.data?.traces || []))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to query traces')
+      setTraceSummaries([])
+    } finally {
+      setLoadingSearch(false)
+    }
+  }, [limit, query, selectedDatasourceId, timeRange.end, timeRange.start])
+
+  const runSearch = useCallback(async () => {
+    if (!selectedDatasourceId) {
+      setError('Select a tracing datasource')
+      return
+    }
+
+    if (isClickHouseDatasource) {
+      await runClickHouseTraceQuery()
+      return
+    }
+
+    setHasSearched(true)
+    setLoadingSearch(true)
+    setError(null)
+
+    try {
+      let start: number
+      let end: number
+
+      if (isCustomRange) {
+        start = Math.floor(timeRange.start / 1000)
+        end = Math.floor(timeRange.end / 1000)
+      } else {
+        const windowDurationSeconds = Math.max(
+          1,
+          Math.floor((timeRange.end - timeRange.start) / 1000),
+        )
+        end = Math.floor(Date.now() / 1000)
+        start = end - windowDurationSeconds
+      }
+
+      const summaries = await searchDataSourceTraces(selectedDatasourceId, {
+        query: query.trim() || undefined,
+        service: selectedService || undefined,
+        start,
+        end,
+        limit,
+      })
+      setTraceSummaries(summaries)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to search traces')
+      setTraceSummaries([])
+    } finally {
+      setLoadingSearch(false)
+    }
+  }, [
+    isClickHouseDatasource,
+    isCustomRange,
+    limit,
+    query,
+    runClickHouseTraceQuery,
+    selectedDatasourceId,
+    selectedService,
+    timeRange.end,
+    timeRange.start,
+  ])
+
+  const loadTrace = useCallback(
+    async (traceId: string) => {
+      if (isClickHouseDatasource) {
+        setError('Trace detail lookup is not available for ClickHouse SQL results yet')
+        return
+      }
+
+      if (!selectedDatasourceId) {
+        setError('Select a tracing datasource')
+        return
+      }
+
+      setLoadingTrace(true)
+      setError(null)
+
+      try {
+        const trace = await fetchDataSourceTrace(selectedDatasourceId, traceId)
+        setActiveTrace(trace)
+        setLoadingServiceGraph(true)
+        setServiceGraphError(null)
+
+        try {
+          const graph = await fetchDataSourceTraceServiceGraph(selectedDatasourceId, traceId)
+          setActiveServiceGraph(graph)
+        } catch (graphError) {
+          setActiveServiceGraph(null)
+          setServiceGraphError(
+            graphError instanceof Error ? graphError.message : 'Failed to fetch trace service graph',
+          )
+        } finally {
+          setLoadingServiceGraph(false)
+        }
+
+        setSelectedTraceId(traceId)
+        setSelectedSpan(null)
+        setTraceIdInput(traceId)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to fetch trace')
+        setActiveTrace(null)
+        setActiveServiceGraph(null)
+        setServiceGraphError(null)
+        setLoadingServiceGraph(false)
+      } finally {
+        setLoadingTrace(false)
+      }
+    },
+    [isClickHouseDatasource, selectedDatasourceId],
+  )
+
+  const loadServices = useCallback(
+    async (autoSearch = false) => {
+      if (isClickHouseDatasource) {
+        setServices([])
+        setSelectedService('')
+        return
+      }
+
+      if (!selectedDatasourceId) {
+        setServices([])
+        setSelectedService('')
+        return
+      }
+
+      setLoadingServices(true)
+      try {
+        const serviceList = await fetchDataSourceTraceServices(selectedDatasourceId)
+        setServices(serviceList)
+        setSelectedService(current =>
+          current && !serviceList.includes(current) ? '' : current,
+        )
+        if (autoSearch) {
+          void runSearch()
+        }
+      } catch {
+        setServices([])
+      } finally {
+        setLoadingServices(false)
+      }
+    },
+    [isClickHouseDatasource, runSearch, selectedDatasourceId],
+  )
+
+  const tryLoadPendingTrace = useCallback(async () => {
+    if (!pendingTraceIdRef.current || !selectedDatasourceId) {
+      return
+    }
+
+    if (
+      pendingTraceDatasourceIdRef.current &&
+      pendingTraceDatasourceIdRef.current !== selectedDatasourceId
+    ) {
+      return
+    }
+
+    const traceId = pendingTraceIdRef.current
+    pendingTraceIdRef.current = ''
+    pendingTraceDatasourceIdRef.current = ''
+    setTraceIdInput(traceId)
+    await loadTrace(traceId)
+  }, [loadTrace, selectedDatasourceId])
+
+  const selectDatasource = useCallback(
+    (datasourceId: string) => {
+      setSelectedDatasourceId(datasourceId)
+      setShowDatasourceMenu(false)
+
+      const ds = tracingDatasources.find(d => d.id === datasourceId)
+      if (ds?.type === 'clickhouse' && !query.trim()) {
+        setQuery(CLICKHOUSE_DEFAULT_QUERY)
+        void runSearch()
+      }
+    },
+    [query, runSearch, tracingDatasources],
+  )
+
+  const buildNavigationWindow = useCallback(
+    (payload: { startTimeUnixNano: number; endTimeUnixNano: number }) => {
+      const startMs = toMilliseconds(payload.startTimeUnixNano)
+      const endMs = toMilliseconds(payload.endTimeUnixNano)
+      const paddedStartMs = Math.max(0, startMs - TRACE_TO_X_PADDING_MS)
+      const paddedEndMs = Math.max(paddedStartMs + 1_000, endMs + TRACE_TO_X_PADDING_MS)
+      return { startMs: paddedStartMs, endMs: paddedEndMs }
+    },
+    [],
+  )
+
+  const openTraceLogs = useCallback(
+    (payload: {
+      traceId: string
+      serviceName: string
+      startTimeUnixNano: number
+      endTimeUnixNano: number
+    }) => {
+      const { startMs, endMs } = buildNavigationWindow(payload)
+      try {
+        localStorage.setItem(
+          TRACE_LOGS_NAVIGATION_CONTEXT_KEY,
+          JSON.stringify({
+            traceId: payload.traceId,
+            serviceName: payload.serviceName || undefined,
+            startMs,
+            endMs,
+            createdAt: Date.now(),
+          }),
+        )
+      } catch {
+        // Ignore localStorage write issues.
+      }
+      navigate('/app/explore/logs')
+    },
+    [buildNavigationWindow, navigate],
+  )
+
+  const openServiceMetrics = useCallback(
+    (payload: {
+      serviceName: string
+      startTimeUnixNano: number
+      endTimeUnixNano: number
+    }) => {
+      const { startMs, endMs } = buildNavigationWindow(payload)
+      try {
+        localStorage.setItem(
+          TRACE_METRICS_NAVIGATION_CONTEXT_KEY,
+          JSON.stringify({
+            serviceName: payload.serviceName || undefined,
+            startMs,
+            endMs,
+            createdAt: Date.now(),
+          }),
+        )
+      } catch {
+        // Ignore localStorage write issues.
+      }
+      navigate('/app/explore/metrics')
+    },
+    [buildNavigationWindow, navigate],
+  )
+
+  useEffect(() => {
+    const queryParam = searchParams.get('q')
+    if (queryParam) {
+      setQuery(queryParam)
+    }
+
+    const queryTraceId = searchParams.get('traceId')
+    const queryDatasourceId = searchParams.get('datasourceId')
+    if (queryTraceId) {
+      pendingTraceIdRef.current = queryTraceId
+      setTraceIdInput(queryTraceId)
+    }
+    if (queryDatasourceId) {
+      pendingTraceDatasourceIdRef.current = queryDatasourceId
+    }
+
+    try {
+      const rawContext = localStorage.getItem(TRACE_NAVIGATION_CONTEXT_KEY)
+      localStorage.removeItem(TRACE_NAVIGATION_CONTEXT_KEY)
+      if (rawContext) {
+        const parsed = JSON.parse(rawContext) as {
+          traceId?: string
+          datasourceId?: string
+          createdAt?: number
+        }
+        if (parsed.traceId && typeof parsed.traceId === 'string') {
+          if (typeof parsed.createdAt === 'number') {
+            const ageMs = Date.now() - parsed.createdAt
+            if (ageMs <= TRACE_NAVIGATION_MAX_AGE_MS) {
+              pendingTraceIdRef.current = parsed.traceId.trim()
+              pendingTraceDatasourceIdRef.current =
+                typeof parsed.datasourceId === 'string' ? parsed.datasourceId.trim() : ''
+            }
+          } else {
+            pendingTraceIdRef.current = parsed.traceId.trim()
+            pendingTraceDatasourceIdRef.current =
+              typeof parsed.datasourceId === 'string' ? parsed.datasourceId.trim() : ''
+          }
+        }
+      }
+    } catch {
+      // Ignore malformed navigation context.
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    if (tracingDatasources.length === 0) {
+      setSelectedDatasourceId('')
+      return
+    }
+
+    const hasSelected = tracingDatasources.some(ds => ds.id === selectedDatasourceId)
+    if (!hasSelected) {
+      const pendingDatasource = pendingTraceDatasourceIdRef.current
+        ? tracingDatasources.find(ds => ds.id === pendingTraceDatasourceIdRef.current)
+        : null
+
+      if (pendingDatasource) {
+        setSelectedDatasourceId(pendingDatasource.id)
+        return
+      }
+
+      const defaultDatasource = tracingDatasources.find(ds => ds.is_default)
+      const selected = defaultDatasource || tracingDatasources[0]
+      if (!selected) return
+      setSelectedDatasourceId(selected.id)
+
+      if (selected.type === 'clickhouse' && !query.trim()) {
+        setQuery(CLICKHOUSE_DEFAULT_QUERY)
+      }
+    }
+  }, [query, selectedDatasourceId, tracingDatasources])
+
+  useEffect(() => {
+    if (!activeDatasource) return
+    if ((datasourceHealth[activeDatasource.id] || 'unknown') === 'unknown') {
+      void checkDatasourceHealth(activeDatasource.id, activeDatasource.type)
+    }
+  }, [activeDatasource, checkDatasourceHealth, datasourceHealth])
+
+  useEffect(() => {
+    setTraceSummaries([])
+    setActiveTrace(null)
+    setActiveServiceGraph(null)
+    setServiceGraphError(null)
+    setLoadingServiceGraph(false)
+    setSelectedTraceId('')
+    setSelectedSpan(null)
+    setHasSearched(false)
+
+    void loadServices(true)
+    if (!isClickHouseDatasource) {
+      void tryLoadPendingTrace()
+    }
+  }, [isClickHouseDatasource, loadServices, selectedDatasourceId, tryLoadPendingTrace])
+
+  useEffect(() => {
+    const ds = tracingDatasources.find(d => d.id === selectedDatasourceId)
+    if (ds) {
+      onDatasourceChanged?.({ id: ds.id, name: ds.name, type: ds.type })
+    }
+  }, [onDatasourceChanged, selectedDatasourceId, tracingDatasources])
+
+  useEffect(() => {
+    function handleDocumentClick(event: MouseEvent) {
+      const target = event.target as Node
+      if (!datasourceMenuRef.current?.contains(target)) {
+        setShowDatasourceMenu(false)
+      }
+    }
+
+    document.addEventListener('click', handleDocumentClick)
+    return () => document.removeEventListener('click', handleDocumentClick)
+  }, [])
+
+  useEffect(() => {
+    const unsubscribe = onRefresh(() => {
+      if (hasSearched && selectedDatasourceId && !loadingSearch && !loadingTrace) {
+        void runSearch()
+      }
+    })
+    return unsubscribe
+  }, [hasSearched, loadingSearch, loadingTrace, onRefresh, runSearch, selectedDatasourceId])
+
+  useEffect(() => {
+    setSelectedDatasourceId('')
+    setDatasourceHealth({})
+    setTraceSummaries([])
+    setActiveTrace(null)
+    setError(null)
+  }, [currentOrgId])
+
+  function toggleDatasourceMenu() {
+    if (!hasTracingDatasources || loadingSearch || loadingTrace) {
+      return
+    }
+    setShowDatasourceMenu(current => !current)
+  }
+
+  async function lookupTraceById() {
+    if (isClickHouseDatasource) {
+      setError('Open Trace ID is not available for ClickHouse SQL results yet')
+      return
+    }
+
+    const traceId = traceIdInput.trim()
+    if (!traceId) {
+      setError('Trace ID is required')
+      return
+    }
+
+    await loadTrace(traceId)
+  }
+
+  function handleSelectServiceFromGraph(serviceName: string) {
+    if (!serviceName) return
+    setSelectedService(serviceName)
+    void runSearch()
+  }
+
+  function handleSelectEdgeFromGraph(edge: { source: string; target: string }) {
+    if (!edge.target) return
+    setSelectedService(edge.target)
+    setQuery(`caller.service=${edge.source} callee.service=${edge.target}`)
+    void runSearch()
+  }
+
+  async function handleOpenTraceFromList(traceId: string) {
+    if (isClickHouseDatasource) {
+      setError('Trace detail lookup is not available for ClickHouse SQL results yet')
+      return
+    }
+    await loadTrace(traceId)
+  }
+
+  const favoriteKey = `explore::traces::${query}`
+
+  return (
+    <div className="flex flex-1 flex-col gap-6">
+      <div className="flex flex-col gap-4 rounded bg-[var(--color-surface-container-low)] p-4">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
+          <div className="flex flex-col gap-2.5">
+            <label className="text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]">
+              Data Source
+            </label>
+            <div ref={datasourceMenuRef} className="relative">
+              <button
+                type="button"
+                className="flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 text-left transition disabled:cursor-not-allowed disabled:opacity-60"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  border: '1px solid var(--color-outline-variant)',
+                  color: 'var(--color-on-surface)',
+                }}
+                data-testid="explore-traces-datasource-btn"
+                disabled={!hasTracingDatasources}
+                onClick={toggleDatasourceMenu}
+              >
+                {activeDatasource ? (
+                  <>
+                    <img
+                      src={getTypeLogo(activeDatasource.type)}
+                      alt={`${dataSourceTypeLabels[activeDatasource.type]} logo`}
+                      className="h-7 w-7 shrink-0 object-contain"
+                    />
+                    <div className="flex min-w-0 flex-col gap-px">
+                      <span className="text-[0.68rem] uppercase tracking-wide text-[var(--color-outline)]">
+                        Active Source
+                      </span>
+                      <strong className="truncate text-sm font-semibold text-[var(--color-on-surface)]">
+                        {activeDatasource.name}
+                      </strong>
+                      <span className="text-xs text-[var(--color-outline)]">
+                        {dataSourceTypeLabels[activeDatasource.type]}
+                      </span>
+                    </div>
+                    <span
+                      className="ml-auto inline-flex items-center gap-1.5 rounded-sm px-2.5 py-0.5 text-xs"
+                      style={{
+                        border: '1px solid var(--color-outline-variant)',
+                        color:
+                          activeDatasourceHealth === 'healthy'
+                            ? 'var(--color-secondary)'
+                            : activeDatasourceHealth === 'unhealthy'
+                              ? 'var(--color-error)'
+                              : 'var(--color-outline)',
+                      }}
+                      title={activeDatasourceHealthError || activeDatasourceHealthLabel}
+                    >
+                      {activeDatasourceHealth === 'checking' ? (
+                        <Loader2 size={12} className="animate-spin" />
+                      ) : activeDatasourceHealth === 'healthy' ? (
+                        <HeartPulse size={12} />
+                      ) : activeDatasourceHealth === 'unhealthy' ? (
+                        <CircleAlert size={12} />
+                      ) : null}
+                      <span>{activeDatasourceHealthLabel}</span>
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-sm text-[var(--color-outline)]">
+                    No tracing datasource configured
+                  </span>
+                )}
+                {showDatasourceMenu ? (
+                  <ChevronUp size={16} className="ml-1 shrink-0 text-[var(--color-outline)]" />
+                ) : (
+                  <ChevronDown size={16} className="ml-1 shrink-0 text-[var(--color-outline)]" />
+                )}
+              </button>
+
+              {showDatasourceMenu && hasTracingDatasources ? (
+                <div className="absolute left-0 right-0 top-full z-[110] mt-1.5 max-h-[280px] overflow-y-auto rounded bg-[var(--color-surface-container-low)] shadow-lg">
+                  {tracingDatasources.map(ds => (
+                    <button
+                      key={ds.id}
+                      type="button"
+                      className={`flex w-full cursor-pointer items-center gap-2.5 border-none bg-transparent px-3 py-2.5 text-left text-[var(--color-on-surface)] hover:bg-[var(--color-surface-container-high)] ${
+                        ds.id === selectedDatasourceId ? 'bg-[var(--color-primary)]/10' : ''
+                      }`}
+                      onClick={() => selectDatasource(ds.id)}
+                    >
+                      <img
+                        src={getTypeLogo(ds.type)}
+                        alt={`${dataSourceTypeLabels[ds.type]} logo`}
+                        className="h-[18px] w-[18px] shrink-0 object-contain"
+                      />
+                      <div className="flex min-w-0 flex-col gap-px">
+                        <strong className="text-sm font-semibold text-[var(--color-on-surface)]">
+                          {ds.name}
+                        </strong>
+                        <span className="text-xs text-[var(--color-outline)]">
+                          {dataSourceTypeLabels[ds.type]}
+                        </span>
+                      </div>
+                      {ds.id === selectedDatasourceId ? (
+                        <Check size={14} className="ml-auto text-[var(--color-primary)]" />
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2.5">
+            <label className="text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]">
+              Search Range
+            </label>
+            <TimeRangePicker stacked />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          {!isClickHouseDatasource ? (
+            <>
+              <label className="flex min-w-[180px] flex-col gap-2">
+                <span className="text-xs font-medium text-[var(--color-outline)]">Service</span>
+                <select
+                  value={selectedService}
+                  data-testid="explore-traces-service-select"
+                  disabled={loadingServices || services.length === 0}
+                  className="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{ border: '1px solid var(--color-outline-variant)' }}
+                  onChange={event => setSelectedService(event.target.value)}
+                >
+                  <option value="">All services</option>
+                  {services.map(service => (
+                    <option key={service} value={service}>
+                      {service}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="flex min-w-[110px] flex-col gap-2">
+                <span className="text-xs font-medium text-[var(--color-outline)]">Limit</span>
+                <select
+                  value={limit}
+                  data-testid="explore-traces-limit-select"
+                  className="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)]"
+                  style={{ border: '1px solid var(--color-outline-variant)' }}
+                  onChange={event => setLimit(Number(event.target.value))}
+                >
+                  <option value={10}>10</option>
+                  <option value={20}>20</option>
+                  <option value={50}>50</option>
+                  <option value={100}>100</option>
+                </select>
+              </label>
+            </>
+          ) : (
+            <ClickHouseSQLEditor
+              value={query}
+              signal="traces"
+              disabled={loadingSearch || !selectedDatasourceId}
+              onChange={setQuery}
+            />
+          )}
+        </div>
+
+        {!isClickHouseDatasource ? (
+          <div className="flex flex-col gap-2">
+            <label htmlFor="trace-search-query" className="text-xs font-medium text-[var(--color-outline)]">
+              Search Query
+            </label>
+            <input
+              id="trace-search-query"
+              value={query}
+              data-testid="explore-traces-search-input"
+              type="text"
+              className="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] placeholder:text-[var(--color-outline)]"
+              style={{ border: '1px solid var(--color-outline-variant)' }}
+              placeholder="service.name=api error=true"
+              onChange={event => setQuery(event.target.value)}
+            />
+          </div>
+        ) : null}
+
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            data-testid="explore-traces-search-btn"
+            className="inline-flex cursor-pointer items-center gap-2 whitespace-nowrap rounded-sm bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={
+              loadingSearch ||
+              !selectedDatasourceId ||
+              (isClickHouseDatasource && !query.trim())
+            }
+            onClick={() => void runSearch()}
+          >
+            {loadingSearch ? <Loader2 size={16} className="animate-spin" /> : <Search size={16} />}
+            <span>
+              {loadingSearch
+                ? 'Searching...'
+                : isClickHouseDatasource
+                  ? 'Run Query'
+                  : 'Search Traces'}
+            </span>
+          </button>
+          {isClickHouseDatasource && query.trim() ? (
+            <button
+              type="button"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm border px-3 py-2.5 text-sm transition"
+              style={{
+                backgroundColor: isFavorite(favoriteKey)
+                  ? 'var(--color-primary-muted)'
+                  : 'var(--color-surface-container-high)',
+                borderColor: isFavorite(favoriteKey)
+                  ? 'var(--color-primary)'
+                  : 'var(--color-stroke-subtle)',
+                color: isFavorite(favoriteKey)
+                  ? 'var(--color-primary)'
+                  : 'var(--color-on-surface-variant)',
+              }}
+              title={isFavorite(favoriteKey) ? 'Remove from favorites' : 'Save to favorites'}
+              onClick={() =>
+                toggleFavorite({
+                  id: favoriteKey,
+                  title: query.length > 40 ? `${query.slice(0, 40)}...` : query,
+                  type: 'explore',
+                })
+              }
+            >
+              <Star size={14} fill={isFavorite(favoriteKey) ? 'currentColor' : 'none'} />
+            </button>
+          ) : null}
+        </div>
+
+        {!isClickHouseDatasource ? (
+          <div className="flex flex-col gap-2">
+            <label htmlFor="trace-id-input" className="text-xs font-medium text-[var(--color-outline)]">
+              Open Trace ID
+            </label>
+            <div className="flex gap-2.5 max-md:flex-col">
+              <input
+                id="trace-id-input"
+                value={traceIdInput}
+                data-testid="explore-traces-id-input"
+                type="text"
+                placeholder="Paste trace id"
+                className="flex-1 rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] placeholder:text-[var(--color-outline)]"
+                style={{ border: '1px solid var(--color-outline-variant)' }}
+                onChange={event => setTraceIdInput(event.target.value)}
+              />
+              <button
+                type="button"
+                data-testid="explore-traces-open-btn"
+                className="inline-flex cursor-pointer items-center gap-2 whitespace-nowrap rounded-sm bg-[var(--color-surface-container-high)] px-4 py-2 text-sm font-medium text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-container-high)] disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={loadingTrace || !selectedDatasourceId || !traceIdInput.trim()}
+                onClick={() => void lookupTraceById()}
+              >
+                {loadingTrace ? (
+                  <Loader2 size={15} className="animate-spin" />
+                ) : (
+                  <Waypoints size={15} />
+                )}
+                <span>{loadingTrace ? 'Loading...' : 'Open Trace'}</span>
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {error ? (
+          <div className="flex items-center gap-2 rounded border border-[var(--color-error)]/25 bg-[var(--color-error)]/10 p-4 text-sm text-[var(--color-error)]">
+            <AlertCircle size={16} />
+            <span>{error}</span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex min-h-[440px] flex-1 flex-col overflow-hidden rounded bg-[var(--color-surface-container-low)]">
+        {!hasTracingDatasources ? (
+          <div className="flex flex-1 flex-col items-center justify-center py-12 text-center text-sm text-[var(--color-outline)]">
+            <p className="m-0">No tracing datasource configured.</p>
+            <p className="m-0 text-xs text-[var(--color-outline)]">
+              Add a Tempo, VictoriaTraces, or ClickHouse datasource in Data Sources.
+            </p>
+          </div>
+        ) : isClickHouseDatasource ? (
+          <div className="flex min-h-[420px] flex-1">
+            {loadingSearch ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-4 py-12 text-[var(--color-outline)]">
+                <Loader2 size={18} className="animate-spin" />
+                <span className="text-sm">Executing trace SQL...</span>
+              </div>
+            ) : traceSummaries.length > 0 ? (
+              <div className="min-h-0 flex-1 p-3">
+                <TraceListPanel traces={traceSummaries} onOpenTrace={handleOpenTraceFromList} />
+              </div>
+            ) : (
+              <div className="flex flex-1 flex-col items-center justify-center py-12 text-center text-sm text-[var(--color-outline)]">
+                <p className="m-0">Run a ClickHouse SQL query to inspect traces.</p>
+                <p className="m-0 text-xs text-[var(--color-outline)]">
+                  Expected columns include span_id, operation_name, service_name, start_time_unix_nano,
+                  and duration_nano.
+                </p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="grid min-h-[460px] flex-1 grid-cols-[320px_minmax(0,1fr)] max-lg:grid-cols-1">
+            <aside className="flex flex-col max-lg:max-h-[320px] max-lg:border-b max-lg:border-[var(--color-stroke-subtle)] max-lg:border-r-0">
+              <div className="flex items-center justify-between bg-[var(--color-surface-container-high)] px-4 py-3">
+                <h2 className="m-0 text-xs font-semibold uppercase tracking-wide text-[var(--color-on-surface-variant)]">
+                  Matching traces
+                </h2>
+                <span className="text-xs text-[var(--color-outline)]">
+                  {traceSummaries.length} result{traceSummaries.length === 1 ? '' : 's'}
+                </span>
+              </div>
+
+              {loadingSearch ? (
+                <div className="flex items-center justify-center gap-2 py-5 text-[var(--color-outline)]">
+                  <Loader2 size={16} className="animate-spin" />
+                  <span className="text-sm">Searching traces...</span>
+                </div>
+              ) : traceSummaries.length > 0 ? (
+                <div className="flex flex-col gap-1.5 overflow-y-auto p-2" data-testid="trace-search-results">
+                  {traceSummaries.map(summary => (
+                    <button
+                      key={summary.traceId}
+                      type="button"
+                      className={`flex cursor-pointer flex-col gap-1 rounded-sm border p-3 text-left transition ${
+                        selectedTraceId === summary.traceId
+                          ? 'border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10'
+                          : 'border-[var(--color-stroke-subtle)] bg-[var(--color-surface-container-low)] hover:bg-[var(--color-surface-container-high)]'
+                      }`}
+                      onClick={() => void loadTrace(summary.traceId)}
+                    >
+                      <code className="break-all font-mono text-xs text-[var(--color-primary)]">
+                        {summary.traceId}
+                      </code>
+                      <div className="grid grid-cols-2 gap-x-2 gap-y-0.5 text-xs text-[var(--color-outline)]">
+                        <span>{summary.rootServiceName || 'unknown service'}</span>
+                        <span>{formatDurationNano(summary.durationNano)}</span>
+                        <span>{summary.spanCount} spans</span>
+                        <span
+                          className={
+                            summary.errorSpanCount > 0
+                              ? 'font-medium text-[var(--color-error)]'
+                              : ''
+                          }
+                        >
+                          {summary.errorSpanCount} errors
+                        </span>
+                      </div>
+                      <span className="text-[0.7rem] text-[var(--color-outline)]">
+                        {formatTraceStart(summary.startTimeUnixNano)}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div className="flex flex-1 flex-col items-center justify-center py-8 text-center text-sm text-[var(--color-outline)]">
+                  Run a trace search or open a trace ID directly.
+                </div>
+              )}
+            </aside>
+
+            <section className="flex flex-col">
+              <div className="flex items-center justify-between bg-[var(--color-surface-container-high)] px-4 py-3">
+                <h2 className="m-0 text-xs font-semibold uppercase tracking-wide text-[var(--color-on-surface-variant)]">
+                  Timeline waterfall
+                </h2>
+                {activeTrace ? (
+                  <span className="text-xs text-[var(--color-outline)]">
+                    {activeTrace.spans.length} spans
+                  </span>
+                ) : null}
+              </div>
+
+              {loadingTrace ? (
+                <div className="flex flex-1 flex-col items-center justify-center gap-4 py-12 text-[var(--color-outline)]">
+                  <Loader2 size={18} className="animate-spin" />
+                  <span className="text-sm">Loading trace...</span>
+                </div>
+              ) : activeTrace ? (
+                <div className="flex flex-col gap-3.5 p-4">
+                  <div className="flex flex-wrap items-center gap-3 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2">
+                    <code className="font-mono text-xs text-[var(--color-primary)]">
+                      {activeTrace.traceId}
+                    </code>
+                    <span className="text-xs text-[var(--color-outline)]">
+                      {formatDurationNano(activeTrace.durationNano)}
+                    </span>
+                    <span className="text-xs text-[var(--color-outline)]">
+                      {activeTrace.services.length} services
+                    </span>
+                  </div>
+
+                  <div className="flex flex-col gap-2.5 rounded bg-[var(--color-surface-container-low)] p-4">
+                    <div className="flex items-center justify-between">
+                      <h3 className="m-0 text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]">
+                        Service dependency graph
+                      </h3>
+                      {activeServiceGraph ? (
+                        <span className="text-xs text-[var(--color-outline)]">
+                          {activeServiceGraph.edges.length} edges
+                        </span>
+                      ) : null}
+                    </div>
+
+                    {loadingServiceGraph ? (
+                      <div className="flex items-center justify-center gap-2 py-5 text-[var(--color-outline)]">
+                        <Loader2 size={16} className="animate-spin" />
+                        <span className="text-sm">Loading service graph...</span>
+                      </div>
+                    ) : serviceGraphError ? (
+                      <div className="flex items-center gap-2 rounded-sm border border-[var(--color-error)]/25 bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
+                        <AlertCircle size={14} />
+                        <span>{serviceGraphError}</span>
+                      </div>
+                    ) : activeServiceGraph && activeServiceGraph.nodes.length > 0 ? (
+                      <TraceServiceGraph
+                        graph={activeServiceGraph}
+                        onSelectService={handleSelectServiceFromGraph}
+                        onSelectEdge={handleSelectEdgeFromGraph}
+                      />
+                    ) : (
+                      <div className="flex items-center gap-2 rounded-sm bg-[var(--color-surface-container-high)] px-3 py-3 text-sm text-[var(--color-outline)]">
+                        Not enough trace data to render service dependencies.
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="grid grid-cols-[minmax(0,1fr)_340px] items-start gap-3.5 max-md:grid-cols-1">
+                    <div className="min-w-0">
+                      <TraceTimeline
+                        trace={activeTrace}
+                        selectedSpanId={selectedSpan?.spanId || null}
+                        onSelectSpan={setSelectedSpan}
+                      />
+                    </div>
+
+                    {selectedSpan ? (
+                      <TraceSpanDetailsPanel
+                        trace={activeTrace}
+                        span={selectedSpan}
+                        onSelectSpan={setSelectedSpan}
+                        onOpenTraceLogs={openTraceLogs}
+                        onOpenServiceMetrics={openServiceMetrics}
+                      />
+                    ) : (
+                      <aside className="flex flex-col gap-2 rounded bg-[var(--color-surface-container-high)] p-4">
+                        <h3 className="m-0 text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]">
+                          Span details
+                        </h3>
+                        <p className="m-0 text-sm text-[var(--color-outline)]">
+                          Select a span in the timeline to inspect attributes, logs, and relationships.
+                        </p>
+                      </aside>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="flex flex-1 flex-col items-center justify-center py-12 text-center text-sm text-[var(--color-outline)]">
+                  <p className="m-0">Select a trace result to view the waterfall timeline.</p>
+                  <p className="m-0 text-xs text-[var(--color-outline)]">
+                    You can search by service/time range or open a known trace ID.
+                  </p>
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TracesExplorePanel.tsx
+++ b/frontend/src/components/TracesExplorePanel.tsx
@@ -164,13 +164,21 @@ export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelPr
     }
   }, [])
 
-  const runClickHouseTraceQuery = useCallback(async () => {
-    if (!query.trim()) {
+  const runClickHouseTraceQuery = useCallback(async (overrides?: {
+    datasourceId?: string
+    queryText?: string
+  }) => {
+    // Allow callers that just updated state (e.g. first ClickHouse datasource
+    // selection) to pass fresh values so we do not read a stale closure.
+    const effectiveQuery = (overrides?.queryText ?? query).trim()
+    const effectiveDatasourceId = overrides?.datasourceId ?? selectedDatasourceId
+
+    if (!effectiveQuery) {
       setError('Query is required')
       return
     }
 
-    if (!selectedDatasourceId) {
+    if (!effectiveDatasourceId) {
       setError('Select a tracing datasource')
       return
     }
@@ -188,8 +196,8 @@ export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelPr
       const start = Math.floor(timeRange.start / 1000)
       const end = Math.floor(timeRange.end / 1000)
 
-      const response = await queryDataSource(selectedDatasourceId, {
-        query,
+      const response = await queryDataSource(effectiveDatasourceId, {
+        query: effectiveQuery,
         signal: 'traces',
         start,
         end,
@@ -384,10 +392,14 @@ export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelPr
       const ds = tracingDatasources.find(d => d.id === datasourceId)
       if (ds?.type === 'clickhouse' && !query.trim()) {
         setQuery(CLICKHOUSE_DEFAULT_QUERY)
-        void runSearch()
+        // Pass fresh values — setState above is not visible to runSearch yet.
+        void runClickHouseTraceQuery({
+          datasourceId,
+          queryText: CLICKHOUSE_DEFAULT_QUERY,
+        })
       }
     },
-    [query, runSearch, tracingDatasources],
+    [query, runClickHouseTraceQuery, tracingDatasources],
   )
 
   const buildNavigationWindow = useCallback(

--- a/frontend/src/components/TracesExplorePanel.tsx
+++ b/frontend/src/components/TracesExplorePanel.tsx
@@ -547,7 +547,7 @@ export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelPr
     if (!isClickHouseDatasource) {
       void tryLoadPendingTrace()
     }
-  }, [isClickHouseDatasource, loadServices, selectedDatasourceId, tryLoadPendingTrace])
+  }, [isClickHouseDatasource, loadServices, tryLoadPendingTrace])
 
   useEffect(() => {
     const ds = tracingDatasources.find(d => d.id === selectedDatasourceId)
@@ -577,7 +577,9 @@ export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelPr
     return unsubscribe
   }, [hasSearched, loadingSearch, loadingTrace, onRefresh, runSearch, selectedDatasourceId])
 
+  // Reset explore state when org changes
   useEffect(() => {
+    void currentOrgId
     setSelectedDatasourceId('')
     setDatasourceHealth({})
     setTraceSummaries([])
@@ -635,12 +637,16 @@ export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelPr
       <div className="flex flex-col gap-4 rounded bg-[var(--color-surface-container-low)] p-4">
         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-4 max-md:grid-cols-1">
           <div className="flex flex-col gap-2.5">
-            <label className="text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]">
+            <span
+              id="explore-traces-datasource-label"
+              className="text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]"
+            >
               Data Source
-            </label>
+            </span>
             <div ref={datasourceMenuRef} className="relative">
               <button
                 type="button"
+                aria-labelledby="explore-traces-datasource-label"
                 className="flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 text-left transition disabled:cursor-not-allowed disabled:opacity-60"
                 style={{
                   backgroundColor: 'var(--color-surface-container-high)',
@@ -739,9 +745,9 @@ export function TracesExplorePanel({ onDatasourceChanged }: TracesExplorePanelPr
           </div>
 
           <div className="flex flex-col gap-2.5">
-            <label className="text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[var(--color-outline)]">
               Search Range
-            </label>
+            </span>
             <TimeRangePicker stacked />
           </div>
         </div>

--- a/frontend/src/components/panels/CanvasPanel.vue
+++ b/frontend/src/components/panels/CanvasPanel.vue
@@ -57,7 +57,7 @@ async function mountExcalidraw() {
     const ExcalidrawWrapper = () => {
       return React.createElement(Excalidraw, {
         initialData: {
-          elements: (props.data?.elements ?? []) as any,
+          elements: (props.data?.elements ?? []) as readonly unknown[],
           appState: safeAppState,
         },
         viewModeEnabled: props.readOnly || !editing.value,

--- a/frontend/src/hooks/useTracingDatasources.ts
+++ b/frontend/src/hooks/useTracingDatasources.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { useDatasources } from '@/hooks/useDatasources'
+import { isTracingType } from '@/types/datasource'
+
+export function useTracingDatasources(orgId: string | null) {
+  const query = useDatasources(orgId)
+
+  const tracingDatasources = useMemo(
+    () => (query.data ?? []).filter(ds => isTracingType(ds.type)),
+    [query.data],
+  )
+
+  return {
+    ...query,
+    tracingDatasources,
+  }
+}

--- a/frontend/src/pages/DashboardsPage.tsx
+++ b/frontend/src/pages/DashboardsPage.tsx
@@ -1,0 +1,69 @@
+import { Plus, Search } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { DashboardList } from '@/components/DashboardList'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+
+export function DashboardsPage() {
+  const navigate = useNavigate()
+  const favorites = useFavoritesStore(state => state.favorites)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const dashboardCountLabel = useMemo(() => {
+    const count = favorites.length
+    if (count === 0) return 'Explore your dashboards'
+    return `${count} pinned dashboard${count === 1 ? '' : 's'}`
+  }, [favorites.length])
+
+  return (
+    <div className="mx-auto max-w-[1600px] px-6 py-8">
+      <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1
+            className="font-display text-2xl font-semibold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            Dashboards
+          </h1>
+          <p className="mt-1 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            {dashboardCountLabel}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div
+            className="flex items-center gap-2 rounded-lg px-3 py-2"
+            style={{
+              backgroundColor: 'var(--color-surface-container-low)',
+              border: 'none',
+            }}
+          >
+            <Search size={16} style={{ color: 'var(--color-outline)' }} />
+            <input
+              type="search"
+              placeholder="Search dashboards..."
+              data-testid="dashboard-search"
+              value={searchQuery}
+              onChange={event => setSearchQuery(event.target.value)}
+              className="w-48 border-none bg-transparent text-sm focus:outline-none"
+              style={{ color: 'var(--color-on-surface)' }}
+            />
+          </div>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+            }}
+            data-testid="new-dashboard-btn"
+            onClick={() => navigate('/app/dashboards/new/ai')}
+          >
+            <Plus size={16} />
+            New Dashboard
+          </button>
+        </div>
+      </header>
+
+      <DashboardList searchQuery={searchQuery} />
+    </div>
+  )
+}

--- a/frontend/src/pages/ExplorePage.spec.tsx
+++ b/frontend/src/pages/ExplorePage.spec.tsx
@@ -214,16 +214,117 @@ describe('ExplorePage', () => {
     expect(screen.getByTestId('time-range-picker-btn')).toBeTruthy()
   })
 
-  it('shows placeholder for traces tab', async () => {
-    const user = userEvent.setup()
-    renderExplore()
+  it('renders traces explore tab at /app/explore/traces', async () => {
+    const mockTracesDatasource: DataSource = {
+      id: 'ds-traces-1',
+      organization_id: 'org-1',
+      name: 'Tempo Prod',
+      type: 'tempo',
+      url: 'http://tempo:3200',
+      is_default: true,
+      auth_type: 'none',
+      trace_id_field: 'trace_id',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    }
+
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([mockTracesDatasource])
+    vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServices').mockResolvedValue(['api', 'gateway'])
+
+    renderExplore('/app/explore/traces')
 
     await waitFor(() => {
-      expect(screen.getByTestId('explore-tab-traces')).toBeTruthy()
+      expect(screen.getByTestId('explore-traces-datasource-btn')).toBeTruthy()
     })
 
-    await user.click(screen.getByTestId('explore-tab-traces'))
-    expect(screen.getByTestId('explore-placeholder-traces')).toBeTruthy()
+    expect(screen.getByTestId('time-range-picker-btn')).toBeTruthy()
+    expect(screen.getByTestId('explore-traces-search-btn')).toBeTruthy()
+  })
+
+  it('executes a trace search and renders timeline with mocked API', async () => {
+    const mockTracesDatasource: DataSource = {
+      id: 'ds-traces-1',
+      organization_id: 'org-1',
+      name: 'Tempo Prod',
+      type: 'tempo',
+      url: 'http://tempo:3200',
+      is_default: true,
+      auth_type: 'none',
+      trace_id_field: 'trace_id',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    }
+
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([mockTracesDatasource])
+    vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServices').mockResolvedValue(['api'])
+    vi.spyOn(datasourcesApi, 'searchDataSourceTraces').mockResolvedValue([
+      {
+        traceId: 'trace-abc-123',
+        rootServiceName: 'api',
+        rootOperationName: 'GET /orders',
+        startTimeUnixNano: 1_700_000_000_000_000_000,
+        durationNano: 2_500_000,
+        spanCount: 3,
+        serviceCount: 2,
+        errorSpanCount: 0,
+      },
+    ])
+    vi.spyOn(datasourcesApi, 'fetchDataSourceTrace').mockResolvedValue({
+      traceId: 'trace-abc-123',
+      startTimeUnixNano: 1_700_000_000_000_000_000,
+      durationNano: 2_500_000,
+      services: ['api', 'gateway'],
+      spans: [
+        {
+          spanId: 'span-root',
+          operationName: 'GET /orders',
+          serviceName: 'api',
+          startTimeUnixNano: 1_700_000_000_000_000_000,
+          durationNano: 2_500_000,
+          status: 'ok',
+        },
+      ],
+    })
+    vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServiceGraph').mockResolvedValue({
+      nodes: [
+        {
+          serviceName: 'api',
+          requestCount: 1,
+          errorCount: 0,
+          errorRate: 0,
+          averageDurationNano: 2_500_000,
+        },
+      ],
+      edges: [],
+      totalRequests: 1,
+      totalErrorCount: 0,
+    })
+
+    renderExplore('/app/explore/traces')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('explore-traces-datasource-btn').textContent).toContain('Tempo Prod')
+    })
+
+    await waitFor(() => {
+      expect(datasourcesApi.searchDataSourceTraces).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trace-search-results')).toBeTruthy()
+    })
+
+    expect(screen.getByText('trace-abc-123')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('trace-abc-123'))
+
+    await waitFor(() => {
+      expect(datasourcesApi.fetchDataSourceTrace).toHaveBeenCalledWith('ds-traces-1', 'trace-abc-123')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trace-timeline')).toBeTruthy()
+    })
   })
 
   it('renders logs explore tab at /app/explore/logs', async () => {

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { LogsExplorePanel } from '@/components/LogsExplorePanel'
 import { MetricsExplorePanel } from '@/components/MetricsExplorePanel'
+import { TracesExplorePanel } from '@/components/TracesExplorePanel'
 
 type ExploreType = 'metrics' | 'logs' | 'traces'
 
@@ -70,16 +71,7 @@ export function ExplorePage() {
       ) : activeType === 'logs' ? (
         <LogsExplorePanel key="logs" />
       ) : (
-        <div
-          className="flex flex-1 flex-col items-center justify-center rounded-lg py-16 text-center"
-          style={{
-            backgroundColor: 'var(--color-surface-container-low)',
-            color: 'var(--color-outline)',
-          }}
-          data-testid="explore-placeholder-traces"
-        >
-          <p className="m-0 text-sm">Traces explore is coming soon.</p>
-        </div>
+        <TracesExplorePanel key="traces" />
       )}
     </div>
   )

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -9,6 +9,9 @@ const PlaceholderPage = lazy(() =>
 )
 const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })))
 const ExplorePage = lazy(() => import('@/pages/ExplorePage').then(m => ({ default: m.ExplorePage })))
+const DashboardsPage = lazy(() =>
+  import('@/pages/DashboardsPage').then(m => ({ default: m.DashboardsPage })),
+)
 const LoginPage = lazy(() => import('@/pages/LoginPage').then(m => ({ default: m.LoginPage })))
 const AuthCallbackPage = lazy(() =>
   import('@/pages/AuthCallbackPage').then(m => ({ default: m.AuthCallbackPage })),
@@ -60,7 +63,7 @@ const appRoutes: RouteObject[] = [
   {
     path: '/app/dashboards',
     handle: withMeta('Dashboards | Ace', 'Browse and organize dashboards in Ace.'),
-    element: placeholder('Dashboards'),
+    element: <DashboardsPage />,
   },
   {
     path: '/app/dashboards/new/ai',

--- a/frontend/src/utils/traceClickHouse.ts
+++ b/frontend/src/utils/traceClickHouse.ts
@@ -1,0 +1,120 @@
+import type { TraceSpan, TraceSummary } from '@/types/datasource'
+
+function getTagValue(tags: Record<string, string> | undefined, keys: string[]): string {
+  if (!tags || Object.keys(tags).length === 0) {
+    return ''
+  }
+
+  const byNormalizedName: Record<string, string> = {}
+  for (const [key, value] of Object.entries(tags)) {
+    const normalizedKey = key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
+    if (normalizedKey && !(normalizedKey in byNormalizedName)) {
+      byNormalizedName[normalizedKey] = value
+    }
+  }
+
+  for (const key of keys) {
+    const normalizedKey = key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
+    if (normalizedKey in byNormalizedName) {
+      const value = byNormalizedName[normalizedKey].trim()
+      if (value) {
+        return value
+      }
+    }
+  }
+
+  return ''
+}
+
+function isTraceErrorSpan(span: TraceSpan): boolean {
+  if (typeof span.status === 'string' && span.status.toLowerCase() === 'error') {
+    return true
+  }
+
+  const errorTag = getTagValue(span.tags, ['error', 'otelStatusCode', 'statusCode'])
+  const normalized = errorTag.toLowerCase()
+  return normalized === 'true' || normalized === '1' || normalized === 'error'
+}
+
+function getTraceIdForSpan(span: TraceSpan): string {
+  const traceIdFromTags = getTagValue(span.tags, [
+    'traceId',
+    'trace_id',
+    'traceid',
+    'otelTraceId',
+    'trace',
+  ])
+  if (traceIdFromTags) {
+    return traceIdFromTags
+  }
+
+  return span.spanId || 'unknown-trace'
+}
+
+export function convertClickHouseSpansToTraceSummaries(spans: TraceSpan[]): TraceSummary[] {
+  const grouped = new Map<
+    string,
+    {
+      traceId: string
+      spans: TraceSpan[]
+      services: Set<string>
+      errorSpanCount: number
+      startTimeUnixNano: number
+      endTimeUnixNano: number
+    }
+  >()
+
+  for (const span of spans) {
+    const traceId = getTraceIdForSpan(span)
+    const group = grouped.get(traceId) || {
+      traceId,
+      spans: [],
+      services: new Set<string>(),
+      errorSpanCount: 0,
+      startTimeUnixNano: Number.MAX_SAFE_INTEGER,
+      endTimeUnixNano: 0,
+    }
+
+    group.spans.push(span)
+    if (span.serviceName) {
+      group.services.add(span.serviceName)
+    }
+
+    if (isTraceErrorSpan(span)) {
+      group.errorSpanCount += 1
+    }
+
+    const spanStart = Math.max(0, span.startTimeUnixNano || 0)
+    const spanEnd = spanStart + Math.max(0, span.durationNano || 0)
+    group.startTimeUnixNano = Math.min(group.startTimeUnixNano, spanStart)
+    group.endTimeUnixNano = Math.max(group.endTimeUnixNano, spanEnd)
+
+    grouped.set(traceId, group)
+  }
+
+  const summaries: TraceSummary[] = []
+  for (const group of grouped.values()) {
+    const spanIds = new Set(group.spans.map(span => span.spanId))
+    const rootSpan =
+      [...group.spans]
+        .sort((left, right) => left.startTimeUnixNano - right.startTimeUnixNano)
+        .find(span => !span.parentSpanId || !spanIds.has(span.parentSpanId)) || group.spans[0]
+
+    const startTimeUnixNano =
+      group.startTimeUnixNano === Number.MAX_SAFE_INTEGER ? 0 : group.startTimeUnixNano
+    const durationNano = Math.max(0, group.endTimeUnixNano - startTimeUnixNano)
+
+    summaries.push({
+      traceId: group.traceId,
+      rootServiceName: rootSpan?.serviceName || 'unknown',
+      rootOperationName: rootSpan?.operationName || '',
+      startTimeUnixNano,
+      durationNano,
+      spanCount: group.spans.length,
+      serviceCount: group.services.size,
+      errorSpanCount: group.errorSpanCount,
+    })
+  }
+
+  return summaries.sort((left, right) => right.startTimeUnixNano - left.startTimeUnixNano)
+}

--- a/frontend/src/utils/traceFormat.ts
+++ b/frontend/src/utils/traceFormat.ts
@@ -1,0 +1,20 @@
+export function formatDurationNano(durationNano: number): string {
+  if (durationNano >= 1_000_000_000) {
+    return `${(durationNano / 1_000_000_000).toFixed(durationNano >= 10_000_000_000 ? 1 : 2)}s`
+  }
+  if (durationNano >= 1_000_000) {
+    return `${(durationNano / 1_000_000).toFixed(durationNano >= 100_000_000 ? 0 : 1)}ms`
+  }
+  if (durationNano >= 1_000) {
+    return `${(durationNano / 1_000).toFixed(durationNano >= 100_000 ? 0 : 1)}us`
+  }
+  return `${durationNano}ns`
+}
+
+export function formatTraceStart(unixNanoTimestamp: number): string {
+  return new Date(Math.floor(unixNanoTimestamp / 1_000_000)).toLocaleTimeString()
+}
+
+export function formatTraceStartFull(unixNanoTimestamp: number): string {
+  return new Date(Math.floor(unixNanoTimestamp / 1_000_000)).toLocaleString()
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,8 +28,8 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '**/dist/**',
-      // Vue legacy specs — re-enabled as features port in tracer bullets (#295–#309)
-      'src/components/**',
+      // Vue legacy specs (.spec.ts) — React ports use .spec.tsx in the same folders
+      'src/components/**/*.spec.ts',
       'src/views/**',
       'src/composables/**',
       'src/App.spec.ts',


### PR DESCRIPTION
## Summary

Ports two tracer bullets from the [Vue → React rewrite map](https://github.com/aceobservability/ace/issues/292):

- **#300 Traces explore** — `TracesExplorePanel` at `/app/explore/traces` with trace search, timeline waterfall, service graph, and span details
- **#301 Dashboard library** — `DashboardsPage` at `/app/dashboards` with folder navigation, search/filter, favorites, drag-and-drop folder moves, and `CreateDashboardModal` (blank, YAML, Grafana import)

Branch rebased onto `main` (cherry-picks only; no duplicate #295–#299 history).

## Test plan

- [x] `npm run type-check` green
- [x] `npm test -- --run` — 350 tests pass
- [x] `npm run build` green
- [x] RTL coverage for `DashboardList` and `CreateDashboardModal` (23 tests)

Closes #301. Also delivers #300 (traces explore), which was implemented on the same branch stack but not yet merged to `main`.