### PR TITLE
feat(frontend): dashboard settings and AI generation (#306)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -229,6 +229,7 @@ func main() {
 	mux.HandleFunc("PUT /api/dashboards/{id}", auth.RequireAuth(jwtManager, dashboardHandler.Update))
 	mux.HandleFunc("DELETE /api/dashboards/{id}", auth.RequireAuth(jwtManager, dashboardHandler.Delete))
 	mux.HandleFunc("GET /api/dashboards/{id}/export", auth.RequireAuth(jwtManager, dashboardHandler.Export))
+	mux.HandleFunc("PUT /api/dashboards/{id}/import", auth.RequireAuth(jwtManager, dashboardHandler.ReplaceImport))
 	mux.HandleFunc("POST /api/orgs/{orgId}/dashboards/import", auth.RequireAuth(jwtManager, dashboardHandler.Import))
 
 	// Folder routes

--- a/backend/internal/handlers/dashboard_cac.go
+++ b/backend/internal/handlers/dashboard_cac.go
@@ -3,11 +3,13 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/aceobservability/ace/backend/internal/authz"
@@ -234,10 +236,7 @@ func (h *DashboardHandler) Import(w http.ResponseWriter, r *http.Request) {
 	}
 	defer tx.Rollback(ctx)
 
-	descPtr := &doc.Description
-	if doc.Description == "" {
-		descPtr = nil
-	}
+	descPtr := descriptionPointer(doc.Description)
 
 	var imported models.Dashboard
 	err = tx.QueryRow(ctx,
@@ -254,47 +253,9 @@ func (h *DashboardHandler) Import(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resolver := NewDatasourceResolver(h.pool)
-
-	for _, panel := range doc.Panels {
-		gridPosRaw, err := json.Marshal(panel.Position)
-		if err != nil {
-			http.Error(w, `{"error":"failed to encode panel layout"}`, http.StatusBadRequest)
-			return
-		}
-
-		// Resolve datasource ref to UUID
-		var dsIDStr *string
-		var datasourceID any
-		if panel.Datasource != nil {
-			resolved, err := resolver.ResolveRef(ctx, orgID, *panel.Datasource)
-			if err != nil {
-				http.Error(w, `{"error":"datasource not found: `+panel.Datasource.Type+`"}`, http.StatusBadRequest)
-				return
-			}
-			datasourceID = *resolved
-			s := resolved.String()
-			dsIDStr = &s
-		}
-
-		// Re-assemble query blob from structured fields
-		queryBlob := converter.ResourcesToQueryBlob(panel.Query, panel.Display, dsIDStr)
-
-		_, err = tx.Exec(ctx,
-			`INSERT INTO panels (dashboard_id, title, type, grid_pos, query, datasource_id, created_by)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-			imported.ID,
-			panel.Title,
-			panel.Type,
-			gridPosRaw,
-			queryBlob,
-			datasourceID,
-			userID,
-		)
-		if err != nil {
-			http.Error(w, `{"error":"failed to create panel during import"}`, http.StatusInternalServerError)
-			return
-		}
+	if err := h.insertPanelsFromDocument(ctx, tx, orgID, imported.ID, userID, doc); err != nil {
+		writeJSONError(w, statusForPanelImportError(err), err.Error())
+		return
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -305,6 +266,195 @@ func (h *DashboardHandler) Import(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(imported)
+}
+
+// ReplaceImport replaces an existing dashboard body (metadata + panels) from a
+// JSON or YAML document. Requires edit permission on the dashboard.
+func (h *DashboardHandler) ReplaceImport(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	dashboardID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, `{"error":"invalid dashboard id"}`, http.StatusBadRequest)
+		return
+	}
+
+	format := converter.NormalizeFormat(r.URL.Query().Get("format"))
+	if format == "" {
+		http.Error(w, `{"error":"format must be json or yaml"}`, http.StatusBadRequest)
+		return
+	}
+
+	rawBody, err := readRawBody(r)
+	if err != nil {
+		http.Error(w, `{"error":"failed to read request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	doc, err := converter.DecodeDashboardDocument(rawBody, format)
+	if err != nil {
+		http.Error(w, `{"error":"invalid dashboard document"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	var orgID *uuid.UUID
+	err = h.pool.QueryRow(ctx, `SELECT organization_id FROM dashboards WHERE id = $1`, dashboardID).Scan(&orgID)
+	if err != nil {
+		http.Error(w, `{"error":"dashboard not found"}`, http.StatusNotFound)
+		return
+	}
+	if orgID == nil {
+		http.Error(w, `{"error":"dashboard organization not found"}`, http.StatusNotFound)
+		return
+	}
+
+	_, err = h.checkOrgMembership(ctx, userID, *orgID)
+	if err != nil {
+		http.Error(w, `{"error":"not a member of this organization"}`, http.StatusForbidden)
+		return
+	}
+
+	canEdit, err := h.authz.Can(ctx, userID, *orgID, authz.ResourceTypeDashboard, dashboardID, authz.ActionEdit)
+	if err != nil {
+		http.Error(w, `{"error":"failed to evaluate dashboard permissions"}`, http.StatusInternalServerError)
+		return
+	}
+	if !canEdit {
+		http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+		return
+	}
+
+	tx, err := h.pool.Begin(ctx)
+	if err != nil {
+		http.Error(w, `{"error":"failed to start replace import"}`, http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback(ctx)
+
+	descPtr := descriptionPointer(doc.Description)
+
+	var updated models.Dashboard
+	err = tx.QueryRow(ctx,
+		`UPDATE dashboards
+		 SET title = $1,
+		     description = $2,
+		     updated_at = NOW()
+		 WHERE id = $3
+		 RETURNING id, title, description, folder_id, sort_order, created_at, updated_at, organization_id, created_by`,
+		doc.Title,
+		descPtr,
+		dashboardID,
+	).Scan(&updated.ID, &updated.Title, &updated.Description, &updated.FolderID, &updated.SortOrder, &updated.CreatedAt, &updated.UpdatedAt, &updated.OrganizationID, &updated.CreatedBy)
+	if err != nil {
+		http.Error(w, `{"error":"dashboard not found"}`, http.StatusNotFound)
+		return
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM panels WHERE dashboard_id = $1`, dashboardID); err != nil {
+		http.Error(w, `{"error":"failed to replace dashboard panels"}`, http.StatusInternalServerError)
+		return
+	}
+
+	if err := h.insertPanelsFromDocument(ctx, tx, *orgID, dashboardID, userID, doc); err != nil {
+		writeJSONError(w, statusForPanelImportError(err), err.Error())
+		return
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		http.Error(w, `{"error":"failed to finalize replace import"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(updated)
+}
+
+// insertPanelsFromDocument inserts all panels from a decoded dashboard document
+// inside an existing transaction so import/replace stay atomic.
+func (h *DashboardHandler) insertPanelsFromDocument(
+	ctx context.Context,
+	tx pgx.Tx,
+	orgID uuid.UUID,
+	dashboardID uuid.UUID,
+	userID uuid.UUID,
+	doc converter.DashboardDocument,
+) error {
+	resolver := NewDatasourceResolver(h.pool)
+
+	for _, panel := range doc.Panels {
+		gridPosRaw, err := json.Marshal(panel.Position)
+		if err != nil {
+			return errInvalidPanelLayout
+		}
+
+		var dsIDStr *string
+		var datasourceID any
+		if panel.Datasource != nil {
+			resolved, err := resolver.ResolveRef(ctx, orgID, *panel.Datasource)
+			if err != nil {
+				return &datasourceNotFoundError{dsType: panel.Datasource.Type}
+			}
+			datasourceID = *resolved
+			s := resolved.String()
+			dsIDStr = &s
+		}
+
+		queryBlob := converter.ResourcesToQueryBlob(panel.Query, panel.Display, dsIDStr)
+
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO panels (dashboard_id, title, type, grid_pos, query, datasource_id, created_by)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			dashboardID,
+			panel.Title,
+			panel.Type,
+			gridPosRaw,
+			queryBlob,
+			datasourceID,
+			userID,
+		); err != nil {
+			return errCreatePanel
+		}
+	}
+
+	return nil
+}
+
+var (
+	errInvalidPanelLayout = errors.New("failed to encode panel layout")
+	errCreatePanel        = errors.New("failed to create panel during import")
+)
+
+type datasourceNotFoundError struct {
+	dsType string
+}
+
+func (e *datasourceNotFoundError) Error() string {
+	return "datasource not found: " + e.dsType
+}
+
+func statusForPanelImportError(err error) int {
+	switch {
+	case errors.Is(err, errInvalidPanelLayout):
+		return http.StatusBadRequest
+	case errors.As(err, new(*datasourceNotFoundError)):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func descriptionPointer(description string) *string {
+	if description == "" {
+		return nil
+	}
+	return &description
 }
 
 func readRawBody(r *http.Request) ([]byte, error) {

--- a/backend/internal/handlers/dashboard_cac_test.go
+++ b/backend/internal/handlers/dashboard_cac_test.go
@@ -43,3 +43,38 @@ func TestDashboardHandler_Import_InvalidFormat(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
 	}
 }
+
+func TestDashboardHandler_ReplaceImport_InvalidFormat(t *testing.T) {
+	handler := &DashboardHandler{pool: nil}
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/dashboards/123e4567-e89b-12d3-a456-426614174000/import?format=toml", bytes.NewBufferString(`{}`))
+	req.SetPathValue("id", "123e4567-e89b-12d3-a456-426614174000")
+	req = req.WithContext(context.WithValue(req.Context(), auth.UserIDKey, userID))
+	rr := httptest.NewRecorder()
+
+	handler.ReplaceImport(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestDashboardHandler_ReplaceImport_InvalidDashboardID(t *testing.T) {
+	handler := &DashboardHandler{pool: nil}
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/dashboards/not-a-uuid/import?format=yaml", bytes.NewBufferString(`version: 2
+title: x
+panels: []
+`))
+	req.SetPathValue("id", "not-a-uuid")
+	req = req.WithContext(context.WithValue(req.Context(), auth.UserIDKey, userID))
+	rr := httptest.NewRecorder()
+
+	handler.ReplaceImport(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}

--- a/frontend/src/api/dashboards.import.spec.ts
+++ b/frontend/src/api/dashboards.import.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { importDashboardYaml } from './dashboards'
+import { importDashboardYaml, replaceDashboardYaml } from './dashboards'
 
 describe('importDashboardYaml', () => {
   const mockFetch = vi.fn()
@@ -47,6 +47,57 @@ describe('importDashboardYaml', () => {
     mockFetch.mockResolvedValue({ ok: false, status: 400 })
 
     await expect(importDashboardYaml('org-1', 'not valid')).rejects.toThrow(
+      'Invalid YAML dashboard document',
+    )
+  })
+})
+
+describe('replaceDashboardYaml', () => {
+  const mockFetch = vi.fn()
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    global.fetch = mockFetch
+    mockFetch.mockClear()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('replaces an existing dashboard body from yaml', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 'dashboard-1',
+          title: 'Replaced Dashboard',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z',
+        }),
+    })
+
+    const yamlPayload = 'version: 2\ntitle: Replaced Dashboard\npanels: []\n'
+    const result = await replaceDashboardYaml('dashboard-1', yamlPayload)
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/dashboards/dashboard-1/import?format=yaml',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/x-yaml',
+        }),
+        body: yamlPayload,
+      }),
+    )
+    expect(result.title).toBe('Replaced Dashboard')
+  })
+
+  it('throws validation error for invalid yaml', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400 })
+
+    await expect(replaceDashboardYaml('dashboard-1', 'not valid')).rejects.toThrow(
       'Invalid YAML dashboard document',
     )
   })

--- a/frontend/src/api/dashboards.ts
+++ b/frontend/src/api/dashboards.ts
@@ -151,3 +151,40 @@ export async function importDashboardYaml(orgId: string, yamlContent: string): P
 
   return response.json()
 }
+
+/** Replace an existing dashboard body (title/description/panels) from a v2 YAML document. */
+export async function replaceDashboardYaml(
+  id: string,
+  yamlContent: string,
+): Promise<Dashboard> {
+  const response = await fetch(`${API_BASE}/api/dashboards/${id}/import?format=yaml`, {
+    method: 'PUT',
+    headers: {
+      ...getAuthHeaders(),
+      'Content-Type': 'application/x-yaml',
+    },
+    body: yamlContent,
+  })
+
+  if (!response.ok) {
+    trackEvent('dashboard_update_failed', {
+      dashboard_id: id,
+      status_code: response.status,
+      via: 'yaml_replace',
+    })
+    if (response.status === 403) {
+      throw new Error('Not authorized to update this dashboard')
+    }
+    if (response.status === 400) {
+      throw new Error('Invalid YAML dashboard document')
+    }
+    throw new Error('Failed to save dashboard YAML')
+  }
+
+  const dashboard = await response.json()
+  trackEvent('dashboard_updated', {
+    dashboard_id: id,
+    updated_fields: ['yaml'],
+  })
+  return dashboard
+}

--- a/frontend/src/components/CreateDashboardModal.tsx
+++ b/frontend/src/components/CreateDashboardModal.tsx
@@ -14,61 +14,19 @@ import { bulkCreateVariables } from '@/api/variables'
 import { useDatasources } from '@/hooks/useDatasources'
 import { useOrganization } from '@/hooks/useOrganization'
 import type { ConversionReport } from '@/types/converter'
+import {
+  buildDashboardYamlPreview,
+  type DashboardYamlPreview,
+} from '@/utils/dashboardYaml'
 
 type CreationMode = 'create' | 'import' | 'grafana'
 type ModalStep = 'choice' | 'form'
 type GrafanaSubTab = 'upload' | 'connect'
 
-type ImportPreview = {
-  title: string
-  description: string
-  panelCount: number
-}
-
 type CreateDashboardModalProps = {
   initialMode?: CreationMode
   onClose: () => void
   onCreated: () => void
-}
-
-function normalizeYamlValue(value: string): string {
-  const trimmed = value.trim()
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1).trim()
-  }
-  return trimmed
-}
-
-function buildYamlPreview(rawYaml: string): ImportPreview {
-  const versionMatch = rawYaml.match(/(?:^|\n)version:\s*(.+)/)
-  if (!versionMatch) {
-    throw new Error('Missing version')
-  }
-
-  const titleMatch = rawYaml.match(/(?:^|\n)title:\s*(.+)/)
-  if (!titleMatch) {
-    throw new Error('Missing dashboard title')
-  }
-
-  const extractedTitle = normalizeYamlValue(titleMatch[1] ?? '')
-  if (!extractedTitle) {
-    throw new Error('Dashboard title is empty')
-  }
-
-  const descriptionMatch = rawYaml.match(/(?:^|\n)description:\s*(.+)/)
-  const panelsSectionMatch = rawYaml.match(
-    /(?:^|\n)panels:\s*\n([\s\S]*?)(?=\n[a-zA-Z_][\w-]*:\s*|\s*$)/,
-  )
-  const panelCount = (panelsSectionMatch?.[1]?.match(/(?:^|\n)\s{2}-\s+/g) ?? []).length
-
-  return {
-    title: extractedTitle,
-    description: normalizeYamlValue(descriptionMatch?.[1] ?? ''),
-    panelCount,
-  }
 }
 
 export function CreateDashboardModal({
@@ -113,7 +71,7 @@ export function CreateDashboardModal({
       include_all: boolean
     }>
   >([])
-  const [importPreview, setImportPreview] = useState<ImportPreview | null>(null)
+  const [importPreview, setImportPreview] = useState<DashboardYamlPreview | null>(null)
 
   const submitLabel = useMemo(() => {
     if (loading) {
@@ -179,7 +137,7 @@ export function CreateDashboardModal({
         return
       }
 
-      setImportPreview(buildYamlPreview(content))
+      setImportPreview(buildDashboardYamlPreview(content))
       setYamlContent(content)
       setYamlFileName(file.name)
     } catch (e) {

--- a/frontend/src/components/DashboardPermissionsEditor.tsx
+++ b/frontend/src/components/DashboardPermissionsEditor.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { listGroups } from '@/api/groups'
+import { listMembers } from '@/api/organizations'
+import { listDashboardPermissions, replaceDashboardPermissions } from '@/api/permissions'
+import type { Dashboard } from '@/types/dashboard'
+import type { Member } from '@/types/organization'
+import type {
+  PrincipalType,
+  ResourcePermissionEntry,
+  ResourcePermissionLevel,
+  UserGroup,
+} from '@/types/rbac'
+
+type DashboardPermissionsEditorProps = {
+  dashboard: Dashboard
+  orgId: string
+}
+
+export function DashboardPermissionsEditor({ dashboard, orgId }: DashboardPermissionsEditorProps) {
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const [members, setMembers] = useState<Member[]>([])
+  const [groups, setGroups] = useState<UserGroup[]>([])
+  const [entries, setEntries] = useState<ResourcePermissionEntry[]>([])
+
+  const [newPrincipalType, setNewPrincipalType] = useState<PrincipalType>('user')
+  const [newPrincipalId, setNewPrincipalId] = useState('')
+  const [newPermission, setNewPermission] = useState<ResourcePermissionLevel>('view')
+
+  const principalOptions = useMemo(() => {
+    if (newPrincipalType === 'user') {
+      return members.map(member => ({
+        id: member.user_id,
+        label: `${member.name || member.email} (${member.email})`,
+      }))
+    }
+
+    return groups.map(group => ({
+      id: group.id,
+      label: group.name,
+    }))
+  }, [groups, members, newPrincipalType])
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    setActionError(null)
+
+    try {
+      const [permissionEntries, orgMembers, orgGroups] = await Promise.all([
+        listDashboardPermissions(dashboard.id),
+        listMembers(orgId),
+        listGroups(orgId),
+      ])
+
+      setEntries(permissionEntries)
+      setMembers(orgMembers)
+      setGroups(orgGroups)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Failed to load dashboard permissions')
+    } finally {
+      setLoading(false)
+    }
+  }, [dashboard.id, orgId])
+
+  useEffect(() => {
+    void loadData()
+  }, [loadData])
+
+  function principalLabel(entry: ResourcePermissionEntry): string {
+    if (entry.principal_type === 'user') {
+      const member = members.find(item => item.user_id === entry.principal_id)
+      return member
+        ? `${member.name || member.email} (${member.email})`
+        : `Unknown user (${entry.principal_id})`
+    }
+
+    const group = groups.find(item => item.id === entry.principal_id)
+    return group ? group.name : `Unknown group (${entry.principal_id})`
+  }
+
+  function addEntry() {
+    setSuccessMessage(null)
+    setActionError(null)
+
+    if (!newPrincipalId) {
+      setActionError('Select a principal to add')
+      return
+    }
+
+    const duplicate = entries.some(
+      entry =>
+        entry.principal_type === newPrincipalType && entry.principal_id === newPrincipalId,
+    )
+
+    if (duplicate) {
+      setActionError('This principal already has a permission entry')
+      return
+    }
+
+    setEntries(current => [
+      ...current,
+      {
+        principal_type: newPrincipalType,
+        principal_id: newPrincipalId,
+        permission: newPermission,
+      },
+    ])
+    setNewPrincipalId('')
+    setNewPermission('view')
+  }
+
+  function updateEntryPermission(index: number, permission: ResourcePermissionLevel) {
+    setEntries(current =>
+      current.map((entry, entryIndex) =>
+        entryIndex === index
+          ? {
+              ...entry,
+              permission,
+            }
+          : entry,
+      ),
+    )
+    setSuccessMessage(null)
+  }
+
+  function removeEntry(index: number) {
+    setEntries(current => current.filter((_, entryIndex) => entryIndex !== index))
+    setActionError(null)
+    setSuccessMessage(null)
+  }
+
+  async function savePermissions() {
+    setSaving(true)
+    setActionError(null)
+    setSuccessMessage(null)
+
+    try {
+      const updatedEntries = await replaceDashboardPermissions(dashboard.id, {
+        entries,
+      })
+      setEntries(updatedEntries)
+      setSuccessMessage('Dashboard permissions updated')
+    } catch (cause) {
+      setActionError(
+        cause instanceof Error ? cause.message : 'Failed to update dashboard permissions',
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="dashboard-permissions-editor">
+      <h3 className="mb-3 text-sm font-semibold text-[var(--color-on-surface)]">Permissions</h3>
+
+      {loading ? (
+        <div className="rounded-sm border border-dashed px-4 py-3 text-sm text-[var(--color-outline)]">
+          Loading permissions...
+        </div>
+      ) : error ? (
+        <div className="rounded-sm border border-[var(--color-error)]/25 bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
+          {error}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div className="mt-4 flex items-center gap-3 rounded-sm bg-[var(--color-surface-container-high)] p-3">
+            <div className="grid flex-1 grid-cols-[130px_minmax(0,1fr)_120px] gap-2 max-md:grid-cols-1">
+              <select
+                value={newPrincipalType}
+                data-testid="principal-type-select"
+                disabled={saving}
+                className="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                onChange={event => {
+                  setNewPrincipalType(event.target.value as PrincipalType)
+                  setNewPrincipalId('')
+                }}
+              >
+                <option value="user">User</option>
+                <option value="group">Group</option>
+              </select>
+              <select
+                value={newPrincipalId}
+                data-testid="principal-select"
+                disabled={saving || principalOptions.length === 0}
+                className="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                onChange={event => setNewPrincipalId(event.target.value)}
+              >
+                <option value="">Select {newPrincipalType}</option>
+                {principalOptions.map(option => (
+                  <option key={`${newPrincipalType}-${option.id}`} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={newPermission}
+                data-testid="permission-select"
+                disabled={saving}
+                className="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20"
+                onChange={event =>
+                  setNewPermission(event.target.value as ResourcePermissionLevel)
+                }
+              >
+                <option value="view">View</option>
+                <option value="edit">Edit</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <button
+              type="button"
+              className="cursor-pointer rounded-sm bg-[var(--color-primary)] px-3 py-2 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="add-permission-entry"
+              disabled={saving}
+              onClick={addEntry}
+            >
+              Add Entry
+            </button>
+          </div>
+
+          {entries.length === 0 ? (
+            <div className="rounded-sm border border-dashed px-4 py-3 text-sm text-[var(--color-outline)]">
+              No explicit ACL entries. Organization role defaults apply.
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded bg-[var(--color-surface-container-low)]">
+              <div className="grid grid-cols-[1fr_auto] bg-[var(--color-surface-container-high)] px-4 py-3 font-mono text-xs uppercase tracking-[0.07em] text-[var(--color-outline)]">
+                <span>Principal</span>
+                <span>Actions</span>
+              </div>
+              {entries.map((entry, index) => (
+                <div
+                  key={`${entry.principal_type}-${entry.principal_id}`}
+                  className="flex items-center justify-between gap-3 px-4 py-3 text-sm text-[var(--color-on-surface-variant)] max-md:flex-col max-md:items-start"
+                  data-testid={`permission-entry-${index}`}
+                >
+                  <div className="flex min-w-0 flex-col">
+                    <strong className="truncate text-sm text-[var(--color-on-surface)]">
+                      {principalLabel(entry)}
+                    </strong>
+                    <span className="mt-1 w-fit rounded-sm bg-[var(--color-primary)]/10 px-2 py-0.5 text-xs uppercase tracking-wide text-[var(--color-primary)]">
+                      {entry.principal_type}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 max-md:w-full max-md:flex-col max-md:items-start">
+                    <select
+                      value={entry.permission}
+                      data-testid={`entry-permission-${index}`}
+                      disabled={saving}
+                      className="rounded-sm bg-[var(--color-surface-container-low)] px-3 py-2 text-sm text-[var(--color-on-surface)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]/20 max-md:w-full"
+                      onChange={event =>
+                        updateEntryPermission(
+                          index,
+                          event.target.value as ResourcePermissionLevel,
+                        )
+                      }
+                    >
+                      <option value="view">View</option>
+                      <option value="edit">Edit</option>
+                      <option value="admin">Admin</option>
+                    </select>
+                    <button
+                      type="button"
+                      className="cursor-pointer text-sm font-medium text-[var(--color-error)] transition hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60 max-md:w-full"
+                      data-testid={`remove-entry-${index}`}
+                      disabled={saving}
+                      onClick={() => removeEntry(index)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {actionError && (
+            <div className="rounded-sm border border-[var(--color-error)]/25 bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
+              {actionError}
+            </div>
+          )}
+          {successMessage && (
+            <div className="rounded-sm border border-[var(--color-primary)]/20 bg-[var(--color-primary)]/10 px-3 py-2 text-sm text-[var(--color-primary)]">
+              {successMessage}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              className="inline-flex cursor-pointer items-center justify-center gap-1 rounded-sm bg-[var(--color-primary)] px-3 py-2 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="save-dashboard-permissions"
+              disabled={saving}
+              onClick={() => void savePermissions()}
+            >
+              {saving ? 'Saving...' : 'Save Permissions'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/DashboardSpecPreview.tsx
+++ b/frontend/src/components/DashboardSpecPreview.tsx
@@ -1,0 +1,335 @@
+import {
+  BarChart3,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  ClipboardCopy,
+  ExternalLink,
+  Gauge,
+  Hash,
+  Loader2,
+  PieChart,
+  Table,
+  TrendingUp,
+  type LucideIcon,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { queryDataSource } from '@/api/datasources'
+import { useDatasources } from '@/hooks/useDatasources'
+import { useOrganization } from '@/hooks/useOrganization'
+import type { DashboardSpec, PanelType } from '@/utils/dashboardSpec'
+import { saveDashboardSpec, validateDashboardSpec } from '@/utils/dashboardSpec'
+
+type DryRunStatus = 'checking' | 'success' | 'empty' | 'error'
+
+type DashboardSpecPreviewProps = {
+  spec: DashboardSpec
+  onSaved?: (dashboardId: string) => void
+}
+
+const DEMO_METRIC_NAMES = [
+  'http_requests_total',
+  'http_request_duration_seconds',
+  'process_cpu_seconds',
+  'process_resident_memory_bytes',
+  'node_cpu_seconds',
+  'node_memory_MemAvailable_bytes',
+]
+
+const panelTypeIcons: Record<PanelType, LucideIcon> = {
+  line_chart: TrendingUp,
+  bar_chart: BarChart3,
+  stat: Hash,
+  gauge: Gauge,
+  table: Table,
+  pie: PieChart,
+}
+
+function dryRunDotClass(status: DryRunStatus): string {
+  switch (status) {
+    case 'checking':
+      return 'animate-pulse bg-[var(--color-outline)]'
+    case 'success':
+      return 'bg-[var(--color-secondary)]'
+    case 'empty':
+      return 'bg-[var(--color-tertiary)]'
+    case 'error':
+      return 'bg-[var(--color-error)]'
+  }
+}
+
+export function DashboardSpecPreview({ spec, onSaved }: DashboardSpecPreviewProps) {
+  const { currentOrgId } = useOrganization()
+  const { data: datasources = [] } = useDatasources(currentOrgId)
+
+  const [saving, setSaving] = useState(false)
+  const [saveSuccess, setSaveSuccess] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [savedDashboardId, setSavedDashboardId] = useState<string | null>(null)
+  const [validationErrors, setValidationErrors] = useState<string[]>([])
+  const [specExpanded, setSpecExpanded] = useState(false)
+  const [specCopied, setSpecCopied] = useState(false)
+  const [dryRunResults, setDryRunResults] = useState<Record<number, DryRunStatus>>({})
+
+  const panelCount = spec.panels?.length ?? 0
+  const knownDatasourceIds = useMemo(() => datasources.map(ds => ds.id), [datasources])
+  const isDemoSpec = useMemo(
+    () =>
+      Boolean(
+        spec.panels?.some(panel =>
+          DEMO_METRIC_NAMES.some(metric => panel.query.expr.includes(metric)),
+        ),
+      ),
+    [spec.panels],
+  )
+  const maxGridRow = useMemo(() => {
+    if (!spec.panels || spec.panels.length === 0) return 1
+    return Math.max(...spec.panels.map(panel => (panel.position?.y ?? 0) + (panel.position?.h ?? 1)))
+  }, [spec.panels])
+  const isSaved = savedDashboardId !== null
+  const hasValidationErrors = validationErrors.length > 0
+
+  useEffect(() => {
+    setSavedDashboardId(null)
+    setSaveSuccess(false)
+    setSaveError(null)
+    setValidationErrors([])
+
+    if (!spec.panels || spec.panels.length === 0) {
+      setDryRunResults({})
+      return
+    }
+
+    let cancelled = false
+    const initial: Record<number, DryRunStatus> = {}
+    spec.panels.forEach((_, index) => {
+      initial[index] = 'checking'
+    })
+    setDryRunResults(initial)
+
+    const now = Math.floor(Date.now() / 1000)
+    void Promise.allSettled(
+      spec.panels.map(async (panel, index) => {
+        try {
+          const result = await queryDataSource(panel.datasource_id, {
+            query: panel.query.expr,
+            signal: 'metrics',
+            start: now - 300,
+            end: now,
+            step: 15,
+          })
+
+          const hasData =
+            result.status === 'success' &&
+            result.data?.result &&
+            result.data.result.length > 0
+
+          if (!cancelled) {
+            setDryRunResults(current => ({
+              ...current,
+              [index]: hasData ? 'success' : 'empty',
+            }))
+          }
+        } catch {
+          if (!cancelled) {
+            setDryRunResults(current => ({
+              ...current,
+              [index]: 'error',
+            }))
+          }
+        }
+      }),
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [spec])
+
+  async function handleSave() {
+    const { valid, errors } = validateDashboardSpec(spec, knownDatasourceIds)
+    if (!valid) {
+      setValidationErrors(errors)
+      return
+    }
+    setValidationErrors([])
+
+    if (!currentOrgId) {
+      setSaveError('No organization selected')
+      return
+    }
+
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const id = await saveDashboardSpec(spec, currentOrgId)
+      setSaveSuccess(true)
+      window.setTimeout(() => {
+        setSavedDashboardId(id)
+        onSaved?.(id)
+      }, 1000)
+    } catch (cause) {
+      setSaveError(cause instanceof Error ? cause.message : 'Failed to save dashboard')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function copySpec() {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(spec, null, 2))
+      setSpecCopied(true)
+      window.setTimeout(() => setSpecCopied(false), 2000)
+    } catch {
+      // clipboard not available
+    }
+  }
+
+  return (
+    <section
+      aria-label={`Dashboard preview: ${spec.title}, ${panelCount} panels`}
+      className={`overflow-hidden rounded-lg border border-[color-mix(in_srgb,var(--color-outline-variant)_30%,transparent)] ${saving ? 'opacity-70' : ''}`}
+    >
+      <div className="flex items-center gap-2 px-3 py-2">
+        <span className="truncate text-sm font-semibold text-[var(--color-on-surface)]">
+          {spec.title}
+        </span>
+        <span className="shrink-0 text-xs text-[var(--color-outline)]">
+          {panelCount} panel{panelCount !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {isDemoSpec && (
+        <div className="px-3 pb-2">
+          <span className="rounded bg-[var(--color-tertiary)]/10 px-2 py-1 text-xs text-[var(--color-tertiary)]">
+            Demo dashboard — connect a real datasource to see your data
+          </span>
+        </div>
+      )}
+
+      <div className="px-3 pb-2">
+        <ul
+          className="m-0 grid list-none gap-1 p-0"
+          style={{
+            gridTemplateColumns: 'repeat(12, 1fr)',
+            gridTemplateRows: `repeat(${maxGridRow}, 24px)`,
+          }}
+        >
+          {spec.panels?.map((panel, index) => {
+            const Icon = panelTypeIcons[panel.type] || TrendingUp
+            const panelKey = `${panel.title}-${panel.type}-${panel.position?.x ?? 0}-${panel.position?.y ?? 0}-${panel.query.expr}`
+            return (
+              <li
+                key={panelKey}
+                aria-label={`${panel.title} (${panel.type})`}
+                className="relative flex min-w-0 items-center gap-1 rounded bg-[var(--color-surface-container-low)] px-1.5 py-0.5"
+                style={{
+                  gridColumn: `${(panel.position?.x ?? 0) + 1} / span ${panel.position?.w ?? 4}`,
+                  gridRow: `${(panel.position?.y ?? 0) + 1} / span ${panel.position?.h ?? 1}`,
+                }}
+              >
+                <Icon size={10} className="shrink-0 text-[var(--color-outline)]" />
+                <span className="truncate text-[10px] text-[var(--color-outline)]">
+                  {panel.title}
+                </span>
+                {dryRunResults[index] && (
+                  <span
+                    className={`ml-auto h-2 w-2 shrink-0 rounded-full ${dryRunDotClass(dryRunResults[index]!)}`}
+                  />
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+
+      {hasValidationErrors && (
+        <div className="px-3 pb-2">
+          <ul className="m-0 list-inside list-disc rounded bg-[var(--color-error)]/10 px-3 py-2 text-xs text-[var(--color-error)]">
+            {validationErrors.map(err => (
+              <li key={err}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {saveError && (
+        <div className="px-3 pb-2" aria-live="polite">
+          <span className="rounded bg-[var(--color-error)]/10 px-2 py-1 text-xs text-[var(--color-error)]">
+            {saveError}
+          </span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 px-3 pb-3" aria-live="polite">
+        {isSaved ? (
+          <>
+            <span className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--color-secondary)]">
+              <Check size={14} />
+              Dashboard saved
+            </span>
+            <Link
+              to={`/app/dashboards/${savedDashboardId}`}
+              className="inline-flex items-center gap-1 text-xs text-[var(--color-primary)] no-underline hover:underline"
+            >
+              <ExternalLink size={12} />
+              Open dashboard
+            </Link>
+          </>
+        ) : saveSuccess ? (
+          <span className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--color-secondary)]">
+            <Check size={14} />
+            Dashboard saved
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm border-none bg-[var(--color-primary)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={saving || hasValidationErrors}
+            data-testid="spec-preview-save-btn"
+            onClick={() => void handleSave()}
+          >
+            {saving && <Loader2 size={14} className="animate-spin" />}
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        )}
+
+        <button
+          type="button"
+          className="ml-auto inline-flex cursor-pointer items-center gap-0.5 border-none bg-transparent text-xs text-[var(--color-outline)] hover:text-[var(--color-on-surface)]"
+          aria-expanded={specExpanded}
+          data-testid="spec-preview-toggle-spec"
+          onClick={() => setSpecExpanded(current => !current)}
+        >
+          View spec
+          {specExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        </button>
+      </div>
+
+      {specExpanded && (
+        <div className="border-t border-[color-mix(in_srgb,var(--color-outline-variant)_30%,transparent)] px-3 py-2">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs text-[var(--color-outline)]">Dashboard spec (JSON)</span>
+            <button
+              type="button"
+              className="inline-flex cursor-pointer items-center gap-1 border-none bg-transparent text-xs text-[var(--color-outline)] hover:text-[var(--color-on-surface)]"
+              data-testid="spec-preview-copy-btn"
+              onClick={() => void copySpec()}
+            >
+              {specCopied ? (
+                <Check size={12} className="text-[var(--color-secondary)]" />
+              ) : (
+                <ClipboardCopy size={12} />
+              )}
+              {specCopied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <pre className="m-0 max-h-48 overflow-x-auto overflow-y-auto rounded bg-[var(--color-surface-container-high)] p-2 text-[10px] text-[var(--color-on-surface-variant)]">
+            {JSON.stringify(spec, null, 2)}
+          </pre>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/DashboardSpecPreview.tsx
+++ b/frontend/src/components/DashboardSpecPreview.tsx
@@ -8,10 +8,10 @@ import {
   Gauge,
   Hash,
   Loader2,
+  type LucideIcon,
   PieChart,
   Table,
   TrendingUp,
-  type LucideIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -73,19 +73,21 @@ export function DashboardSpecPreview({ spec, onSaved }: DashboardSpecPreviewProp
   const [dryRunResults, setDryRunResults] = useState<Record<number, DryRunStatus>>({})
 
   const panelCount = spec.panels?.length ?? 0
-  const knownDatasourceIds = useMemo(() => datasources.map(ds => ds.id), [datasources])
+  const knownDatasourceIds = useMemo(() => datasources.map((ds) => ds.id), [datasources])
   const isDemoSpec = useMemo(
     () =>
       Boolean(
-        spec.panels?.some(panel =>
-          DEMO_METRIC_NAMES.some(metric => panel.query.expr.includes(metric)),
+        spec.panels?.some((panel) =>
+          DEMO_METRIC_NAMES.some((metric) => panel.query.expr.includes(metric)),
         ),
       ),
     [spec.panels],
   )
   const maxGridRow = useMemo(() => {
     if (!spec.panels || spec.panels.length === 0) return 1
-    return Math.max(...spec.panels.map(panel => (panel.position?.y ?? 0) + (panel.position?.h ?? 1)))
+    return Math.max(
+      ...spec.panels.map((panel) => (panel.position?.y ?? 0) + (panel.position?.h ?? 1)),
+    )
   }, [spec.panels])
   const isSaved = savedDashboardId !== null
   const hasValidationErrors = validationErrors.length > 0
@@ -114,26 +116,24 @@ export function DashboardSpecPreview({ spec, onSaved }: DashboardSpecPreviewProp
         try {
           const result = await queryDataSource(panel.datasource_id, {
             query: panel.query.expr,
-            signal: 'metrics',
+            signal: panel.query.signal ?? 'metrics',
             start: now - 300,
             end: now,
             step: 15,
           })
 
           const hasData =
-            result.status === 'success' &&
-            result.data?.result &&
-            result.data.result.length > 0
+            result.status === 'success' && result.data?.result && result.data.result.length > 0
 
           if (!cancelled) {
-            setDryRunResults(current => ({
+            setDryRunResults((current) => ({
               ...current,
               [index]: hasData ? 'success' : 'empty',
             }))
           }
         } catch {
           if (!cancelled) {
-            setDryRunResults(current => ({
+            setDryRunResults((current) => ({
               ...current,
               [index]: 'error',
             }))
@@ -247,7 +247,7 @@ export function DashboardSpecPreview({ spec, onSaved }: DashboardSpecPreviewProp
       {hasValidationErrors && (
         <div className="px-3 pb-2">
           <ul className="m-0 list-inside list-disc rounded bg-[var(--color-error)]/10 px-3 py-2 text-xs text-[var(--color-error)]">
-            {validationErrors.map(err => (
+            {validationErrors.map((err) => (
               <li key={err}>{err}</li>
             ))}
           </ul>
@@ -300,7 +300,7 @@ export function DashboardSpecPreview({ spec, onSaved }: DashboardSpecPreviewProp
           className="ml-auto inline-flex cursor-pointer items-center gap-0.5 border-none bg-transparent text-xs text-[var(--color-outline)] hover:text-[var(--color-on-surface)]"
           aria-expanded={specExpanded}
           data-testid="spec-preview-toggle-spec"
-          onClick={() => setSpecExpanded(current => !current)}
+          onClick={() => setSpecExpanded((current) => !current)}
         >
           View spec
           {specExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}

--- a/frontend/src/components/ShimmerLoader.tsx
+++ b/frontend/src/components/ShimmerLoader.tsx
@@ -1,0 +1,24 @@
+type ShimmerLoaderProps = {
+  width?: string
+  height?: string
+  rounded?: string
+}
+
+export function ShimmerLoader({
+  width = '100%',
+  height = '1rem',
+  rounded = '0.5rem',
+}: ShimmerLoaderProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className="animate-pulse"
+      style={{
+        width,
+        height,
+        borderRadius: rounded,
+        backgroundColor: 'var(--color-surface-container-high)',
+      }}
+    />
+  )
+}

--- a/frontend/src/hooks/useAIProvider.ts
+++ b/frontend/src/hooks/useAIProvider.ts
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { listAIModels, listAIProviders, type AIProviderInfo } from '@/api/aiProviders'
+import { API_BASE } from '@/api/base'
+import { useOrganization } from '@/hooks/useOrganization'
+import type { DashboardSpec } from '@/utils/dashboardSpec'
+
+function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token')
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+export interface AIModel {
+  id: string
+  name: string
+  vendor: string
+  category: string
+  provider_id?: string
+  provider_name?: string
+}
+
+export interface ToolDefinition {
+  type: 'function'
+  function: {
+    name: string
+    description: string
+    parameters: Record<string, unknown>
+  }
+}
+
+export interface ToolCall {
+  id: string
+  type: 'function'
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+export type ChatRequestMessage =
+  | { role: 'user' | 'assistant' | 'system'; content: string }
+  | { role: 'assistant'; content: string | null; tool_calls: ToolCall[] }
+  | { role: 'tool'; tool_call_id: string; content: string }
+
+type AIMessage = {
+  role: 'user' | 'assistant'
+  content: string
+  dashboardSpec?: DashboardSpec
+}
+
+type AIProviderState = {
+  providers: AIProviderInfo[]
+  selectedProviderId: string
+  models: AIModel[]
+  selectedModel: string
+  isLoading: boolean
+  error: string | null
+  chatMessages: AIMessage[]
+  orgId: string | null
+}
+
+const listeners = new Set<() => void>()
+
+let state: AIProviderState = {
+  providers: [],
+  selectedProviderId: '',
+  models: [],
+  selectedModel: '',
+  isLoading: false,
+  error: null,
+  chatMessages: [],
+  orgId: null,
+}
+
+function emit() {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function setState(partial: Partial<AIProviderState>) {
+  state = { ...state, ...partial }
+  emit()
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function getSnapshot() {
+  return state
+}
+
+function resetForOrg(orgId: string | null) {
+  if (state.orgId === orgId) return
+  setState({
+    providers: [],
+    selectedProviderId: '',
+    models: [],
+    selectedModel: '',
+    chatMessages: [],
+    error: null,
+    orgId,
+  })
+}
+
+async function fetchProviders(orgId: string | null) {
+  setState({ error: null })
+  if (!orgId) return
+
+  try {
+    const providers = await listAIProviders(orgId)
+    const selectedProviderId =
+      providers.length > 0 && !providers.find(provider => provider.id === state.selectedProviderId)
+        ? providers[0]!.id
+        : state.selectedProviderId || providers[0]?.id || ''
+
+    setState({
+      providers,
+      selectedProviderId,
+    })
+  } catch (cause) {
+    setState({
+      error: cause instanceof Error ? cause.message : 'Failed to fetch providers',
+    })
+  }
+}
+
+async function fetchModels(orgId: string | null, providerId?: string) {
+  if (!orgId) return
+
+  try {
+    const models = await listAIModels(orgId, providerId)
+    const selectedModel =
+      models.length > 0 && !models.find(model => model.id === state.selectedModel)
+        ? models.find(model => model.id === 'claude-sonnet-4.6')?.id || models[0]!.id
+        : state.selectedModel || models[0]?.id || ''
+
+    setState({
+      models,
+      selectedModel,
+    })
+  } catch {
+    // ignore model fetch errors for generation UX
+  }
+}
+
+async function sendChatRequest(
+  orgId: string | null,
+  datasourceType: string,
+  datasourceName: string,
+  messages: ChatRequestMessage[],
+  tools?: ToolDefinition[],
+  signal?: AbortSignal,
+): Promise<{ content: string | null; toolCalls: ToolCall[] }> {
+  if (!orgId) throw new Error('No organization selected')
+
+  const body: Record<string, unknown> = {
+    provider_id: state.selectedProviderId || undefined,
+    model: state.selectedModel || undefined,
+    datasource_type: datasourceType,
+    datasource_name: datasourceName,
+    messages,
+  }
+  if (tools && tools.length > 0) {
+    body.tools = tools
+    body.stream = false
+  }
+
+  const fetchOptions: RequestInit = {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: JSON.stringify(body),
+    ...(signal ? { signal } : {}),
+  }
+
+  let response = await fetch(`${API_BASE}/api/orgs/${orgId}/ai/chat`, fetchOptions)
+
+  if (response.status === 429) {
+    await Promise.race([
+      new Promise(resolve => setTimeout(resolve, 2000)),
+      ...(signal
+        ? [
+            new Promise<never>((_, reject) =>
+              signal.addEventListener(
+                'abort',
+                () => reject(new DOMException('Aborted', 'AbortError')),
+                { once: true },
+              ),
+            ),
+          ]
+        : []),
+    ])
+    response = await fetch(`${API_BASE}/api/orgs/${orgId}/ai/chat`, fetchOptions)
+  }
+
+  if (!response.ok) {
+    const errData = await response.json().catch(() => ({}))
+    throw new Error(errData.error || `AI request failed (${response.status})`)
+  }
+
+  const contentType = response.headers.get('content-type') || ''
+
+  if (contentType.includes('text/event-stream')) {
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error('No response stream')
+
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let fullContent = ''
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() || ''
+
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed || trimmed === 'data: [DONE]') continue
+        if (trimmed.startsWith('data: ')) {
+          try {
+            const json = JSON.parse(trimmed.slice(6))
+            const content = json.choices?.[0]?.delta?.content
+            if (content) fullContent += content
+          } catch {
+            // skip malformed
+          }
+        }
+      }
+    }
+
+    return { content: fullContent, toolCalls: [] }
+  }
+
+  const data = await response.json()
+  const choices = data.choices
+  if (!choices || choices.length === 0) throw new Error('No response from model')
+
+  let content: string | null = null
+  let toolCalls: ToolCall[] = []
+  for (const choice of choices) {
+    if (choice.message?.content && !content) {
+      content = choice.message.content
+    }
+    if (choice.message?.tool_calls?.length) {
+      toolCalls = choice.message.tool_calls
+    }
+  }
+
+  return { content, toolCalls }
+}
+
+export function useAIProvider() {
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const { currentOrgId } = useOrganization()
+
+  useEffect(() => {
+    resetForOrg(currentOrgId)
+  }, [currentOrgId])
+
+  const fetchProvidersBound = useCallback(async () => {
+    await fetchProviders(currentOrgId)
+  }, [currentOrgId])
+
+  const fetchModelsBound = useCallback(
+    async (providerId?: string) => {
+      await fetchModels(currentOrgId, providerId)
+    },
+    [currentOrgId],
+  )
+
+  const sendChatRequestBound = useCallback(
+    async (
+      datasourceType: string,
+      datasourceName: string,
+      messages: ChatRequestMessage[],
+      tools?: ToolDefinition[],
+      signal?: AbortSignal,
+    ) =>
+      sendChatRequest(currentOrgId, datasourceType, datasourceName, messages, tools, signal),
+    [currentOrgId],
+  )
+
+  return {
+    providers: snapshot.providers,
+    selectedProviderId: snapshot.selectedProviderId,
+    models: snapshot.models,
+    selectedModel: snapshot.selectedModel,
+    isLoading: snapshot.isLoading,
+    error: snapshot.error,
+    chatMessages: snapshot.chatMessages,
+    fetchProviders: fetchProvidersBound,
+    fetchModels: fetchModelsBound,
+    sendChatRequest: sendChatRequestBound,
+  }
+}

--- a/frontend/src/hooks/useDashboardGeneration.ts
+++ b/frontend/src/hooks/useDashboardGeneration.ts
@@ -1,0 +1,219 @@
+import { useCallback, useRef, useState } from 'react'
+import type { ChatRequestMessage, ToolCall, ToolDefinition } from '@/hooks/useAIProvider'
+import { useAIProvider } from '@/hooks/useAIProvider'
+import { executeCopilotTool } from '@/lib/copilotTools'
+import type { DashboardSpec } from '@/utils/dashboardSpec'
+import { validateDashboardSpec } from '@/utils/dashboardSpec'
+
+export interface ToolStatus {
+  name: string
+  status: 'running' | 'complete' | 'error'
+}
+
+export interface DashboardGenCallbacks {
+  onContent?: (text: string) => void
+  onDashboardSpec?: (spec: DashboardSpec) => void
+  onToolStatus?: (status: ToolStatus) => void
+}
+
+const MAX_TOOL_ITERATIONS = 10
+
+type GenerateDashboardArgs = {
+  title: string
+  description?: string
+  panels: Array<{
+    title: string
+    type: DashboardSpec['panels'][number]['type']
+    grid_pos?: DashboardSpec['panels'][number]['position']
+    position?: DashboardSpec['panels'][number]['position']
+    query: {
+      expr: string
+      legend_format?: string
+      legend?: string
+      signal?: 'metrics' | 'logs' | 'traces'
+    }
+  }>
+}
+
+function normalizeGeneratedSpec(raw: GenerateDashboardArgs, datasourceId: string): DashboardSpec {
+  return {
+    title: raw.title,
+    description: raw.description,
+    panels: (raw.panels ?? []).map(panel => ({
+      title: panel.title,
+      type: panel.type,
+      position: panel.position ?? panel.grid_pos ?? { x: 0, y: 0, w: 6, h: 3 },
+      datasource_id: datasourceId,
+      query: {
+        expr: panel.query.expr,
+        ...(panel.query.signal ? { signal: panel.query.signal } : {}),
+        ...(panel.query.legend
+          ? { legend: panel.query.legend }
+          : panel.query.legend_format
+            ? { legend: panel.query.legend_format }
+            : {}),
+      },
+    })),
+  }
+}
+
+export function useDashboardGeneration(
+  datasourceId: () => string,
+  orgId: () => string,
+  datasourceType: () => string,
+) {
+  const { sendChatRequest } = useAIProvider()
+  const [toolStatuses, setToolStatuses] = useState<ToolStatus[]>([])
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [progressText, setProgressText] = useState('')
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const generatingRef = useRef(false)
+
+  const cancel = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+      abortControllerRef.current = null
+    }
+    generatingRef.current = false
+    setIsGenerating(false)
+    setError(null)
+  }, [])
+
+  const generate = useCallback(
+    async (
+      messages: ChatRequestMessage[],
+      tools: ToolDefinition[],
+      datasourceName: string,
+      callbacks?: DashboardGenCallbacks,
+    ): Promise<{ spec: DashboardSpec | null; content: string | null }> => {
+      if (generatingRef.current) return { spec: null, content: null }
+
+      generatingRef.current = true
+      setIsGenerating(true)
+      setError(null)
+      setToolStatuses([])
+      setProgressText('')
+
+      abortControllerRef.current = new AbortController()
+      const signal = abortControllerRef.current.signal
+
+      const requestMessages: ChatRequestMessage[] = [...messages]
+      let lastContent: string | null = null
+      let resultSpec: DashboardSpec | null = null
+
+      try {
+        for (let i = 0; i < MAX_TOOL_ITERATIONS; i += 1) {
+          if (signal.aborted) break
+
+          const { content, toolCalls } = await sendChatRequest(
+            datasourceType(),
+            datasourceName,
+            requestMessages,
+            tools,
+            signal,
+          )
+
+          if (content) {
+            lastContent = content
+            setProgressText(content)
+            callbacks?.onContent?.(content)
+            requestMessages.push({ role: 'assistant', content })
+          }
+
+          if (!toolCalls.length) break
+
+          for (const tc of toolCalls) {
+            if (signal.aborted) break
+
+            if (tc.function.name === 'generate_dashboard') {
+              let rawSpec: GenerateDashboardArgs
+              try {
+                rawSpec = JSON.parse(tc.function.arguments) as GenerateDashboardArgs
+              } catch {
+                setError('AI returned an invalid dashboard.')
+                return { spec: null, content: lastContent }
+              }
+
+              const spec = normalizeGeneratedSpec(rawSpec, datasourceId())
+              const validation = validateDashboardSpec(spec, [datasourceId()])
+              if (!validation.valid) {
+                setError(`Generated dashboard has issues: ${validation.errors.join('; ')}`)
+                return { spec: null, content: lastContent }
+              }
+
+              resultSpec = spec
+              callbacks?.onDashboardSpec?.(spec)
+              requestMessages.push(
+                { role: 'assistant', content: null, tool_calls: [tc] },
+                { role: 'tool', tool_call_id: tc.id, content: JSON.stringify(spec) },
+              )
+              break
+            }
+
+            const statusEntry: ToolStatus = { name: tc.function.name, status: 'running' }
+            setToolStatuses(current => [...current, statusEntry])
+            callbacks?.onToolStatus?.(statusEntry)
+
+            const result = await executeCopilotTool(tc as ToolCall, {
+              datasourceId: datasourceId(),
+              orgId: orgId(),
+              signal,
+            }).catch((err: unknown) => {
+              setToolStatuses(current => {
+                const next = [...current]
+                const index = next.findLastIndex(entry => entry.name === tc.function.name)
+                if (index >= 0) next[index] = { ...next[index]!, status: 'error' }
+                return next
+              })
+              return `Error: ${err instanceof Error ? err.message : 'Tool execution failed'}`
+            })
+
+            setToolStatuses(current => {
+              const next = [...current]
+              const index = next.findLastIndex(
+                entry => entry.name === tc.function.name && entry.status === 'running',
+              )
+              if (index >= 0 && next[index]!.status === 'running') {
+                next[index] = { ...next[index]!, status: 'complete' }
+              }
+              return next
+            })
+
+            requestMessages.push(
+              { role: 'assistant', content: null, tool_calls: [tc] },
+              { role: 'tool', tool_call_id: tc.id, content: result },
+            )
+          }
+
+          if (resultSpec) break
+        }
+
+        if (!resultSpec && !lastContent) {
+          setError('Could not generate a dashboard. Try a more specific prompt.')
+        }
+      } catch (cause) {
+        if (cause instanceof DOMException && cause.name === 'AbortError') {
+          // cancelled
+        } else if (cause instanceof Error && cause.message.includes('429')) {
+          setError('AI request failed (429)')
+        } else {
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : 'Could not reach AI provider. Check your provider settings.',
+          )
+        }
+      } finally {
+        generatingRef.current = false
+        setIsGenerating(false)
+        abortControllerRef.current = null
+      }
+
+      return { spec: resultSpec, content: lastContent }
+    },
+    [datasourceId, datasourceType, orgId, sendChatRequest],
+  )
+
+  return { toolStatuses, isGenerating, error, progressText, generate, cancel }
+}

--- a/frontend/src/hooks/useDashboardGeneration.ts
+++ b/frontend/src/hooks/useDashboardGeneration.ts
@@ -35,25 +35,48 @@ type GenerateDashboardArgs = {
   }>
 }
 
-function normalizeGeneratedSpec(raw: GenerateDashboardArgs, datasourceId: string): DashboardSpec {
+function defaultSignalForDatasourceType(
+  datasourceType: string,
+): 'metrics' | 'logs' | 'traces' | undefined {
+  if (['loki', 'victorialogs', 'elasticsearch', 'clickhouse'].includes(datasourceType)) {
+    return 'logs'
+  }
+  if (['tempo', 'victoriatraces'].includes(datasourceType)) {
+    return 'traces'
+  }
+  if (['victoriametrics', 'prometheus'].includes(datasourceType)) {
+    return 'metrics'
+  }
+  return undefined
+}
+
+function normalizeGeneratedSpec(
+  raw: GenerateDashboardArgs,
+  datasourceId: string,
+  datasourceType: string,
+): DashboardSpec {
+  const fallbackSignal = defaultSignalForDatasourceType(datasourceType)
   return {
     title: raw.title,
     description: raw.description,
-    panels: (raw.panels ?? []).map(panel => ({
-      title: panel.title,
-      type: panel.type,
-      position: panel.position ?? panel.grid_pos ?? { x: 0, y: 0, w: 6, h: 3 },
-      datasource_id: datasourceId,
-      query: {
-        expr: panel.query.expr,
-        ...(panel.query.signal ? { signal: panel.query.signal } : {}),
-        ...(panel.query.legend
-          ? { legend: panel.query.legend }
-          : panel.query.legend_format
-            ? { legend: panel.query.legend_format }
-            : {}),
-      },
-    })),
+    panels: (raw.panels ?? []).map((panel) => {
+      const signal = panel.query.signal ?? fallbackSignal
+      return {
+        title: panel.title,
+        type: panel.type,
+        position: panel.position ?? panel.grid_pos ?? { x: 0, y: 0, w: 6, h: 3 },
+        datasource_id: datasourceId,
+        query: {
+          expr: panel.query.expr,
+          ...(signal ? { signal } : {}),
+          ...(panel.query.legend
+            ? { legend: panel.query.legend }
+            : panel.query.legend_format
+              ? { legend: panel.query.legend_format }
+              : {}),
+        },
+      }
+    }),
   }
 }
 
@@ -135,7 +158,7 @@ export function useDashboardGeneration(
                 return { spec: null, content: lastContent }
               }
 
-              const spec = normalizeGeneratedSpec(rawSpec, datasourceId())
+              const spec = normalizeGeneratedSpec(rawSpec, datasourceId(), datasourceType())
               const validation = validateDashboardSpec(spec, [datasourceId()])
               if (!validation.valid) {
                 setError(`Generated dashboard has issues: ${validation.errors.join('; ')}`)
@@ -152,7 +175,7 @@ export function useDashboardGeneration(
             }
 
             const statusEntry: ToolStatus = { name: tc.function.name, status: 'running' }
-            setToolStatuses(current => [...current, statusEntry])
+            setToolStatuses((current) => [...current, statusEntry])
             callbacks?.onToolStatus?.(statusEntry)
 
             const result = await executeCopilotTool(tc as ToolCall, {
@@ -160,20 +183,31 @@ export function useDashboardGeneration(
               orgId: orgId(),
               signal,
             }).catch((err: unknown) => {
-              setToolStatuses(current => {
+              setToolStatuses((current) => {
                 const next = [...current]
-                const index = next.findLastIndex(entry => entry.name === tc.function.name)
+                let index = -1
+                for (let i = next.length - 1; i >= 0; i -= 1) {
+                  if (next[i]!.name === tc.function.name) {
+                    index = i
+                    break
+                  }
+                }
                 if (index >= 0) next[index] = { ...next[index]!, status: 'error' }
                 return next
               })
               return `Error: ${err instanceof Error ? err.message : 'Tool execution failed'}`
             })
 
-            setToolStatuses(current => {
+            setToolStatuses((current) => {
               const next = [...current]
-              const index = next.findLastIndex(
-                entry => entry.name === tc.function.name && entry.status === 'running',
-              )
+              let index = -1
+              for (let i = next.length - 1; i >= 0; i -= 1) {
+                const entry = next[i]!
+                if (entry.name === tc.function.name && entry.status === 'running') {
+                  index = i
+                  break
+                }
+              }
               if (index >= 0 && next[index]!.status === 'running') {
                 next[index] = { ...next[index]!, status: 'complete' }
               }

--- a/frontend/src/lib/copilotTools.ts
+++ b/frontend/src/lib/copilotTools.ts
@@ -1,0 +1,318 @@
+import {
+  fetchDataSourceLabels,
+  fetchDataSourceLabelValues,
+  fetchDataSourceMetricNames,
+  fetchDataSourceTraceServices,
+  listDataSources,
+} from '@/api/datasources'
+import type { ToolCall, ToolDefinition } from '@/hooks/useAIProvider'
+
+const datasourceIdParam = {
+  datasource_id: {
+    type: 'string',
+    description: 'Override the default datasource. Use an ID from list_datasources.',
+  },
+} as const
+
+const listDatasourcesTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'list_datasources',
+    description:
+      'List all datasources available in the current organization. Use this to discover datasource IDs before querying metrics or labels.',
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+  },
+}
+
+const getMetricsTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'get_metrics',
+    description:
+      'List available metric names from the datasource. Use this to discover what metrics exist before writing a query.',
+    parameters: {
+      type: 'object',
+      properties: {
+        search: {
+          type: 'string',
+          description: 'Optional search filter to narrow down metric names',
+        },
+        ...datasourceIdParam,
+      },
+    },
+  },
+}
+
+const getLabelsTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'get_labels',
+    description:
+      'List available label names from the datasource. Optionally filter to labels for a specific metric.',
+    parameters: {
+      type: 'object',
+      properties: {
+        metric: {
+          type: 'string',
+          description: 'Optional metric name to filter labels for',
+        },
+        ...datasourceIdParam,
+      },
+    },
+  },
+}
+
+const getLabelValuesTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'get_label_values',
+    description:
+      'List values for a specific label from the datasource. Optionally filter to values for a specific metric.',
+    parameters: {
+      type: 'object',
+      properties: {
+        label: {
+          type: 'string',
+          description: 'The label name to get values for (required)',
+        },
+        metric: {
+          type: 'string',
+          description: 'Optional metric name to filter label values for',
+        },
+        ...datasourceIdParam,
+      },
+      required: ['label'],
+    },
+  },
+}
+
+const writeQueryTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'write_query',
+    description:
+      'Write a query into the query editor on the current page. Supports PromQL/MetricsQL for metrics, LogQL for logs, and TraceQL for traces. The user can then review it before running.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'The query expression to write (PromQL/MetricsQL, LogQL, TraceQL, etc.)',
+        },
+      },
+      required: ['query'],
+    },
+  },
+}
+
+const runQueryTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'run_query',
+    description:
+      'Execute the query currently in the editor. Use after write_query to run the query and show results to the user.',
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+  },
+}
+
+const generateDashboardTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'generate_dashboard',
+    description:
+      'Generate a complete dashboard from the discovered metrics. Call this after using get_metrics, get_labels, and get_label_values to understand the available data. The dashboard will be previewed for the user before saving.',
+    parameters: {
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+          description: 'Dashboard title',
+        },
+        description: {
+          type: 'string',
+          description: 'Brief dashboard description',
+        },
+        panels: {
+          type: 'array',
+          description: 'Array of panel specifications',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string', description: 'Panel title' },
+              type: {
+                type: 'string',
+                enum: ['line_chart', 'bar_chart', 'gauge', 'stat', 'table', 'pie'],
+                description: 'Visualization type',
+              },
+              grid_pos: {
+                type: 'object',
+                properties: {
+                  x: { type: 'number', description: 'Column position (0-11)' },
+                  y: { type: 'number', description: 'Row position' },
+                  w: { type: 'number', description: 'Width in columns (1-12)' },
+                  h: { type: 'number', description: 'Height in rows' },
+                },
+                required: ['x', 'y', 'w', 'h'],
+              },
+              query: {
+                type: 'object',
+                description: 'Query configuration for this panel',
+                properties: {
+                  expr: { type: 'string', description: 'PromQL/MetricsQL query expression' },
+                  legend_format: { type: 'string', description: 'Optional legend format string' },
+                },
+                required: ['expr'],
+              },
+            },
+            required: ['title', 'type', 'grid_pos', 'query'],
+          },
+        },
+      },
+      required: ['title', 'panels'],
+    },
+  },
+}
+
+const getTraceServicesTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'get_trace_services',
+    description:
+      'List service names from a tracing datasource. Use this to discover what services are reporting traces.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ...datasourceIdParam,
+      },
+    },
+  },
+}
+
+const METRICS_TYPES = ['victoriametrics', 'prometheus']
+const LOGS_TYPES = ['loki', 'victorialogs', 'elasticsearch', 'clickhouse']
+const TRACES_TYPES = ['tempo', 'victoriatraces']
+
+const commonTools: ToolDefinition[] = [
+  listDatasourcesTool,
+  getLabelsTool,
+  getLabelValuesTool,
+  writeQueryTool,
+  runQueryTool,
+]
+
+export function getToolsForDatasourceType(datasourceType: string): ToolDefinition[] {
+  if (METRICS_TYPES.includes(datasourceType)) {
+    return [...commonTools, getMetricsTool, generateDashboardTool]
+  }
+
+  if (LOGS_TYPES.includes(datasourceType)) {
+    return [...commonTools]
+  }
+
+  if (TRACES_TYPES.includes(datasourceType)) {
+    return [...commonTools, getTraceServicesTool]
+  }
+
+  return [...commonTools, getMetricsTool, getTraceServicesTool, generateDashboardTool]
+}
+
+function resolveDatasourceId(args: Record<string, unknown>, defaultId: string): string | null {
+  const id = (args.datasource_id as string) || defaultId
+  return id || null
+}
+
+export async function executeCopilotTool(
+  toolCall: ToolCall,
+  options: {
+    datasourceId: string
+    orgId: string
+    signal?: AbortSignal
+  },
+): Promise<string> {
+  const args = JSON.parse(toolCall.function.arguments || '{}') as Record<string, unknown>
+
+  switch (toolCall.function.name) {
+    case 'list_datasources': {
+      if (!options.orgId) return 'Error: no organization selected'
+      const sources = await listDataSources(options.orgId)
+      return JSON.stringify(sources.map(ds => ({ id: ds.id, name: ds.name, type: ds.type })))
+    }
+
+    case 'get_metrics': {
+      const dsId = resolveDatasourceId(args, options.datasourceId)
+      if (!dsId) {
+        return 'Error: no datasource selected. Call list_datasources first to get a datasource ID.'
+      }
+      const metrics = await fetchDataSourceMetricNames(
+        dsId,
+        args.search as string | undefined,
+        options.signal,
+      )
+      if (metrics.length === 0) return 'No metrics found'
+      if (metrics.length > 100) {
+        return `Found ${metrics.length} metrics. Showing first 100:\n${metrics.slice(0, 100).join('\n')}`
+      }
+      return metrics.join('\n')
+    }
+
+    case 'get_labels': {
+      const dsId = resolveDatasourceId(args, options.datasourceId)
+      if (!dsId) {
+        return 'Error: no datasource selected. Call list_datasources first to get a datasource ID.'
+      }
+      const labels = await fetchDataSourceLabels(
+        dsId,
+        args.metric as string | undefined,
+        options.signal,
+      )
+      if (labels.length === 0) return 'No labels found'
+      return labels.join('\n')
+    }
+
+    case 'get_label_values': {
+      if (!args.label) return 'Error: label parameter is required'
+      const dsId = resolveDatasourceId(args, options.datasourceId)
+      if (!dsId) {
+        return 'Error: no datasource selected. Call list_datasources first to get a datasource ID.'
+      }
+      const values = await fetchDataSourceLabelValues(
+        dsId,
+        args.label as string,
+        args.metric as string | undefined,
+        options.signal,
+      )
+      if (values.length === 0) return `No values found for label "${args.label}"`
+      if (values.length > 100) {
+        return `Found ${values.length} values for "${args.label}". Showing first 100:\n${values.slice(0, 100).join('\n')}`
+      }
+      return values.join('\n')
+    }
+
+    case 'get_trace_services': {
+      const dsId = resolveDatasourceId(args, options.datasourceId)
+      if (!dsId) {
+        return 'Error: no datasource selected. Call list_datasources first to get a datasource ID.'
+      }
+      const services = await fetchDataSourceTraceServices(dsId, options.signal)
+      if (services.length === 0) return 'No services found'
+      return services.join('\n')
+    }
+
+    case 'write_query':
+      return args.query
+        ? `Query prepared: ${args.query}`
+        : 'Error: query parameter is required'
+
+    case 'run_query':
+      return 'Query execution is not available during dashboard generation'
+
+    default:
+      return `Unknown tool: ${toolCall.function.name}`
+  }
+}

--- a/frontend/src/lib/copilotTools.ts
+++ b/frontend/src/lib/copilotTools.ts
@@ -126,7 +126,7 @@ const generateDashboardTool: ToolDefinition = {
   function: {
     name: 'generate_dashboard',
     description:
-      'Generate a complete dashboard from the discovered metrics. Call this after using get_metrics, get_labels, and get_label_values to understand the available data. The dashboard will be previewed for the user before saving.',
+      'Generate a complete dashboard from discovered data. Call this after exploring the selected datasource (metrics, labels, services, etc.). The dashboard will be previewed for the user before saving.',
     parameters: {
       type: 'object',
       properties: {
@@ -164,8 +164,17 @@ const generateDashboardTool: ToolDefinition = {
                 type: 'object',
                 description: 'Query configuration for this panel',
                 properties: {
-                  expr: { type: 'string', description: 'PromQL/MetricsQL query expression' },
+                  expr: {
+                    type: 'string',
+                    description:
+                      'Query expression (PromQL/MetricsQL, LogQL, TraceQL, etc. matching the datasource)',
+                  },
                   legend_format: { type: 'string', description: 'Optional legend format string' },
+                  signal: {
+                    type: 'string',
+                    enum: ['metrics', 'logs', 'traces'],
+                    description: 'Signal type for this panel query',
+                  },
                 },
                 required: ['expr'],
               },
@@ -207,16 +216,18 @@ const commonTools: ToolDefinition[] = [
 ]
 
 export function getToolsForDatasourceType(datasourceType: string): ToolDefinition[] {
+  // generate_dashboard must be available for every datasource type used by AI
+  // dashboard generation; without it the model cannot emit a previewable spec.
   if (METRICS_TYPES.includes(datasourceType)) {
     return [...commonTools, getMetricsTool, generateDashboardTool]
   }
 
   if (LOGS_TYPES.includes(datasourceType)) {
-    return [...commonTools]
+    return [...commonTools, generateDashboardTool]
   }
 
   if (TRACES_TYPES.includes(datasourceType)) {
-    return [...commonTools, getTraceServicesTool]
+    return [...commonTools, getTraceServicesTool, generateDashboardTool]
   }
 
   return [...commonTools, getMetricsTool, getTraceServicesTool, generateDashboardTool]
@@ -241,7 +252,7 @@ export async function executeCopilotTool(
     case 'list_datasources': {
       if (!options.orgId) return 'Error: no organization selected'
       const sources = await listDataSources(options.orgId)
-      return JSON.stringify(sources.map(ds => ({ id: ds.id, name: ds.name, type: ds.type })))
+      return JSON.stringify(sources.map((ds) => ({ id: ds.id, name: ds.name, type: ds.type })))
     }
 
     case 'get_metrics': {
@@ -305,9 +316,7 @@ export async function executeCopilotTool(
     }
 
     case 'write_query':
-      return args.query
-        ? `Query prepared: ${args.query}`
-        : 'Error: query parameter is required'
+      return args.query ? `Query prepared: ${args.query}` : 'Error: query parameter is required'
 
     case 'run_query':
       return 'Query execution is not available during dashboard generation'

--- a/frontend/src/pages/DashboardGenPage.spec.tsx
+++ b/frontend/src/pages/DashboardGenPage.spec.tsx
@@ -1,0 +1,231 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as datasourcesApi from '@/api/datasources'
+import { DashboardGenPage } from '@/pages/DashboardGenPage'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+import type { DashboardSpec } from '@/utils/dashboardSpec'
+
+const mockGenerate = vi.fn()
+const mockCancel = vi.fn()
+const mockFetchProviders = vi.fn()
+const mockFetchModels = vi.fn()
+
+let mockProviders: Array<{ id: string; display_name: string }> = [
+  { id: 'p1', display_name: 'OpenAI' },
+]
+
+vi.mock('@/hooks/useOrganization', () => ({
+  useOrganization: () => ({
+    currentOrg: { id: 'org-1' },
+    currentOrgId: 'org-1',
+  }),
+}))
+
+vi.mock('@/hooks/useAIProvider', () => ({
+  useAIProvider: () => ({
+    fetchProviders: mockFetchProviders,
+    fetchModels: mockFetchModels,
+    providers: mockProviders,
+    selectedProviderId: mockProviders[0]?.id ?? '',
+  }),
+}))
+
+vi.mock('@/hooks/useDashboardGeneration', () => ({
+  useDashboardGeneration: () => ({
+    generate: mockGenerate,
+    cancel: mockCancel,
+    isGenerating: false,
+    error: null,
+    toolStatuses: [],
+    progressText: '',
+  }),
+}))
+
+vi.mock('@/lib/copilotTools', () => ({
+  getToolsForDatasourceType: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('@/components/DashboardSpecPreview', () => ({
+  DashboardSpecPreview: ({
+    spec,
+    onSaved,
+  }: {
+    spec: DashboardSpec
+    onSaved?: (id: string) => void
+  }) => (
+    <div data-testid="spec-preview">
+      <span>{spec.title}</span>
+      <button
+        type="button"
+        data-testid="mock-save-generated-dashboard"
+        onClick={() => onSaved?.('dash-ai-1')}
+      >
+        Save generated
+      </button>
+    </div>
+  ),
+}))
+
+function renderGenPage() {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/app/dashboards/new/ai',
+        element: <DashboardGenPage />,
+      },
+      {
+        path: '/app/dashboards/:id',
+        element: <div>Saved dashboard</div>,
+      },
+      {
+        path: '/app/settings',
+        element: <div>Settings</div>,
+      },
+    ],
+    { initialEntries: ['/app/dashboards/new/ai'] },
+  )
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  return router
+}
+
+describe('DashboardGenPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    mockProviders = [{ id: 'p1', display_name: 'OpenAI' }]
+    mockGenerate.mockReset()
+    mockCancel.mockReset()
+    mockFetchProviders.mockResolvedValue(undefined)
+    mockFetchModels.mockResolvedValue(undefined)
+    mockGenerate.mockResolvedValue({ spec: null, content: null })
+
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([
+      {
+        id: 'ds-1',
+        organization_id: 'org-1',
+        name: 'VictoriaMetrics',
+        type: 'victoriametrics',
+        url: 'http://vm:8428',
+        is_default: true,
+        auth_type: 'none',
+        trace_id_field: 'trace_id',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'ds-2',
+        organization_id: 'org-1',
+        name: 'Loki',
+        type: 'loki',
+        url: 'http://loki:3100',
+        is_default: false,
+        auth_type: 'none',
+        trace_id_field: 'trace_id',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+  })
+
+  it('renders describe step with heading', async () => {
+    renderGenPage()
+
+    expect(await screen.findByText('What do you want to monitor?')).toBeTruthy()
+  })
+
+  it('has a generate button that is disabled when input is empty', async () => {
+    renderGenPage()
+
+    const btn = await screen.findByTestId('gen-generate-btn')
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('generates and saves a dashboard on the happy path', async () => {
+    const user = userEvent.setup()
+    mockGenerate.mockResolvedValue({
+      spec: {
+        title: 'API Latency Dashboard',
+        description: 'Generated',
+        panels: [
+          {
+            title: 'p95 latency',
+            type: 'line_chart',
+            position: { x: 0, y: 0, w: 12, h: 3 },
+            datasource_id: 'ds-1',
+            query: { expr: 'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))' },
+          },
+        ],
+      },
+      content: null,
+    })
+
+    const router = renderGenPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('gen-describe-input')).toBeTruthy()
+    })
+
+    await user.type(screen.getByTestId('gen-describe-input'), 'Monitor API latency')
+    await user.click(screen.getByTestId('gen-generate-btn'))
+
+    await waitFor(() => {
+      expect(mockGenerate).toHaveBeenCalled()
+    })
+
+    expect(await screen.findByTestId('spec-preview')).toBeTruthy()
+    expect(screen.getByText('API Latency Dashboard')).toBeTruthy()
+
+    await user.click(screen.getByTestId('mock-save-generated-dashboard'))
+
+    expect(await screen.findByText('Dashboard created!')).toBeTruthy()
+
+    await waitFor(
+      () => {
+        expect(router.state.location.pathname).toBe('/app/dashboards/dash-ai-1')
+      },
+      { timeout: 2500 },
+    )
+  })
+
+  it('shows datasource dropdown when multiple datasources exist', async () => {
+    renderGenPage()
+
+    expect(await screen.findByTestId('gen-datasource-select')).toBeTruthy()
+  })
+
+  it('shows no AI provider warning when providers is empty', async () => {
+    mockProviders = []
+    renderGenPage()
+
+    expect(await screen.findByTestId('gen-no-provider-warning')).toBeTruthy()
+    expect(screen.getByText(/No AI provider configured/i)).toBeTruthy()
+  })
+
+  it('persists selected datasource to localStorage on generate', async () => {
+    const user = userEvent.setup()
+    mockGenerate.mockResolvedValue({ spec: null, content: null })
+
+    renderGenPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('gen-describe-input')).toBeTruthy()
+    })
+
+    await user.type(screen.getByTestId('gen-describe-input'), 'Test')
+    await user.click(screen.getByTestId('gen-generate-btn'))
+
+    await waitFor(() => {
+      expect(localStorage.getItem('ace:lastDatasource:org-1')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/pages/DashboardGenPage.tsx
+++ b/frontend/src/pages/DashboardGenPage.tsx
@@ -1,0 +1,481 @@
+import {
+  AlertCircle,
+  ArrowRight,
+  Check,
+  Loader2,
+  RotateCcw,
+  Sparkles,
+  Wrench,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { listDataSources } from '@/api/datasources'
+import { DashboardSpecPreview } from '@/components/DashboardSpecPreview'
+import { ShimmerLoader } from '@/components/ShimmerLoader'
+import { useAIProvider } from '@/hooks/useAIProvider'
+import { useDashboardGeneration } from '@/hooks/useDashboardGeneration'
+import { useOrganization } from '@/hooks/useOrganization'
+import { getToolsForDatasourceType } from '@/lib/copilotTools'
+import type { DataSource } from '@/types/datasource'
+import type { DashboardSpec } from '@/utils/dashboardSpec'
+
+type Step = 'describe' | 'generate' | 'review' | 'create'
+
+const SUGGESTIONS = [
+  'API latency',
+  'K8s cluster health',
+  'Error rates',
+  'Database performance',
+  'Memory usage',
+  'Request throughput',
+]
+
+function toolStatusLabel(name: string): string {
+  switch (name) {
+    case 'get_metrics':
+      return 'Discovering metrics'
+    case 'get_labels':
+      return 'Fetching labels'
+    case 'get_label_values':
+      return 'Fetching label values'
+    case 'list_datasources':
+      return 'Listing datasources'
+    case 'get_trace_services':
+      return 'Discovering services'
+    default:
+      return name
+  }
+}
+
+export function DashboardGenPage() {
+  const navigate = useNavigate()
+  const { currentOrg } = useOrganization()
+  const { fetchProviders, fetchModels, providers, selectedProviderId } = useAIProvider()
+
+  const [currentStep, setCurrentStep] = useState<Step>('describe')
+  const [prompt, setPrompt] = useState('')
+  const [generatedSpec, setGeneratedSpec] = useState<DashboardSpec | null>(null)
+  const [datasources, setDatasources] = useState<DataSource[]>([])
+  const [selectedDatasourceId, setSelectedDatasourceId] = useState('')
+  const [loadingDatasources, setLoadingDatasources] = useState(false)
+
+  const selectedDatasource = useMemo(
+    () => datasources.find(ds => ds.id === selectedDatasourceId),
+    [datasources, selectedDatasourceId],
+  )
+
+  const { generate, toolStatuses, isGenerating, error: genError, progressText, cancel } =
+    useDashboardGeneration(
+      () => selectedDatasourceId,
+      () => currentOrg?.id ?? '',
+      () => selectedDatasource?.type ?? '',
+    )
+
+  const canGenerate = Boolean(
+    prompt.trim() && selectedDatasourceId && providers.length > 0 && !isGenerating,
+  )
+
+  useEffect(() => {
+    const orgId = currentOrg?.id
+    if (!orgId) return
+
+    let cancelled = false
+
+    async function load() {
+      setLoadingDatasources(true)
+      try {
+        const [dsList] = await Promise.all([
+          listDataSources(orgId).catch(() => [] as DataSource[]),
+          fetchProviders(),
+          fetchModels(selectedProviderId || undefined),
+        ])
+        if (cancelled) return
+
+        setDatasources(dsList)
+
+        if (dsList.length === 1) {
+          setSelectedDatasourceId(dsList[0]!.id)
+        } else if (dsList.length > 1) {
+          const saved = localStorage.getItem(`ace:lastDatasource:${orgId}`)
+          if (saved && dsList.find(ds => ds.id === saved)) {
+            setSelectedDatasourceId(saved)
+          } else {
+            const metricsDs = dsList.find(ds =>
+              ['victoriametrics', 'prometheus'].includes(ds.type),
+            )
+            setSelectedDatasourceId(metricsDs?.id ?? dsList[0]!.id)
+          }
+        }
+      } finally {
+        if (!cancelled) setLoadingDatasources(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+      cancel()
+    }
+  }, [cancel, currentOrg?.id, fetchModels, fetchProviders, selectedProviderId])
+
+  async function startGeneration() {
+    if (!canGenerate) return
+
+    setCurrentStep('generate')
+    setGeneratedSpec(null)
+
+    const ds = selectedDatasource
+    const dsType = ds?.type ?? ''
+    const dsName = ds?.name ?? ''
+
+    if (currentOrg?.id) {
+      localStorage.setItem(`ace:lastDatasource:${currentOrg.id}`, selectedDatasourceId)
+    }
+
+    const messages = [
+      {
+        role: 'system' as const,
+        content: `Generate a monitoring dashboard. Datasource: '${dsName}' (${dsType}, id: ${selectedDatasourceId}). Discover metrics first, then call generate_dashboard.`,
+      },
+      {
+        role: 'user' as const,
+        content: `Create a dashboard for: ${prompt.trim()}`,
+      },
+    ]
+
+    const tools = getToolsForDatasourceType(dsType)
+    const result = await generate(messages, tools, dsName)
+
+    if (result.spec) {
+      setGeneratedSpec(result.spec)
+      setCurrentStep('review')
+    }
+  }
+
+  function handleSpecSaved(dashboardId: string) {
+    setCurrentStep('create')
+    window.setTimeout(() => {
+      navigate(`/app/dashboards/${dashboardId}`)
+    }, 1500)
+  }
+
+  function tryAgain() {
+    cancel()
+    setCurrentStep('describe')
+    setGeneratedSpec(null)
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      {currentStep === 'describe' && (
+        <div className="flex flex-col items-center text-center">
+          <div
+            className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+            }}
+          >
+            <Sparkles size={32} className="text-white" />
+          </div>
+
+          <h1
+            className="mb-3 font-display text-2xl font-bold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            What do you want to monitor?
+          </h1>
+          <p
+            className="mb-8 max-w-md text-sm"
+            style={{ color: 'var(--color-on-surface-variant)' }}
+          >
+            {selectedDatasource
+              ? `Describe what you'd like to observe on ${selectedDatasource.name}`
+              : "Describe what you'd like to observe and we'll generate a dashboard with relevant panels and queries."}
+          </p>
+
+          {loadingDatasources ? (
+            <div className="mb-4 w-full">
+              <ShimmerLoader height="36px" />
+            </div>
+          ) : datasources.length === 0 ? (
+            <div className="mb-4 w-full">
+              <div
+                className="rounded-lg px-4 py-3 text-sm"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  color: 'var(--color-on-surface-variant)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+              >
+                No datasources configured.{' '}
+                <Link
+                  to="/app/settings"
+                  className="underline"
+                  style={{ color: 'var(--color-primary)' }}
+                >
+                  Add one in Settings
+                </Link>
+              </div>
+            </div>
+          ) : datasources.length > 1 ? (
+            <select
+              value={selectedDatasourceId}
+              data-testid="gen-datasource-select"
+              aria-label="Select datasource"
+              className="mb-4 w-full rounded-lg px-4 text-sm focus:outline-none focus:ring-2"
+              style={{
+                height: '36px',
+                backgroundColor: 'var(--color-surface-container-low)',
+                color: 'var(--color-on-surface)',
+                border: '1px solid var(--color-outline-variant)',
+              }}
+              onChange={event => setSelectedDatasourceId(event.target.value)}
+            >
+              {datasources.map(ds => (
+                <option key={ds.id} value={ds.id}>
+                  {ds.name} ({ds.type})
+                </option>
+              ))}
+            </select>
+          ) : null}
+
+          {!loadingDatasources && providers.length === 0 && (
+            <div
+              className="mb-4 w-full rounded-lg px-4 py-3 text-sm"
+              data-testid="gen-no-provider-warning"
+              style={{
+                backgroundColor: 'var(--color-surface-container-high)',
+                color: 'var(--color-on-surface-variant)',
+                border: '1px solid var(--color-outline-variant)',
+              }}
+            >
+              No AI provider configured.{' '}
+              <Link
+                to="/app/settings"
+                className="underline"
+                style={{ color: 'var(--color-primary)' }}
+              >
+                Set one up in Settings
+              </Link>
+            </div>
+          )}
+
+          <input
+            data-testid="gen-describe-input"
+            type="text"
+            value={prompt}
+            placeholder="e.g., Monitor HTTP API performance and error rates..."
+            className="mb-4 w-full rounded-lg px-4 text-sm focus:outline-none focus:ring-2"
+            style={{
+              height: '36px',
+              backgroundColor: 'var(--color-surface-container-low)',
+              color: 'var(--color-on-surface)',
+              border: '1px solid var(--color-outline-variant)',
+            }}
+            onChange={event => setPrompt(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                void startGeneration()
+              }
+            }}
+          />
+
+          <div className="mb-8 flex flex-wrap justify-center gap-2">
+            {SUGGESTIONS.map(suggestion => (
+              <button
+                key={suggestion}
+                type="button"
+                data-testid="gen-suggestion-chip"
+                className="cursor-pointer rounded-full px-3 py-1.5 text-xs font-medium transition hover:opacity-80"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  color: 'var(--color-on-surface-variant)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+                onClick={() => setPrompt(suggestion)}
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            data-testid="gen-generate-btn"
+            className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg px-6 py-3 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+            }}
+            disabled={!canGenerate}
+            aria-disabled={!canGenerate}
+            onClick={() => void startGeneration()}
+          >
+            <Sparkles size={16} />
+            Generate Dashboard
+            <ArrowRight size={16} />
+          </button>
+        </div>
+      )}
+
+      {currentStep === 'generate' && (
+        <div className="flex flex-col items-center py-16 text-center">
+          <div
+            className="mb-6 flex h-16 w-16 animate-pulse items-center justify-center rounded-2xl"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+            }}
+          >
+            <Sparkles size={32} className="text-white" />
+          </div>
+
+          <h2
+            className="mb-4 font-display text-xl font-bold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            {selectedDatasource
+              ? `Analyzing ${selectedDatasource.name} and building panels...`
+              : 'Generating your dashboard...'}
+          </h2>
+          <p className="mb-6 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            &quot;{prompt}&quot;
+          </p>
+
+          {toolStatuses.length > 0 ? (
+            <div
+              aria-live="polite"
+              role="status"
+              className="mb-4 flex w-full max-w-sm flex-col gap-2"
+            >
+              {toolStatuses.map(ts => (
+                <div
+                  key={`${ts.name}-${ts.status}`}
+                  className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs"
+                  style={{
+                    backgroundColor: 'var(--color-surface-container-high)',
+                    color: 'var(--color-on-surface-variant)',
+                  }}
+                >
+                  {ts.status === 'running' ? (
+                    <Loader2 size={12} className="shrink-0 animate-spin" />
+                  ) : ts.status === 'complete' ? (
+                    <Check size={12} className="shrink-0" style={{ color: 'var(--color-secondary)' }} />
+                  ) : (
+                    <Wrench size={12} className="shrink-0" style={{ color: 'var(--color-error)' }} />
+                  )}
+                  <span>{toolStatusLabel(ts.name)}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex w-full max-w-sm flex-col gap-3">
+              <ShimmerLoader height="2rem" />
+              <ShimmerLoader height="2rem" width="80%" />
+              <ShimmerLoader height="2rem" width="60%" />
+            </div>
+          )}
+
+          {progressText && (
+            <p className="mt-4 max-w-sm text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+              {progressText}
+            </p>
+          )}
+
+          {genError && (
+            <div className="mt-6 flex flex-col items-center">
+              <AlertCircle size={32} style={{ color: 'var(--color-error)' }} />
+              <p className="mb-4 mt-3 text-sm" style={{ color: 'var(--color-error)' }}>
+                {genError}
+              </p>
+              <button
+                type="button"
+                data-testid="gen-try-again-btn"
+                className="inline-flex cursor-pointer items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition hover:opacity-80"
+                style={{
+                  color: 'var(--color-on-surface-variant)',
+                  border: '1px solid var(--color-outline-variant)',
+                  backgroundColor: 'transparent',
+                }}
+                onClick={tryAgain}
+              >
+                <RotateCcw size={14} />
+                Try Again
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {currentStep === 'review' && (
+        <div className="flex flex-col items-center">
+          <h2
+            className="mb-2 text-center font-display text-xl font-bold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            Review your dashboard
+          </h2>
+          <p
+            className="mb-6 text-center text-sm"
+            style={{ color: 'var(--color-on-surface-variant)' }}
+          >
+            We generated a dashboard based on your description. Review and save it.
+          </p>
+
+          <div className="w-full">
+            {generatedSpec && (
+              <DashboardSpecPreview spec={generatedSpec} onSaved={handleSpecSaved} />
+            )}
+          </div>
+
+          <button
+            type="button"
+            className="mt-4 inline-flex cursor-pointer items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition hover:opacity-80"
+            style={{
+              color: 'var(--color-on-surface-variant)',
+              border: '1px solid var(--color-outline-variant)',
+              backgroundColor: 'transparent',
+            }}
+            onClick={tryAgain}
+          >
+            <RotateCcw size={14} />
+            Start over
+          </button>
+        </div>
+      )}
+
+      {currentStep === 'create' && (
+        <div className="flex flex-col items-center py-16 text-center">
+          <div
+            className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
+            style={{ backgroundColor: 'var(--color-secondary)' }}
+          >
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="white"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="Success"
+            >
+              <title>Success</title>
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </div>
+
+          <h2
+            className="mb-2 font-display text-xl font-bold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            Dashboard created!
+          </h2>
+          <p className="text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            Redirecting you to your new dashboard...
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/DashboardGenPage.tsx
+++ b/frontend/src/pages/DashboardGenPage.tsx
@@ -1,12 +1,4 @@
-import {
-  AlertCircle,
-  ArrowRight,
-  Check,
-  Loader2,
-  RotateCcw,
-  Sparkles,
-  Wrench,
-} from 'lucide-react'
+import { AlertCircle, ArrowRight, Check, Loader2, RotateCcw, Sparkles, Wrench } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { listDataSources } from '@/api/datasources'
@@ -60,16 +52,22 @@ export function DashboardGenPage() {
   const [loadingDatasources, setLoadingDatasources] = useState(false)
 
   const selectedDatasource = useMemo(
-    () => datasources.find(ds => ds.id === selectedDatasourceId),
+    () => datasources.find((ds) => ds.id === selectedDatasourceId),
     [datasources, selectedDatasourceId],
   )
 
-  const { generate, toolStatuses, isGenerating, error: genError, progressText, cancel } =
-    useDashboardGeneration(
-      () => selectedDatasourceId,
-      () => currentOrg?.id ?? '',
-      () => selectedDatasource?.type ?? '',
-    )
+  const {
+    generate,
+    toolStatuses,
+    isGenerating,
+    error: genError,
+    progressText,
+    cancel,
+  } = useDashboardGeneration(
+    () => selectedDatasourceId,
+    () => currentOrg?.id ?? '',
+    () => selectedDatasource?.type ?? '',
+  )
 
   const canGenerate = Boolean(
     prompt.trim() && selectedDatasourceId && providers.length > 0 && !isGenerating,
@@ -78,6 +76,7 @@ export function DashboardGenPage() {
   useEffect(() => {
     const orgId = currentOrg?.id
     if (!orgId) return
+    const organizationId = orgId
 
     let cancelled = false
 
@@ -85,7 +84,7 @@ export function DashboardGenPage() {
       setLoadingDatasources(true)
       try {
         const [dsList] = await Promise.all([
-          listDataSources(orgId).catch(() => [] as DataSource[]),
+          listDataSources(organizationId).catch(() => [] as DataSource[]),
           fetchProviders(),
           fetchModels(selectedProviderId || undefined),
         ])
@@ -96,11 +95,11 @@ export function DashboardGenPage() {
         if (dsList.length === 1) {
           setSelectedDatasourceId(dsList[0]!.id)
         } else if (dsList.length > 1) {
-          const saved = localStorage.getItem(`ace:lastDatasource:${orgId}`)
-          if (saved && dsList.find(ds => ds.id === saved)) {
+          const saved = localStorage.getItem(`ace:lastDatasource:${organizationId}`)
+          if (saved && dsList.find((ds) => ds.id === saved)) {
             setSelectedDatasourceId(saved)
           } else {
-            const metricsDs = dsList.find(ds =>
+            const metricsDs = dsList.find((ds) =>
               ['victoriametrics', 'prometheus'].includes(ds.type),
             )
             setSelectedDatasourceId(metricsDs?.id ?? dsList[0]!.id)
@@ -184,10 +183,7 @@ export function DashboardGenPage() {
           >
             What do you want to monitor?
           </h1>
-          <p
-            className="mb-8 max-w-md text-sm"
-            style={{ color: 'var(--color-on-surface-variant)' }}
-          >
+          <p className="mb-8 max-w-md text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
             {selectedDatasource
               ? `Describe what you'd like to observe on ${selectedDatasource.name}`
               : "Describe what you'd like to observe and we'll generate a dashboard with relevant panels and queries."}
@@ -229,9 +225,9 @@ export function DashboardGenPage() {
                 color: 'var(--color-on-surface)',
                 border: '1px solid var(--color-outline-variant)',
               }}
-              onChange={event => setSelectedDatasourceId(event.target.value)}
+              onChange={(event) => setSelectedDatasourceId(event.target.value)}
             >
-              {datasources.map(ds => (
+              {datasources.map((ds) => (
                 <option key={ds.id} value={ds.id}>
                   {ds.name} ({ds.type})
                 </option>
@@ -272,8 +268,8 @@ export function DashboardGenPage() {
               color: 'var(--color-on-surface)',
               border: '1px solid var(--color-outline-variant)',
             }}
-            onChange={event => setPrompt(event.target.value)}
-            onKeyDown={event => {
+            onChange={(event) => setPrompt(event.target.value)}
+            onKeyDown={(event) => {
               if (event.key === 'Enter') {
                 void startGeneration()
               }
@@ -281,7 +277,7 @@ export function DashboardGenPage() {
           />
 
           <div className="mb-8 flex flex-wrap justify-center gap-2">
-            {SUGGESTIONS.map(suggestion => (
+            {SUGGESTIONS.map((suggestion) => (
               <button
                 key={suggestion}
                 type="button"
@@ -346,7 +342,7 @@ export function DashboardGenPage() {
               role="status"
               className="mb-4 flex w-full max-w-sm flex-col gap-2"
             >
-              {toolStatuses.map(ts => (
+              {toolStatuses.map((ts) => (
                 <div
                   key={`${ts.name}-${ts.status}`}
                   className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs"
@@ -358,9 +354,17 @@ export function DashboardGenPage() {
                   {ts.status === 'running' ? (
                     <Loader2 size={12} className="shrink-0 animate-spin" />
                   ) : ts.status === 'complete' ? (
-                    <Check size={12} className="shrink-0" style={{ color: 'var(--color-secondary)' }} />
+                    <Check
+                      size={12}
+                      className="shrink-0"
+                      style={{ color: 'var(--color-secondary)' }}
+                    />
                   ) : (
-                    <Wrench size={12} className="shrink-0" style={{ color: 'var(--color-error)' }} />
+                    <Wrench
+                      size={12}
+                      className="shrink-0"
+                      style={{ color: 'var(--color-error)' }}
+                    />
                   )}
                   <span>{toolStatusLabel(ts.name)}</span>
                 </div>
@@ -375,7 +379,10 @@ export function DashboardGenPage() {
           )}
 
           {progressText && (
-            <p className="mt-4 max-w-sm text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            <p
+              className="mt-4 max-w-sm text-sm"
+              style={{ color: 'var(--color-on-surface-variant)' }}
+            >
               {progressText}
             </p>
           )}

--- a/frontend/src/pages/DashboardSettingsPage.spec.tsx
+++ b/frontend/src/pages/DashboardSettingsPage.spec.tsx
@@ -38,11 +38,10 @@ const mockDashboard = {
   updated_at: '2026-02-09T00:00:00Z',
 }
 
-const initialYaml = `schema_version: 1
-dashboard:
-  title: Production Overview
-  description: Main prod metrics
-  panels: []
+const initialYaml = `version: 2
+title: Production Overview
+description: Main prod metrics
+panels: []
 `
 
 function renderSettings(section = 'general') {
@@ -85,8 +84,9 @@ describe('DashboardSettingsPage', () => {
       format: 'yaml',
       content: initialYaml,
       document: {
-        schema_version: 1,
-        dashboard: { title: 'Production Overview', panels: [] },
+        version: 2,
+        title: 'Production Overview',
+        panels: [],
       },
       warnings: [],
     })
@@ -139,6 +139,17 @@ describe('DashboardSettingsPage', () => {
     expect(screen.queryByTestId('settings-section-permissions')).toBeNull()
   })
 
+  it('hides permissions section for editors (admin-only API)', async () => {
+    mockCurrentOrg.role = 'editor'
+    const router = renderSettings('permissions')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/app/dashboards/dashboard-1/settings/general')
+    })
+
+    expect(screen.queryByTestId('settings-section-permissions')).toBeNull()
+  })
+
   it('saves general settings and persists dashboard view preferences', async () => {
     const user = userEvent.setup()
     renderSettings('general')
@@ -174,19 +185,24 @@ describe('DashboardSettingsPage', () => {
     })
   })
 
-  it('saves YAML editor content', async () => {
+  it('saves YAML editor content via full-body replace', async () => {
     const user = userEvent.setup()
+    vi.spyOn(dashboardApi, 'replaceDashboardYaml').mockResolvedValue({
+      ...mockDashboard,
+      title: 'YAML Updated',
+      description: 'From YAML',
+    })
+
     renderSettings('yaml')
 
     await waitFor(() => {
       expect(screen.getByTestId('yaml-editor-input')).toBeTruthy()
     })
 
-    const nextYaml = `schema_version: 1
-dashboard:
-  title: YAML Updated
-  description: From YAML
-  panels: []
+    const nextYaml = `version: 2
+title: YAML Updated
+description: From YAML
+panels: []
 `
     const yamlInput = screen.getByTestId('yaml-editor-input')
     fireEvent.change(yamlInput, { target: { value: nextYaml } })
@@ -194,13 +210,35 @@ dashboard:
     await user.click(screen.getByTestId('save-dashboard-yaml'))
 
     await waitFor(() => {
-      expect(dashboardApi.updateDashboard).toHaveBeenCalledWith('dashboard-1', {
-        title: 'YAML Updated',
-        description: 'From YAML',
-      })
+      expect(dashboardApi.replaceDashboardYaml).toHaveBeenCalledWith('dashboard-1', nextYaml)
     })
+    expect(dashboardApi.updateDashboard).not.toHaveBeenCalled()
 
     expect(await screen.findByText('Dashboard YAML saved')).toBeTruthy()
+  })
+
+  it('rejects nested v1 YAML schema on save', async () => {
+    const user = userEvent.setup()
+    const replaceSpy = vi.spyOn(dashboardApi, 'replaceDashboardYaml')
+    renderSettings('yaml')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('yaml-editor-input')).toBeTruthy()
+    })
+
+    const nestedV1 = `schema_version: 1
+dashboard:
+  title: Nested
+  panels: []
+`
+    fireEvent.change(screen.getByTestId('yaml-editor-input'), {
+      target: { value: nestedV1 },
+    })
+
+    await user.click(screen.getByTestId('save-dashboard-yaml'))
+
+    expect(await screen.findByTestId('yaml-validation-error')).toBeTruthy()
+    expect(replaceSpy).not.toHaveBeenCalled()
   })
 
   it('renders dashboard permissions editor inline on permissions section', async () => {

--- a/frontend/src/pages/DashboardSettingsPage.spec.tsx
+++ b/frontend/src/pages/DashboardSettingsPage.spec.tsx
@@ -1,0 +1,213 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as converterApi from '@/api/converter'
+import * as dashboardApi from '@/api/dashboards'
+import { DashboardSettingsPage } from '@/pages/DashboardSettingsPage'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+import type { MembershipRole } from '@/types/organization'
+
+const mockCurrentOrg = {
+  id: 'org-1',
+  name: 'Acme',
+  slug: 'acme',
+  role: 'admin' as MembershipRole,
+  created_at: '2026-02-08T00:00:00Z',
+  updated_at: '2026-02-08T00:00:00Z',
+}
+
+vi.mock('@/hooks/useOrganization', () => ({
+  useOrganization: () => ({
+    currentOrgId: mockCurrentOrg.id,
+    currentOrg: mockCurrentOrg,
+  }),
+}))
+
+vi.mock('@/components/DashboardPermissionsEditor', () => ({
+  DashboardPermissionsEditor: () => <div data-testid="dashboard-permissions-editor" />,
+}))
+
+const mockDashboard = {
+  id: 'dashboard-1',
+  title: 'Production Overview',
+  description: 'Main prod metrics',
+  organization_id: 'org-1',
+  created_at: '2026-02-09T00:00:00Z',
+  updated_at: '2026-02-09T00:00:00Z',
+}
+
+const initialYaml = `schema_version: 1
+dashboard:
+  title: Production Overview
+  description: Main prod metrics
+  panels: []
+`
+
+function renderSettings(section = 'general') {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/app/dashboards/:id/settings/:section',
+        element: <DashboardSettingsPage />,
+      },
+      {
+        path: '/app/dashboards/:id',
+        element: <div>Dashboard detail</div>,
+      },
+    ],
+    { initialEntries: [`/app/dashboards/dashboard-1/settings/${section}`] },
+  )
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  return router
+}
+
+describe('DashboardSettingsPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockCurrentOrg.role = 'admin'
+    localStorage.removeItem('dashboard_view_settings')
+
+    vi.spyOn(dashboardApi, 'getDashboard').mockResolvedValue({ ...mockDashboard })
+    vi.spyOn(dashboardApi, 'updateDashboard').mockResolvedValue({ ...mockDashboard })
+    vi.spyOn(dashboardApi, 'exportDashboardYaml').mockResolvedValue(
+      new Blob([initialYaml], { type: 'application/x-yaml' }),
+    )
+    vi.spyOn(converterApi, 'convertGrafanaDashboard').mockResolvedValue({
+      format: 'yaml',
+      content: initialYaml,
+      document: {
+        schema_version: 1,
+        dashboard: { title: 'Production Overview', panels: [] },
+      },
+      warnings: [],
+    })
+  })
+
+  it('renders general section with secondary sidebar', async () => {
+    renderSettings('general')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-settings-sidebar')).toBeTruthy()
+    })
+
+    expect(screen.getByText('Dashboard Settings')).toBeTruthy()
+    expect(screen.getByTestId('settings-section-general').className).toContain(
+      'text-[var(--color-primary)]',
+    )
+  })
+
+  it('navigates sections through sidebar links', async () => {
+    const user = userEvent.setup()
+    const router = renderSettings('general')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('settings-section-yaml')).toBeTruthy()
+    })
+
+    await user.click(screen.getByTestId('settings-section-yaml'))
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/app/dashboards/dashboard-1/settings/yaml')
+    })
+  })
+
+  it('redirects invalid section routes to general', async () => {
+    const router = renderSettings('invalid')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/app/dashboards/dashboard-1/settings/general')
+    })
+  })
+
+  it('hides permissions section for viewers and redirects direct permissions route', async () => {
+    mockCurrentOrg.role = 'viewer'
+    const router = renderSettings('permissions')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/app/dashboards/dashboard-1/settings/general')
+    })
+
+    expect(screen.queryByTestId('settings-section-permissions')).toBeNull()
+  })
+
+  it('saves general settings and persists dashboard view preferences', async () => {
+    const user = userEvent.setup()
+    renderSettings('general')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-name-input')).toBeTruthy()
+    })
+
+    const nameInput = screen.getByTestId('dashboard-name-input')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Updated Overview')
+
+    await user.selectOptions(screen.getByTestId('dashboard-refresh-select'), '30s')
+
+    const variablesInput = screen.getByLabelText(/Variable names/i)
+    await user.clear(variablesInput)
+    await user.type(variablesInput, 'env,cluster')
+
+    await user.click(screen.getByTestId('save-dashboard-settings'))
+
+    await waitFor(() => {
+      expect(dashboardApi.updateDashboard).toHaveBeenCalledWith('dashboard-1', {
+        title: 'Updated Overview',
+        description: 'Main prod metrics',
+      })
+    })
+
+    const storedSettings = JSON.parse(localStorage.getItem('dashboard_view_settings') || '{}')
+    expect(storedSettings['dashboard-1']).toEqual({
+      timeRangePreset: '1h',
+      refreshInterval: '30s',
+      variables: ['env', 'cluster'],
+    })
+  })
+
+  it('saves YAML editor content', async () => {
+    const user = userEvent.setup()
+    renderSettings('yaml')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('yaml-editor-input')).toBeTruthy()
+    })
+
+    const nextYaml = `schema_version: 1
+dashboard:
+  title: YAML Updated
+  description: From YAML
+  panels: []
+`
+    const yamlInput = screen.getByTestId('yaml-editor-input')
+    fireEvent.change(yamlInput, { target: { value: nextYaml } })
+
+    await user.click(screen.getByTestId('save-dashboard-yaml'))
+
+    await waitFor(() => {
+      expect(dashboardApi.updateDashboard).toHaveBeenCalledWith('dashboard-1', {
+        title: 'YAML Updated',
+        description: 'From YAML',
+      })
+    })
+
+    expect(await screen.findByText('Dashboard YAML saved')).toBeTruthy()
+  })
+
+  it('renders dashboard permissions editor inline on permissions section', async () => {
+    renderSettings('permissions')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-permissions-editor')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/pages/DashboardSettingsPage.spec.tsx
+++ b/frontend/src/pages/DashboardSettingsPage.spec.tsx
@@ -177,8 +177,10 @@ describe('DashboardSettingsPage', () => {
       })
     })
 
-    const storedSettings = JSON.parse(localStorage.getItem('dashboard_view_settings') || '{}')
-    expect(storedSettings['dashboard-1']).toEqual({
+    const storedEntries = JSON.parse(
+      localStorage.getItem('dashboard_view_settings') || '[]',
+    ) as Array<[string, { timeRangePreset: string; refreshInterval: string; variables: string[] }]>
+    expect(Object.fromEntries(storedEntries)['dashboard-1']).toEqual({
       timeRangePreset: '1h',
       refreshInterval: '30s',
       variables: ['env', 'cluster'],

--- a/frontend/src/pages/DashboardSettingsPage.tsx
+++ b/frontend/src/pages/DashboardSettingsPage.tsx
@@ -2,10 +2,19 @@ import { ArrowLeft, Download, Settings } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { convertGrafanaDashboard } from '@/api/converter'
-import { exportDashboardYaml, getDashboard, updateDashboard } from '@/api/dashboards'
+import {
+  exportDashboardYaml,
+  getDashboard,
+  replaceDashboardYaml,
+  updateDashboard,
+} from '@/api/dashboards'
 import { DashboardPermissionsEditor } from '@/components/DashboardPermissionsEditor'
 import { useOrganization } from '@/hooks/useOrganization'
 import type { Dashboard } from '@/types/dashboard'
+import {
+  extractYamlTitleAndDescription,
+  validateDashboardYaml,
+} from '@/utils/dashboardYaml'
 
 interface DashboardViewSettings {
   timeRangePreset: string
@@ -36,16 +45,6 @@ const REFRESH_OPTIONS = [
   { label: '5m', value: '5m' },
 ]
 
-const TIME_RANGE_LOOKUP: Record<string, string> = {
-  'now-5m|now': '5m',
-  'now-15m|now': '15m',
-  'now-30m|now': '30m',
-  'now-1h|now': '1h',
-  'now-6h|now': '6h',
-  'now-24h|now': '24h',
-  'now-7d|now': '7d',
-}
-
 const ALL_SECTIONS: Array<{ key: SettingsSection; label: string }> = [
   { key: 'general', label: 'General' },
   { key: 'yaml', label: 'YAML Editor' },
@@ -71,104 +70,6 @@ function readStoredDashboardSettings(): Record<string, DashboardViewSettings> {
     return JSON.parse(rawSettings) as Record<string, DashboardViewSettings>
   } catch {
     return {}
-  }
-}
-
-function normalizeYamlValue(value: string): string {
-  const trimmed = value.trim()
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1).trim()
-  }
-  return trimmed
-}
-
-function extractDashboardSection(rawYaml: string): string {
-  const dashboardSectionMatch = rawYaml.match(/(?:^|\n)dashboard:\s*\n([\s\S]*)/)
-  return dashboardSectionMatch?.[1] ?? ''
-}
-
-function validateYamlContent(rawYaml: string): string | null {
-  if (!rawYaml.trim()) {
-    return 'YAML content is required'
-  }
-
-  const schemaVersionMatch = rawYaml.match(/(?:^|\n)schema_version:\s*(\d+)/)
-  if (!schemaVersionMatch) {
-    return 'Missing schema_version'
-  }
-  if (schemaVersionMatch[1] !== '1') {
-    return `Unsupported schema_version ${schemaVersionMatch[1]}`
-  }
-
-  const dashboardSection = extractDashboardSection(rawYaml)
-  if (!dashboardSection) {
-    return 'Missing dashboard section'
-  }
-
-  const titleMatch = dashboardSection.match(/(?:^|\n)\s{2}title:\s*(.+)/)
-  if (!titleMatch || !normalizeYamlValue(titleMatch[1] ?? '')) {
-    return 'Missing dashboard title'
-  }
-
-  const panelsMatch = dashboardSection.match(/(?:^|\n)\s{2}panels:\s*(?:\n|\[])/)
-  if (!panelsMatch) {
-    return 'Missing dashboard panels section'
-  }
-
-  return null
-}
-
-function extractVariables(rawYaml: string): string[] {
-  const dashboardSection = extractDashboardSection(rawYaml)
-  if (!dashboardSection) return []
-
-  const variablesSectionMatch = dashboardSection.match(
-    /(?:^|\n)\s{2}variables:\s*\n([\s\S]*?)(?=\n\s{2}[a-zA-Z_][\w-]*:\s*|\s*$)/,
-  )
-
-  const section = variablesSectionMatch?.[1] ?? ''
-  return [...section.matchAll(/(?:^|\n)\s{4}-\s*name:\s*(.+)/g)]
-    .map(match => normalizeYamlValue(match[1] ?? ''))
-    .filter(name => name.length > 0)
-}
-
-function extractTimeRangePreset(rawYaml: string, fallback: string): string {
-  const dashboardSection = extractDashboardSection(rawYaml)
-  if (!dashboardSection) return fallback
-
-  const fromMatch = dashboardSection.match(/(?:^|\n)\s{4}from:\s*(.+)/)
-  const toMatch = dashboardSection.match(/(?:^|\n)\s{4}to:\s*(.+)/)
-
-  const fromValue = normalizeYamlValue(fromMatch?.[1] ?? '')
-  const toValue = normalizeYamlValue(toMatch?.[1] ?? '')
-  if (!fromValue || !toValue) return fallback
-
-  return TIME_RANGE_LOOKUP[`${fromValue}|${toValue}`] ?? fallback
-}
-
-function extractRefreshInterval(rawYaml: string, fallback: string): string {
-  const dashboardSection = extractDashboardSection(rawYaml)
-  if (!dashboardSection) return fallback
-
-  const refreshMatch = dashboardSection.match(/(?:^|\n)\s{2}refresh_interval:\s*(.+)/)
-  const value = normalizeYamlValue(refreshMatch?.[1] ?? '')
-  return REFRESH_OPTIONS.some(option => option.value === value) ? value : fallback
-}
-
-function extractTitleAndDescription(
-  rawYaml: string,
-  fallbackTitle: string,
-): { title: string; description: string } {
-  const dashboardSection = extractDashboardSection(rawYaml)
-  const titleMatch = dashboardSection.match(/(?:^|\n)\s{2}title:\s*(.+)/)
-  const descriptionMatch = dashboardSection.match(/(?:^|\n)\s{2}description:\s*(.+)/)
-
-  return {
-    title: normalizeYamlValue(titleMatch?.[1] ?? fallbackTitle),
-    description: normalizeYamlValue(descriptionMatch?.[1] ?? ''),
   }
 }
 
@@ -215,9 +116,8 @@ export function DashboardSettingsPage() {
   const [grafanaWarnings, setGrafanaWarnings] = useState<string[]>([])
   const [showGrafanaReplace, setShowGrafanaReplace] = useState(false)
 
-  const canManagePermissions = Boolean(
-    currentOrg && (currentOrg.role === 'admin' || currentOrg.role === 'editor'),
-  )
+  // Permissions API requires org admin (see backend permissions.go).
+  const canManagePermissions = Boolean(currentOrg && currentOrg.role === 'admin')
   const canEdit = Boolean(
     currentOrg && (currentOrg.role === 'admin' || currentOrg.role === 'editor'),
   )
@@ -407,11 +307,11 @@ export function DashboardSettingsPage() {
   async function saveYamlSettings() {
     if (!dashboard || !canEdit || isYamlSaving) return
 
-    const validationError = validateYamlContent(yamlContent)
+    const validationError = validateDashboardYaml(yamlContent)
     setYamlValidationError(validationError)
     if (validationError) return
 
-    const { title: nextTitle, description: nextDescription } = extractTitleAndDescription(
+    const { title: nextTitle, description: nextDescription } = extractYamlTitleAndDescription(
       yamlContent,
       dashboard.title,
     )
@@ -424,28 +324,20 @@ export function DashboardSettingsPage() {
     resetFormState()
 
     try {
-      await updateDashboard(dashboard.id, {
-        title: nextTitle,
-        description: nextDescription || undefined,
-      })
+      // Persist full dashboard body (title/description/panels) via replace-import.
+      const updated = await replaceDashboardYaml(dashboard.id, yamlContent)
 
-      const yamlSettings = {
-        timeRangePreset: extractTimeRangePreset(yamlContent, timeRangePreset),
-        refreshInterval: extractRefreshInterval(yamlContent, refreshInterval),
-        variables: extractVariables(yamlContent),
-      }
+      const savedTitle = updated.title || nextTitle
+      const savedDescription = updated.description ?? nextDescription
 
       setDashboard({
         ...dashboard,
-        title: nextTitle,
-        description: nextDescription || undefined,
+        ...updated,
+        title: savedTitle,
+        description: savedDescription || undefined,
       })
-      setTitle(nextTitle)
-      setDescription(nextDescription)
-      setTimeRangePreset(yamlSettings.timeRangePreset)
-      setRefreshInterval(yamlSettings.refreshInterval)
-      setVariablesInput(yamlSettings.variables.join(', '))
-      persistDashboardViewSettings(yamlSettings)
+      setTitle(savedTitle)
+      setDescription(savedDescription)
 
       setOriginalYamlContent(yamlContent)
       setYamlValidationError(null)
@@ -468,7 +360,7 @@ export function DashboardSettingsPage() {
       const response = await convertGrafanaDashboard(grafanaSource, 'yaml')
       setYamlContent(response.content)
       setGrafanaWarnings(response.warnings)
-      setYamlValidationError(validateYamlContent(response.content))
+      setYamlValidationError(validateDashboardYaml(response.content))
     } catch (cause) {
       setActionError(
         cause instanceof Error ? cause.message : 'Failed to convert Grafana dashboard',
@@ -734,7 +626,7 @@ export function DashboardSettingsPage() {
                       onChange={event => {
                         const next = event.target.value
                         setYamlContent(next)
-                        setYamlValidationError(validateYamlContent(next))
+                        setYamlValidationError(validateDashboardYaml(next))
                       }}
                     />
                   </div>

--- a/frontend/src/pages/DashboardSettingsPage.tsx
+++ b/frontend/src/pages/DashboardSettingsPage.tsx
@@ -65,26 +65,54 @@ function isDashboardSettingsKey(value: string): boolean {
   return value.length > 0 && !FORBIDDEN_SETTINGS_KEYS.has(value)
 }
 
-function readStoredDashboardSettings(): Record<string, DashboardViewSettings> {
+function isDashboardViewSettings(value: unknown): value is DashboardViewSettings {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const candidate = value as Partial<DashboardViewSettings>
+  return (
+    typeof candidate.timeRangePreset === 'string' &&
+    typeof candidate.refreshInterval === 'string' &&
+    Array.isArray(candidate.variables)
+  )
+}
+
+function readStoredDashboardSettings(): Map<string, DashboardViewSettings> {
+  const settings = new Map<string, DashboardViewSettings>()
   const rawSettings = localStorage.getItem(DASHBOARD_VIEW_SETTINGS_KEY)
-  if (!rawSettings) {
-    return Object.create(null) as Record<string, DashboardViewSettings>
-  }
+  if (!rawSettings) return settings
 
   try {
     const parsed = JSON.parse(rawSettings) as unknown
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return Object.create(null) as Record<string, DashboardViewSettings>
+
+    // Preferred format: Map entries array — avoids dynamic object property writes.
+    if (Array.isArray(parsed)) {
+      for (const entry of parsed) {
+        if (!Array.isArray(entry) || entry.length < 2) continue
+        const [key, value] = entry
+        if (typeof key !== 'string' || !isDashboardSettingsKey(key)) continue
+        if (!isDashboardViewSettings(value)) continue
+        settings.set(key, {
+          timeRangePreset: value.timeRangePreset,
+          refreshInterval: value.refreshInterval,
+          variables: value.variables.filter((item): item is string => typeof item === 'string'),
+        })
+      }
+      return settings
     }
 
-    const sanitized = Object.create(null) as Record<string, DashboardViewSettings>
+    // Legacy object format from earlier builds.
+    if (!parsed || typeof parsed !== 'object') return settings
+
     for (const [key, value] of Object.entries(parsed)) {
-      if (!isDashboardSettingsKey(key) || !value || typeof value !== 'object') continue
-      sanitized[key] = value as DashboardViewSettings
+      if (!isDashboardSettingsKey(key) || !isDashboardViewSettings(value)) continue
+      settings.set(key, {
+        timeRangePreset: value.timeRangePreset,
+        refreshInterval: value.refreshInterval,
+        variables: value.variables.filter((item): item is string => typeof item === 'string'),
+      })
     }
-    return sanitized
+    return settings
   } catch {
-    return Object.create(null) as Record<string, DashboardViewSettings>
+    return settings
   }
 }
 
@@ -205,7 +233,7 @@ export function DashboardSettingsPage() {
 
   const applyStoredDashboardSettings = useCallback((id: string) => {
     const allSettings = readStoredDashboardSettings()
-    const storedSettings = allSettings[id]
+    const storedSettings = allSettings.get(id)
     setTimeRangePreset(storedSettings?.timeRangePreset || '1h')
     setRefreshInterval(storedSettings?.refreshInterval || 'off')
     setVariablesInput((storedSettings?.variables || []).join(', '))
@@ -215,13 +243,12 @@ export function DashboardSettingsPage() {
     if (!isDashboardSettingsKey(dashboardId)) return
 
     const allSettings = readStoredDashboardSettings()
-    const nextSettings = Object.create(null) as Record<string, DashboardViewSettings>
-    for (const [key, value] of Object.entries(allSettings)) {
-      if (!isDashboardSettingsKey(key)) continue
-      nextSettings[key] = value
-    }
-    nextSettings[dashboardId] = settings
-    localStorage.setItem(DASHBOARD_VIEW_SETTINGS_KEY, JSON.stringify(nextSettings))
+    allSettings.set(dashboardId, settings)
+    // Persist as entry tuples so we never write user-controlled object keys.
+    localStorage.setItem(
+      DASHBOARD_VIEW_SETTINGS_KEY,
+      JSON.stringify(Array.from(allSettings.entries())),
+    )
   }
 
   function resetFormState() {

--- a/frontend/src/pages/DashboardSettingsPage.tsx
+++ b/frontend/src/pages/DashboardSettingsPage.tsx
@@ -1,0 +1,871 @@
+import { ArrowLeft, Download, Settings } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { convertGrafanaDashboard } from '@/api/converter'
+import { exportDashboardYaml, getDashboard, updateDashboard } from '@/api/dashboards'
+import { DashboardPermissionsEditor } from '@/components/DashboardPermissionsEditor'
+import { useOrganization } from '@/hooks/useOrganization'
+import type { Dashboard } from '@/types/dashboard'
+
+interface DashboardViewSettings {
+  timeRangePreset: string
+  refreshInterval: string
+  variables: string[]
+}
+
+type SettingsSection = 'general' | 'yaml' | 'permissions'
+
+const DASHBOARD_VIEW_SETTINGS_KEY = 'dashboard_view_settings'
+
+const TIME_RANGE_OPTIONS = [
+  { label: 'Last 5 minutes', value: '5m' },
+  { label: 'Last 15 minutes', value: '15m' },
+  { label: 'Last 30 minutes', value: '30m' },
+  { label: 'Last 1 hour', value: '1h' },
+  { label: 'Last 6 hours', value: '6h' },
+  { label: 'Last 24 hours', value: '24h' },
+  { label: 'Last 7 days', value: '7d' },
+]
+
+const REFRESH_OPTIONS = [
+  { label: 'Off', value: 'off' },
+  { label: '5s', value: '5s' },
+  { label: '15s', value: '15s' },
+  { label: '30s', value: '30s' },
+  { label: '1m', value: '1m' },
+  { label: '5m', value: '5m' },
+]
+
+const TIME_RANGE_LOOKUP: Record<string, string> = {
+  'now-5m|now': '5m',
+  'now-15m|now': '15m',
+  'now-30m|now': '30m',
+  'now-1h|now': '1h',
+  'now-6h|now': '6h',
+  'now-24h|now': '24h',
+  'now-7d|now': '7d',
+}
+
+const ALL_SECTIONS: Array<{ key: SettingsSection; label: string }> = [
+  { key: 'general', label: 'General' },
+  { key: 'yaml', label: 'YAML Editor' },
+  { key: 'permissions', label: 'Permissions' },
+]
+
+function isSettingsSection(value: string | undefined): value is SettingsSection {
+  return value === 'general' || value === 'yaml' || value === 'permissions'
+}
+
+function dashboardLoadErrorMessage(cause: unknown): string {
+  if (cause instanceof Error && cause.message === 'Not a member of this organization') {
+    return 'You do not have permission to view this dashboard'
+  }
+  return 'Dashboard not found'
+}
+
+function readStoredDashboardSettings(): Record<string, DashboardViewSettings> {
+  const rawSettings = localStorage.getItem(DASHBOARD_VIEW_SETTINGS_KEY)
+  if (!rawSettings) return {}
+
+  try {
+    return JSON.parse(rawSettings) as Record<string, DashboardViewSettings>
+  } catch {
+    return {}
+  }
+}
+
+function normalizeYamlValue(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+function extractDashboardSection(rawYaml: string): string {
+  const dashboardSectionMatch = rawYaml.match(/(?:^|\n)dashboard:\s*\n([\s\S]*)/)
+  return dashboardSectionMatch?.[1] ?? ''
+}
+
+function validateYamlContent(rawYaml: string): string | null {
+  if (!rawYaml.trim()) {
+    return 'YAML content is required'
+  }
+
+  const schemaVersionMatch = rawYaml.match(/(?:^|\n)schema_version:\s*(\d+)/)
+  if (!schemaVersionMatch) {
+    return 'Missing schema_version'
+  }
+  if (schemaVersionMatch[1] !== '1') {
+    return `Unsupported schema_version ${schemaVersionMatch[1]}`
+  }
+
+  const dashboardSection = extractDashboardSection(rawYaml)
+  if (!dashboardSection) {
+    return 'Missing dashboard section'
+  }
+
+  const titleMatch = dashboardSection.match(/(?:^|\n)\s{2}title:\s*(.+)/)
+  if (!titleMatch || !normalizeYamlValue(titleMatch[1] ?? '')) {
+    return 'Missing dashboard title'
+  }
+
+  const panelsMatch = dashboardSection.match(/(?:^|\n)\s{2}panels:\s*(?:\n|\[])/)
+  if (!panelsMatch) {
+    return 'Missing dashboard panels section'
+  }
+
+  return null
+}
+
+function extractVariables(rawYaml: string): string[] {
+  const dashboardSection = extractDashboardSection(rawYaml)
+  if (!dashboardSection) return []
+
+  const variablesSectionMatch = dashboardSection.match(
+    /(?:^|\n)\s{2}variables:\s*\n([\s\S]*?)(?=\n\s{2}[a-zA-Z_][\w-]*:\s*|\s*$)/,
+  )
+
+  const section = variablesSectionMatch?.[1] ?? ''
+  return [...section.matchAll(/(?:^|\n)\s{4}-\s*name:\s*(.+)/g)]
+    .map(match => normalizeYamlValue(match[1] ?? ''))
+    .filter(name => name.length > 0)
+}
+
+function extractTimeRangePreset(rawYaml: string, fallback: string): string {
+  const dashboardSection = extractDashboardSection(rawYaml)
+  if (!dashboardSection) return fallback
+
+  const fromMatch = dashboardSection.match(/(?:^|\n)\s{4}from:\s*(.+)/)
+  const toMatch = dashboardSection.match(/(?:^|\n)\s{4}to:\s*(.+)/)
+
+  const fromValue = normalizeYamlValue(fromMatch?.[1] ?? '')
+  const toValue = normalizeYamlValue(toMatch?.[1] ?? '')
+  if (!fromValue || !toValue) return fallback
+
+  return TIME_RANGE_LOOKUP[`${fromValue}|${toValue}`] ?? fallback
+}
+
+function extractRefreshInterval(rawYaml: string, fallback: string): string {
+  const dashboardSection = extractDashboardSection(rawYaml)
+  if (!dashboardSection) return fallback
+
+  const refreshMatch = dashboardSection.match(/(?:^|\n)\s{2}refresh_interval:\s*(.+)/)
+  const value = normalizeYamlValue(refreshMatch?.[1] ?? '')
+  return REFRESH_OPTIONS.some(option => option.value === value) ? value : fallback
+}
+
+function extractTitleAndDescription(
+  rawYaml: string,
+  fallbackTitle: string,
+): { title: string; description: string } {
+  const dashboardSection = extractDashboardSection(rawYaml)
+  const titleMatch = dashboardSection.match(/(?:^|\n)\s{2}title:\s*(.+)/)
+  const descriptionMatch = dashboardSection.match(/(?:^|\n)\s{2}description:\s*(.+)/)
+
+  return {
+    title: normalizeYamlValue(titleMatch?.[1] ?? fallbackTitle),
+    description: normalizeYamlValue(descriptionMatch?.[1] ?? ''),
+  }
+}
+
+function fileNameFromTitle(titleValue: string): string {
+  const normalized = titleValue
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return `${normalized || 'dashboard'}.yaml`
+}
+
+export function DashboardSettingsPage() {
+  const navigate = useNavigate()
+  const { id: dashboardId = '', section: sectionParam } = useParams<{
+    id: string
+    section?: string
+  }>()
+  const { currentOrg, currentOrgId } = useOrganization()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [dashboard, setDashboard] = useState<Dashboard | null>(null)
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [timeRangePreset, setTimeRangePreset] = useState('1h')
+  const [refreshInterval, setRefreshInterval] = useState('off')
+  const [variablesInput, setVariablesInput] = useState('')
+
+  const [isSaving, setIsSaving] = useState(false)
+  const [isYamlSaving, setIsYamlSaving] = useState(false)
+  const [isYamlLoading, setIsYamlLoading] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+  const [isConvertingGrafana, setIsConvertingGrafana] = useState(false)
+
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [yamlValidationError, setYamlValidationError] = useState<string | null>(null)
+  const [yamlContent, setYamlContent] = useState('')
+  const [originalYamlContent, setOriginalYamlContent] = useState('')
+  const [grafanaSource, setGrafanaSource] = useState('')
+  const [grafanaWarnings, setGrafanaWarnings] = useState<string[]>([])
+  const [showGrafanaReplace, setShowGrafanaReplace] = useState(false)
+
+  const canManagePermissions = Boolean(
+    currentOrg && (currentOrg.role === 'admin' || currentOrg.role === 'editor'),
+  )
+  const canEdit = Boolean(
+    currentOrg && (currentOrg.role === 'admin' || currentOrg.role === 'editor'),
+  )
+  const permissionsOrgId = currentOrgId || dashboard?.organization_id || null
+
+  const settingsSections = useMemo(() => {
+    if (canManagePermissions) return ALL_SECTIONS
+    return ALL_SECTIONS.filter(section => section.key !== 'permissions')
+  }, [canManagePermissions])
+
+  const isSectionAllowed = useCallback(
+    (value: string | undefined): value is SettingsSection => {
+      if (!isSettingsSection(value)) return false
+      if (value === 'permissions' && currentOrg && !canManagePermissions) return false
+      return true
+    },
+    [canManagePermissions, currentOrg],
+  )
+
+  const activeSection: SettingsSection = isSectionAllowed(sectionParam) ? sectionParam : 'general'
+
+  const parsedVariables = useMemo(
+    () =>
+      variablesInput
+        .split(',')
+        .map(variable => variable.trim())
+        .filter(variable => variable.length > 0),
+    [variablesInput],
+  )
+
+  const yamlDirty = yamlContent !== originalYamlContent
+
+  const yamlDiffPreview = useMemo(() => {
+    if (!yamlDirty) return [] as string[]
+
+    const originalLines = originalYamlContent.split('\n')
+    const updatedLines = yamlContent.split('\n')
+    const maxLength = Math.max(originalLines.length, updatedLines.length)
+    const preview: string[] = []
+
+    for (let index = 0; index < maxLength; index += 1) {
+      const originalLine = originalLines[index]
+      const updatedLine = updatedLines[index]
+      if (originalLine === updatedLine) continue
+
+      if (typeof originalLine === 'string') {
+        preview.push(`- ${originalLine}`)
+      }
+      if (typeof updatedLine === 'string') {
+        preview.push(`+ ${updatedLine}`)
+      }
+
+      if (preview.length >= 16) break
+    }
+
+    return preview
+  }, [originalYamlContent, yamlContent, yamlDirty])
+
+  const sectionPath = useCallback(
+    (section: SettingsSection): string => `/app/dashboards/${dashboardId}/settings/${section}`,
+    [dashboardId],
+  )
+
+  function navigateToSection(section: SettingsSection) {
+    if (section === activeSection) return
+    setSuccessMessage(null)
+    setActionError(null)
+    navigate(sectionPath(section))
+  }
+
+  const applyStoredDashboardSettings = useCallback((id: string) => {
+    const allSettings = readStoredDashboardSettings()
+    const storedSettings = allSettings[id]
+    setTimeRangePreset(storedSettings?.timeRangePreset || '1h')
+    setRefreshInterval(storedSettings?.refreshInterval || 'off')
+    setVariablesInput((storedSettings?.variables || []).join(', '))
+  }, [])
+
+  function persistDashboardViewSettings(settings: DashboardViewSettings) {
+    const allSettings = readStoredDashboardSettings()
+    allSettings[dashboardId] = settings
+    localStorage.setItem(DASHBOARD_VIEW_SETTINGS_KEY, JSON.stringify(allSettings))
+  }
+
+  function resetFormState() {
+    setActionError(null)
+    setSuccessMessage(null)
+    setYamlValidationError(null)
+  }
+
+  const loadDashboardYaml = useCallback(async (id: string) => {
+    setIsYamlLoading(true)
+    setYamlValidationError(null)
+
+    try {
+      const fileBlob = await exportDashboardYaml(id)
+      const content = await fileBlob.text()
+      setYamlContent(content)
+      setOriginalYamlContent(content)
+    } catch (cause) {
+      setYamlValidationError(
+        cause instanceof Error ? cause.message : 'Failed to load dashboard YAML',
+      )
+    } finally {
+      setIsYamlLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!dashboardId) return
+
+    let cancelled = false
+
+    async function loadData() {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const dashboardData = await getDashboard(dashboardId)
+        if (cancelled) return
+
+        setDashboard(dashboardData)
+        setTitle(dashboardData.title)
+        setDescription(dashboardData.description || '')
+        applyStoredDashboardSettings(dashboardId)
+        await loadDashboardYaml(dashboardId)
+      } catch (cause) {
+        if (cancelled) return
+        setDashboard(null)
+        setError(dashboardLoadErrorMessage(cause))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void loadData()
+    return () => {
+      cancelled = true
+    }
+  }, [applyStoredDashboardSettings, dashboardId, loadDashboardYaml])
+
+  useEffect(() => {
+    if (!isSectionAllowed(sectionParam)) {
+      navigate(sectionPath('general'), { replace: true })
+    }
+  }, [sectionParam, isSectionAllowed, navigate, sectionPath])
+
+  async function saveGeneralSettings() {
+    if (!dashboard || !canEdit || isSaving) return
+
+    if (!title.trim()) {
+      setActionError('Dashboard name is required')
+      return
+    }
+
+    setIsSaving(true)
+    resetFormState()
+
+    try {
+      await updateDashboard(dashboard.id, {
+        title: title.trim(),
+        description: description.trim() || undefined,
+      })
+
+      setDashboard({
+        ...dashboard,
+        title: title.trim(),
+        description: description.trim() || undefined,
+      })
+
+      persistDashboardViewSettings({
+        timeRangePreset,
+        refreshInterval,
+        variables: parsedVariables,
+      })
+
+      setSuccessMessage('Dashboard settings saved')
+    } catch (cause) {
+      setActionError(
+        cause instanceof Error ? cause.message : 'Failed to save dashboard settings',
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function saveYamlSettings() {
+    if (!dashboard || !canEdit || isYamlSaving) return
+
+    const validationError = validateYamlContent(yamlContent)
+    setYamlValidationError(validationError)
+    if (validationError) return
+
+    const { title: nextTitle, description: nextDescription } = extractTitleAndDescription(
+      yamlContent,
+      dashboard.title,
+    )
+    if (!nextTitle.trim()) {
+      setYamlValidationError('Dashboard title is required')
+      return
+    }
+
+    setIsYamlSaving(true)
+    resetFormState()
+
+    try {
+      await updateDashboard(dashboard.id, {
+        title: nextTitle,
+        description: nextDescription || undefined,
+      })
+
+      const yamlSettings = {
+        timeRangePreset: extractTimeRangePreset(yamlContent, timeRangePreset),
+        refreshInterval: extractRefreshInterval(yamlContent, refreshInterval),
+        variables: extractVariables(yamlContent),
+      }
+
+      setDashboard({
+        ...dashboard,
+        title: nextTitle,
+        description: nextDescription || undefined,
+      })
+      setTitle(nextTitle)
+      setDescription(nextDescription)
+      setTimeRangePreset(yamlSettings.timeRangePreset)
+      setRefreshInterval(yamlSettings.refreshInterval)
+      setVariablesInput(yamlSettings.variables.join(', '))
+      persistDashboardViewSettings(yamlSettings)
+
+      setOriginalYamlContent(yamlContent)
+      setYamlValidationError(null)
+      setSuccessMessage('Dashboard YAML saved')
+    } catch (cause) {
+      setActionError(cause instanceof Error ? cause.message : 'Failed to save dashboard YAML')
+    } finally {
+      setIsYamlSaving(false)
+    }
+  }
+
+  async function replaceWithGrafana() {
+    if (!grafanaSource.trim() || isConvertingGrafana) return
+
+    setIsConvertingGrafana(true)
+    setActionError(null)
+    setYamlValidationError(null)
+
+    try {
+      const response = await convertGrafanaDashboard(grafanaSource, 'yaml')
+      setYamlContent(response.content)
+      setGrafanaWarnings(response.warnings)
+      setYamlValidationError(validateYamlContent(response.content))
+    } catch (cause) {
+      setActionError(
+        cause instanceof Error ? cause.message : 'Failed to convert Grafana dashboard',
+      )
+    } finally {
+      setIsConvertingGrafana(false)
+    }
+  }
+
+  async function exportSettings() {
+    if (!dashboard || isExporting) return
+
+    setIsExporting(true)
+    setActionError(null)
+
+    try {
+      const fileBlob = await exportDashboardYaml(dashboard.id)
+      const objectUrl = URL.createObjectURL(fileBlob)
+      const link = document.createElement('a')
+
+      link.href = objectUrl
+      link.download = fileNameFromTitle(dashboard.title)
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(objectUrl)
+
+      setSuccessMessage('Dashboard export downloaded')
+    } catch (cause) {
+      setActionError(cause instanceof Error ? cause.message : 'Failed to export dashboard')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-8 py-6">
+      <button
+        type="button"
+        className="mb-4 flex cursor-pointer items-center gap-1 border-none bg-transparent text-sm text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)]"
+        data-testid="dashboard-settings-back-btn"
+        title="Back to Dashboard"
+        onClick={() => navigate(`/app/dashboards/${dashboardId}`)}
+      >
+        <ArrowLeft size={16} />
+        <span>Back to dashboard</span>
+      </button>
+
+      <h1 className="font-display text-2xl font-bold text-[var(--color-on-surface)]">
+        Dashboard Settings
+      </h1>
+      {dashboard && (
+        <p className="mt-1 text-sm text-[var(--color-outline)]">{dashboard.title}</p>
+      )}
+
+      {loading ? (
+        <div className="py-8 text-center text-[var(--color-outline)]">Loading...</div>
+      ) : error ? (
+        <div className="py-8 text-center text-[var(--color-error)]">{error}</div>
+      ) : dashboard ? (
+        <>
+          <nav
+            className="mt-6 mb-6 flex gap-1 border-b border-[color-mix(in_srgb,var(--color-outline-variant)_15%,transparent)]"
+            data-testid="dashboard-settings-sidebar"
+          >
+            {settingsSections.map(section => (
+              <button
+                key={section.key}
+                type="button"
+                className={`cursor-pointer border-b-2 px-4 py-2.5 text-sm font-medium transition ${
+                  activeSection === section.key
+                    ? 'border-[var(--color-primary)] text-[var(--color-primary)]'
+                    : 'border-transparent text-[var(--color-outline)] hover:text-[var(--color-on-surface)]'
+                }`}
+                data-testid={`settings-section-${section.key}`}
+                onClick={() => navigateToSection(section.key)}
+              >
+                {section.label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="flex flex-col gap-4">
+            {!canEdit && activeSection !== 'permissions' && (
+              <p className="m-0 rounded-sm bg-[var(--color-tertiary)]/10 px-4 py-3 text-sm text-[var(--color-tertiary)]">
+                You have view-only access. Settings are visible, but only editors and admins can
+                save changes.
+              </p>
+            )}
+
+            {activeSection === 'general' && (
+              <section className="rounded-lg bg-[var(--color-surface-container-low)] p-6">
+                <h2 className="mb-4 flex items-center gap-2 font-display text-base font-semibold text-[var(--color-on-surface)]">
+                  <Settings size={18} /> General
+                </h2>
+
+                <div className="grid gap-4">
+                  <div className="grid gap-1.5">
+                    <label
+                      htmlFor="dashboard-name"
+                      className="text-sm font-medium text-[var(--color-on-surface-variant)]"
+                    >
+                      Name
+                    </label>
+                    <input
+                      id="dashboard-name"
+                      data-testid="dashboard-name-input"
+                      type="text"
+                      value={title}
+                      autoComplete="off"
+                      disabled={!canEdit || isSaving}
+                      className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      onChange={event => setTitle(event.target.value)}
+                    />
+                  </div>
+
+                  <div className="grid gap-1.5">
+                    <label
+                      htmlFor="dashboard-description"
+                      className="text-sm font-medium text-[var(--color-on-surface-variant)]"
+                    >
+                      Description
+                    </label>
+                    <textarea
+                      id="dashboard-description"
+                      data-testid="dashboard-description-input"
+                      rows={3}
+                      value={description}
+                      disabled={!canEdit || isSaving}
+                      placeholder="Optional dashboard description"
+                      className="min-h-[100px] w-full resize-y rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      onChange={event => setDescription(event.target.value)}
+                    />
+                  </div>
+
+                  <div className="grid gap-1.5">
+                    <label
+                      htmlFor="dashboard-time-range"
+                      className="text-sm font-medium text-[var(--color-on-surface-variant)]"
+                    >
+                      Default time range
+                    </label>
+                    <select
+                      id="dashboard-time-range"
+                      data-testid="dashboard-time-range-select"
+                      value={timeRangePreset}
+                      disabled={!canEdit || isSaving}
+                      className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      onChange={event => setTimeRangePreset(event.target.value)}
+                    >
+                      {TIME_RANGE_OPTIONS.map(option => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="grid gap-1.5">
+                    <label
+                      htmlFor="dashboard-refresh"
+                      className="text-sm font-medium text-[var(--color-on-surface-variant)]"
+                    >
+                      Refresh interval
+                    </label>
+                    <select
+                      id="dashboard-refresh"
+                      data-testid="dashboard-refresh-select"
+                      value={refreshInterval}
+                      disabled={!canEdit || isSaving}
+                      className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      onChange={event => setRefreshInterval(event.target.value)}
+                    >
+                      {REFRESH_OPTIONS.map(option => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="grid gap-1.5">
+                    <label
+                      htmlFor="dashboard-variables"
+                      className="text-sm font-medium text-[var(--color-on-surface-variant)]"
+                    >
+                      Variable names (comma-separated)
+                    </label>
+                    <input
+                      id="dashboard-variables"
+                      type="text"
+                      value={variablesInput}
+                      disabled={!canEdit || isSaving}
+                      placeholder="env, cluster, instance"
+                      className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      onChange={event => setVariablesInput(event.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-6 flex items-center justify-between gap-3">
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1.5 rounded-sm bg-[var(--color-surface-container-high)] px-5 py-2.5 text-sm font-semibold text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-bright)] disabled:cursor-not-allowed disabled:opacity-60"
+                    data-testid="dashboard-export-yaml-btn"
+                    disabled={isExporting}
+                    onClick={() => void exportSettings()}
+                  >
+                    <Download size={14} />
+                    <span>{isExporting ? 'Exporting...' : 'Export YAML'}</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-sm px-5 py-2.5 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-60"
+                    style={{
+                      background:
+                        'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dim) 100%)',
+                    }}
+                    data-testid="save-dashboard-settings"
+                    disabled={!canEdit || isSaving}
+                    onClick={() => void saveGeneralSettings()}
+                  >
+                    {isSaving ? 'Saving...' : 'Save settings'}
+                  </button>
+                </div>
+              </section>
+            )}
+
+            {activeSection === 'yaml' && (
+              <section className="rounded-lg bg-[var(--color-surface-container-low)] p-6">
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <h2 className="m-0 font-display text-base font-semibold text-[var(--color-on-surface)]">
+                    Dashboard YAML
+                  </h2>
+                  <button
+                    type="button"
+                    className="rounded-sm bg-[var(--color-surface-container-high)] px-5 py-2.5 text-sm font-semibold text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-bright)] disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={isConvertingGrafana || isYamlSaving}
+                    data-testid="grafana-replace-toggle"
+                    onClick={() => setShowGrafanaReplace(current => !current)}
+                  >
+                    {showGrafanaReplace ? 'Hide Grafana replace' : 'Replace with Grafana'}
+                  </button>
+                </div>
+
+                <p className="mb-4 m-0 text-sm text-[var(--color-outline)]">
+                  Edit dashboard YAML directly. Validation runs as you type and shows required
+                  schema fields.
+                </p>
+
+                {isYamlLoading ? (
+                  <p className="m-0 text-sm text-[var(--color-outline)]">
+                    Loading current dashboard YAML...
+                  </p>
+                ) : (
+                  <div className="mb-4 overflow-hidden rounded-lg bg-[var(--color-surface-container-high)]">
+                    <textarea
+                      value={yamlContent}
+                      className="min-h-[320px] w-full resize-y border-none bg-transparent px-3 py-2.5 font-mono text-xs leading-relaxed text-[var(--color-on-surface)] focus:outline-none"
+                      data-testid="yaml-editor-input"
+                      spellCheck={false}
+                      readOnly={!canEdit || isYamlSaving}
+                      onChange={event => {
+                        const next = event.target.value
+                        setYamlContent(next)
+                        setYamlValidationError(validateYamlContent(next))
+                      }}
+                    />
+                  </div>
+                )}
+
+                {showGrafanaReplace && (
+                  <div
+                    className="mb-4 grid gap-3 rounded-lg bg-[var(--color-surface-container-high)] p-4"
+                    data-testid="grafana-replace-panel"
+                  >
+                    <label
+                      htmlFor="grafana-replace-source"
+                      className="text-sm font-medium text-[var(--color-on-surface-variant)]"
+                    >
+                      Grafana JSON
+                    </label>
+                    <textarea
+                      id="grafana-replace-source"
+                      value={grafanaSource}
+                      rows={5}
+                      placeholder="Paste Grafana dashboard JSON"
+                      className="min-h-[100px] w-full resize-y rounded-sm border-none bg-[var(--color-surface-bright)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      data-testid="grafana-source"
+                      disabled={isConvertingGrafana || isYamlSaving}
+                      onChange={event => setGrafanaSource(event.target.value)}
+                    />
+                    <button
+                      type="button"
+                      className="justify-self-start rounded-sm bg-[var(--color-surface-bright)] px-5 py-2.5 text-sm font-semibold text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-container-highest)] disabled:cursor-not-allowed disabled:opacity-60"
+                      disabled={!grafanaSource.trim() || isConvertingGrafana || isYamlSaving}
+                      data-testid="grafana-replace-convert"
+                      onClick={() => void replaceWithGrafana()}
+                    >
+                      {isConvertingGrafana ? 'Converting...' : 'Convert to YAML'}
+                    </button>
+                    {grafanaWarnings.length > 0 && (
+                      <ul
+                        className="m-0 pl-5 text-xs text-[var(--color-tertiary)]"
+                        data-testid="grafana-warnings"
+                      >
+                        {grafanaWarnings.map(warning => (
+                          <li key={warning}>{warning}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )}
+
+                {yamlDiffPreview.length > 0 && (
+                  <div
+                    className="mb-4 rounded-lg bg-[var(--color-surface-container-high)] p-4"
+                    data-testid="yaml-diff-preview"
+                  >
+                    <h4 className="mb-2 m-0 font-mono text-xs uppercase tracking-[0.07em] text-[var(--color-outline)]">
+                      Diff preview
+                    </h4>
+                    <pre className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-snug text-[var(--color-on-surface)]">
+                      {yamlDiffPreview.join('\n')}
+                    </pre>
+                  </div>
+                )}
+
+                <div className="flex items-center justify-between gap-3">
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1.5 rounded-sm bg-[var(--color-surface-container-high)] px-5 py-2.5 text-sm font-semibold text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-bright)] disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={isExporting}
+                    onClick={() => void exportSettings()}
+                  >
+                    <Download size={14} />
+                    <span>{isExporting ? 'Exporting...' : 'Export YAML'}</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-sm px-5 py-2.5 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-60"
+                    style={{
+                      background:
+                        'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dim) 100%)',
+                    }}
+                    data-testid="save-dashboard-yaml"
+                    disabled={!canEdit || isYamlSaving}
+                    onClick={() => void saveYamlSettings()}
+                  >
+                    {isYamlSaving ? 'Saving YAML...' : 'Save YAML'}
+                  </button>
+                </div>
+              </section>
+            )}
+
+            {activeSection === 'permissions' && (
+              <section
+                className="rounded-lg bg-[var(--color-surface-container-low)] p-6"
+                data-testid="permissions-settings-panel"
+              >
+                <h2 className="mb-2 m-0 font-display text-base font-semibold text-[var(--color-on-surface)]">
+                  Permissions
+                </h2>
+                <p className="mb-4 m-0 text-sm text-[var(--color-outline)]">
+                  Manage who can view, edit, or administer this dashboard.
+                </p>
+                {permissionsOrgId ? (
+                  <DashboardPermissionsEditor dashboard={dashboard} orgId={permissionsOrgId} />
+                ) : (
+                  <p className="rounded-sm px-4 py-3 text-sm text-[var(--color-outline)]">
+                    Permissions are unavailable until organization context is loaded.
+                  </p>
+                )}
+              </section>
+            )}
+
+            {actionError && (
+              <p className="m-0 rounded-sm bg-[var(--color-error)]/10 px-4 py-3 text-sm text-[var(--color-error)]">
+                {actionError}
+              </p>
+            )}
+            {yamlValidationError && (
+              <p
+                className="m-0 rounded-sm bg-[var(--color-error)]/10 px-4 py-3 text-sm text-[var(--color-error)]"
+                data-testid="yaml-validation-error"
+              >
+                {yamlValidationError}
+              </p>
+            )}
+            {successMessage && (
+              <p className="m-0 rounded-sm bg-[var(--color-secondary)]/10 px-4 py-3 text-sm text-[var(--color-secondary)]">
+                {successMessage}
+              </p>
+            )}
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/DashboardSettingsPage.tsx
+++ b/frontend/src/pages/DashboardSettingsPage.tsx
@@ -11,10 +11,7 @@ import {
 import { DashboardPermissionsEditor } from '@/components/DashboardPermissionsEditor'
 import { useOrganization } from '@/hooks/useOrganization'
 import type { Dashboard } from '@/types/dashboard'
-import {
-  extractYamlTitleAndDescription,
-  validateDashboardYaml,
-} from '@/utils/dashboardYaml'
+import { extractYamlTitleAndDescription, validateDashboardYaml } from '@/utils/dashboardYaml'
 
 interface DashboardViewSettings {
   timeRangePreset: string
@@ -62,14 +59,32 @@ function dashboardLoadErrorMessage(cause: unknown): string {
   return 'Dashboard not found'
 }
 
+const FORBIDDEN_SETTINGS_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
+
+function isDashboardSettingsKey(value: string): boolean {
+  return value.length > 0 && !FORBIDDEN_SETTINGS_KEYS.has(value)
+}
+
 function readStoredDashboardSettings(): Record<string, DashboardViewSettings> {
   const rawSettings = localStorage.getItem(DASHBOARD_VIEW_SETTINGS_KEY)
-  if (!rawSettings) return {}
+  if (!rawSettings) {
+    return Object.create(null) as Record<string, DashboardViewSettings>
+  }
 
   try {
-    return JSON.parse(rawSettings) as Record<string, DashboardViewSettings>
+    const parsed = JSON.parse(rawSettings) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return Object.create(null) as Record<string, DashboardViewSettings>
+    }
+
+    const sanitized = Object.create(null) as Record<string, DashboardViewSettings>
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!isDashboardSettingsKey(key) || !value || typeof value !== 'object') continue
+      sanitized[key] = value as DashboardViewSettings
+    }
+    return sanitized
   } catch {
-    return {}
+    return Object.create(null) as Record<string, DashboardViewSettings>
   }
 }
 
@@ -125,7 +140,7 @@ export function DashboardSettingsPage() {
 
   const settingsSections = useMemo(() => {
     if (canManagePermissions) return ALL_SECTIONS
-    return ALL_SECTIONS.filter(section => section.key !== 'permissions')
+    return ALL_SECTIONS.filter((section) => section.key !== 'permissions')
   }, [canManagePermissions])
 
   const isSectionAllowed = useCallback(
@@ -143,8 +158,8 @@ export function DashboardSettingsPage() {
     () =>
       variablesInput
         .split(',')
-        .map(variable => variable.trim())
-        .filter(variable => variable.length > 0),
+        .map((variable) => variable.trim())
+        .filter((variable) => variable.length > 0),
     [variablesInput],
   )
 
@@ -197,9 +212,16 @@ export function DashboardSettingsPage() {
   }, [])
 
   function persistDashboardViewSettings(settings: DashboardViewSettings) {
+    if (!isDashboardSettingsKey(dashboardId)) return
+
     const allSettings = readStoredDashboardSettings()
-    allSettings[dashboardId] = settings
-    localStorage.setItem(DASHBOARD_VIEW_SETTINGS_KEY, JSON.stringify(allSettings))
+    const nextSettings = Object.create(null) as Record<string, DashboardViewSettings>
+    for (const [key, value] of Object.entries(allSettings)) {
+      if (!isDashboardSettingsKey(key)) continue
+      nextSettings[key] = value
+    }
+    nextSettings[dashboardId] = settings
+    localStorage.setItem(DASHBOARD_VIEW_SETTINGS_KEY, JSON.stringify(nextSettings))
   }
 
   function resetFormState() {
@@ -296,9 +318,7 @@ export function DashboardSettingsPage() {
 
       setSuccessMessage('Dashboard settings saved')
     } catch (cause) {
-      setActionError(
-        cause instanceof Error ? cause.message : 'Failed to save dashboard settings',
-      )
+      setActionError(cause instanceof Error ? cause.message : 'Failed to save dashboard settings')
     } finally {
       setIsSaving(false)
     }
@@ -362,9 +382,7 @@ export function DashboardSettingsPage() {
       setGrafanaWarnings(response.warnings)
       setYamlValidationError(validateDashboardYaml(response.content))
     } catch (cause) {
-      setActionError(
-        cause instanceof Error ? cause.message : 'Failed to convert Grafana dashboard',
-      )
+      setActionError(cause instanceof Error ? cause.message : 'Failed to convert Grafana dashboard')
     } finally {
       setIsConvertingGrafana(false)
     }
@@ -412,9 +430,7 @@ export function DashboardSettingsPage() {
       <h1 className="font-display text-2xl font-bold text-[var(--color-on-surface)]">
         Dashboard Settings
       </h1>
-      {dashboard && (
-        <p className="mt-1 text-sm text-[var(--color-outline)]">{dashboard.title}</p>
-      )}
+      {dashboard && <p className="mt-1 text-sm text-[var(--color-outline)]">{dashboard.title}</p>}
 
       {loading ? (
         <div className="py-8 text-center text-[var(--color-outline)]">Loading...</div>
@@ -426,7 +442,7 @@ export function DashboardSettingsPage() {
             className="mt-6 mb-6 flex gap-1 border-b border-[color-mix(in_srgb,var(--color-outline-variant)_15%,transparent)]"
             data-testid="dashboard-settings-sidebar"
           >
-            {settingsSections.map(section => (
+            {settingsSections.map((section) => (
               <button
                 key={section.key}
                 type="button"
@@ -473,7 +489,7 @@ export function DashboardSettingsPage() {
                       autoComplete="off"
                       disabled={!canEdit || isSaving}
                       className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
-                      onChange={event => setTitle(event.target.value)}
+                      onChange={(event) => setTitle(event.target.value)}
                     />
                   </div>
 
@@ -492,7 +508,7 @@ export function DashboardSettingsPage() {
                       disabled={!canEdit || isSaving}
                       placeholder="Optional dashboard description"
                       className="min-h-[100px] w-full resize-y rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
-                      onChange={event => setDescription(event.target.value)}
+                      onChange={(event) => setDescription(event.target.value)}
                     />
                   </div>
 
@@ -509,9 +525,9 @@ export function DashboardSettingsPage() {
                       value={timeRangePreset}
                       disabled={!canEdit || isSaving}
                       className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
-                      onChange={event => setTimeRangePreset(event.target.value)}
+                      onChange={(event) => setTimeRangePreset(event.target.value)}
                     >
-                      {TIME_RANGE_OPTIONS.map(option => (
+                      {TIME_RANGE_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>
                           {option.label}
                         </option>
@@ -532,9 +548,9 @@ export function DashboardSettingsPage() {
                       value={refreshInterval}
                       disabled={!canEdit || isSaving}
                       className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
-                      onChange={event => setRefreshInterval(event.target.value)}
+                      onChange={(event) => setRefreshInterval(event.target.value)}
                     >
-                      {REFRESH_OPTIONS.map(option => (
+                      {REFRESH_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>
                           {option.label}
                         </option>
@@ -556,7 +572,7 @@ export function DashboardSettingsPage() {
                       disabled={!canEdit || isSaving}
                       placeholder="env, cluster, instance"
                       className="w-full rounded-sm border-none bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
-                      onChange={event => setVariablesInput(event.target.value)}
+                      onChange={(event) => setVariablesInput(event.target.value)}
                     />
                   </div>
                 </div>
@@ -600,7 +616,7 @@ export function DashboardSettingsPage() {
                     className="rounded-sm bg-[var(--color-surface-container-high)] px-5 py-2.5 text-sm font-semibold text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-bright)] disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={isConvertingGrafana || isYamlSaving}
                     data-testid="grafana-replace-toggle"
-                    onClick={() => setShowGrafanaReplace(current => !current)}
+                    onClick={() => setShowGrafanaReplace((current) => !current)}
                   >
                     {showGrafanaReplace ? 'Hide Grafana replace' : 'Replace with Grafana'}
                   </button>
@@ -623,7 +639,7 @@ export function DashboardSettingsPage() {
                       data-testid="yaml-editor-input"
                       spellCheck={false}
                       readOnly={!canEdit || isYamlSaving}
-                      onChange={event => {
+                      onChange={(event) => {
                         const next = event.target.value
                         setYamlContent(next)
                         setYamlValidationError(validateDashboardYaml(next))
@@ -651,7 +667,7 @@ export function DashboardSettingsPage() {
                       className="min-h-[100px] w-full resize-y rounded-sm border-none bg-[var(--color-surface-bright)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] transition placeholder:text-[var(--color-outline)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20 disabled:cursor-not-allowed disabled:opacity-60"
                       data-testid="grafana-source"
                       disabled={isConvertingGrafana || isYamlSaving}
-                      onChange={event => setGrafanaSource(event.target.value)}
+                      onChange={(event) => setGrafanaSource(event.target.value)}
                     />
                     <button
                       type="button"
@@ -667,7 +683,7 @@ export function DashboardSettingsPage() {
                         className="m-0 pl-5 text-xs text-[var(--color-tertiary)]"
                         data-testid="grafana-warnings"
                       >
-                        {grafanaWarnings.map(warning => (
+                        {grafanaWarnings.map((warning) => (
                           <li key={warning}>{warning}</li>
                         ))}
                       </ul>

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -15,6 +15,12 @@ const DashboardsPage = lazy(() =>
 const DashboardDetailPage = lazy(() =>
   import('@/pages/DashboardDetailPage').then(m => ({ default: m.DashboardDetailPage })),
 )
+const DashboardSettingsPage = lazy(() =>
+  import('@/pages/DashboardSettingsPage').then(m => ({ default: m.DashboardSettingsPage })),
+)
+const DashboardGenPage = lazy(() =>
+  import('@/pages/DashboardGenPage').then(m => ({ default: m.DashboardGenPage })),
+)
 const LoginPage = lazy(() => import('@/pages/LoginPage').then(m => ({ default: m.LoginPage })))
 const AuthCallbackPage = lazy(() =>
   import('@/pages/AuthCallbackPage').then(m => ({ default: m.AuthCallbackPage })),
@@ -71,7 +77,7 @@ const appRoutes: RouteObject[] = [
   {
     path: '/app/dashboards/new/ai',
     handle: withMeta('Generate Dashboard — Ace'),
-    element: placeholder('Generate Dashboard'),
+    element: <DashboardGenPage />,
   },
   {
     path: '/app/dashboards/:id',
@@ -85,7 +91,7 @@ const appRoutes: RouteObject[] = [
   {
     path: '/app/dashboards/:id/settings/:section',
     handle: withMeta('Dashboard Settings | Ace'),
-    element: placeholder('Dashboard Settings'),
+    element: <DashboardSettingsPage />,
   },
   {
     path: '/app/services',

--- a/frontend/src/utils/dashboardYaml.spec.ts
+++ b/frontend/src/utils/dashboardYaml.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDashboardYamlPreview,
+  DASHBOARD_YAML_VERSION,
+  extractYamlTitleAndDescription,
+  validateDashboardYaml,
+} from './dashboardYaml'
+
+describe('validateDashboardYaml', () => {
+  it('accepts flat v2 documents', () => {
+    const yaml = `version: ${DASHBOARD_YAML_VERSION}
+title: Prod
+description: Overview
+panels: []
+`
+    expect(validateDashboardYaml(yaml)).toBeNull()
+  })
+
+  it('rejects nested v1 schema', () => {
+    const yaml = `schema_version: 1
+dashboard:
+  title: Nested
+  panels: []
+`
+    expect(validateDashboardYaml(yaml)).toBe('Missing version')
+  })
+
+  it('rejects wrong version', () => {
+    const yaml = `version: 1
+title: Old
+panels: []
+`
+    expect(validateDashboardYaml(yaml)).toContain('Unsupported version')
+  })
+
+  it('requires panels key', () => {
+    const yaml = `version: 2
+title: No panels
+`
+    expect(validateDashboardYaml(yaml)).toBe('Missing panels section')
+  })
+})
+
+describe('extractYamlTitleAndDescription', () => {
+  it('reads top-level title and description', () => {
+    const yaml = `version: 2
+title: "API Latency"
+description: 'Service health'
+panels: []
+`
+    expect(extractYamlTitleAndDescription(yaml)).toEqual({
+      title: 'API Latency',
+      description: 'Service health',
+    })
+  })
+})
+
+describe('buildDashboardYamlPreview', () => {
+  it('counts block-list panels', () => {
+    const yaml = `version: 2
+title: Imported
+panels:
+  - title: Requests
+    type: line_chart
+  - title: Errors
+    type: stat
+`
+    expect(buildDashboardYamlPreview(yaml)).toEqual({
+      title: 'Imported',
+      description: '',
+      panelCount: 2,
+    })
+  })
+})

--- a/frontend/src/utils/dashboardYaml.ts
+++ b/frontend/src/utils/dashboardYaml.ts
@@ -1,0 +1,90 @@
+/** Backend dashboard CaC schema version (flat document root). */
+export const DASHBOARD_YAML_VERSION = 2
+
+export function normalizeYamlValue(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+/**
+ * Validate a dashboard YAML document against the backend v2 flat schema:
+ *   version: 2
+ *   title: ...
+ *   description: ...   # optional
+ *   panels: [...]      # required key (may be empty)
+ */
+export function validateDashboardYaml(rawYaml: string): string | null {
+  if (!rawYaml.trim()) {
+    return 'YAML content is required'
+  }
+
+  const versionMatch = rawYaml.match(/(?:^|\n)version:\s*(\d+)/)
+  if (!versionMatch) {
+    return 'Missing version'
+  }
+  if (versionMatch[1] !== String(DASHBOARD_YAML_VERSION)) {
+    return `Unsupported version ${versionMatch[1]} (expected ${DASHBOARD_YAML_VERSION})`
+  }
+
+  const titleMatch = rawYaml.match(/(?:^|\n)title:\s*(.+)/)
+  if (!titleMatch || !normalizeYamlValue(titleMatch[1] ?? '')) {
+    return 'Missing dashboard title'
+  }
+
+  // panels may be an empty list (`panels: []`) or a block list (`panels:\n  - ...`).
+  const panelsMatch = rawYaml.match(/(?:^|\n)panels:\s*(?:\n|\[)/)
+  if (!panelsMatch) {
+    return 'Missing panels section'
+  }
+
+  return null
+}
+
+export function extractYamlTitleAndDescription(
+  rawYaml: string,
+  fallbackTitle = '',
+): { title: string; description: string } {
+  const titleMatch = rawYaml.match(/(?:^|\n)title:\s*(.+)/)
+  const descriptionMatch = rawYaml.match(/(?:^|\n)description:\s*(.+)/)
+
+  return {
+    title: normalizeYamlValue(titleMatch?.[1] ?? fallbackTitle),
+    description: normalizeYamlValue(descriptionMatch?.[1] ?? ''),
+  }
+}
+
+export type DashboardYamlPreview = {
+  title: string
+  description: string
+  panelCount: number
+}
+
+/** Lightweight preview for import UIs. Throws on missing version/title. */
+export function buildDashboardYamlPreview(rawYaml: string): DashboardYamlPreview {
+  const versionMatch = rawYaml.match(/(?:^|\n)version:\s*(.+)/)
+  if (!versionMatch) {
+    throw new Error('Missing version')
+  }
+
+  const { title, description } = extractYamlTitleAndDescription(rawYaml)
+  if (!title) {
+    throw new Error(titleMatchMissing(rawYaml) ? 'Missing dashboard title' : 'Dashboard title is empty')
+  }
+
+  const panelsSectionMatch = rawYaml.match(
+    /(?:^|\n)panels:\s*\n([\s\S]*?)(?=\n[a-zA-Z_][\w-]*:\s*|\s*$)/,
+  )
+  const panelCount = (panelsSectionMatch?.[1]?.match(/(?:^|\n)\s{2}-\s+/g) ?? []).length
+
+  return { title, description, panelCount }
+}
+
+function titleMatchMissing(rawYaml: string): boolean {
+  return !/(?:^|\n)title:\s*/.test(rawYaml)
+}

--- a/website/api/routes.md
+++ b/website/api/routes.md
@@ -187,7 +187,6 @@ title: API Routes
 | POST | `/api/datasources/{id}/alertmanager/silences` | Yes | - | CreateSilence proxies POST /api/datasources/{id}/alertmanager/silences to AlertManager. |
 | DELETE | `/api/datasources/{id}/alertmanager/silences/{silenceId}` | Yes | - | ExpireSilence proxies DELETE /api/datasources/{id}/alertmanager/silences/{silenceId} to AlertManager. |
 | GET | `/api/datasources/{id}/alertmanager/receivers` | Yes | - | ListReceivers proxies GET /api/datasources/{id}/alertmanager/receivers to AlertManager. |
-| GET | `/api/datasources/{id}/alertmanager/status` | Yes | - | Status proxies GET /api/datasources/{id}/alertmanager/status to AlertManager. |
 | GET | `/api/datasources/{id}/alertmanager/health` | Yes | - | Health proxies GET /api/datasources/{id}/alertmanager/health to AlertManager. |
 
 ## GitHub Copilot auth routes

--- a/website/api/routes.md
+++ b/website/api/routes.md
@@ -107,6 +107,7 @@ title: API Routes
 | PUT | `/api/dashboards/{id}` | Yes | - | Update modifies a dashboard's title, description, or folder assignment. |
 | DELETE | `/api/dashboards/{id}` | Yes | - | Delete removes a dashboard and its associated panels. |
 | GET | `/api/dashboards/{id}/export` | Yes | - | Export serializes a dashboard and its panels to a portable JSON or YAML document. |
+| PUT | `/api/dashboards/{id}/import` | Yes | - | ReplaceImport replaces an existing dashboard body (metadata + panels) from a |
 | POST | `/api/orgs/{orgId}/dashboards/import` | Yes | - | Import creates a dashboard and its panels from a JSON or YAML document. Requires admin or editor role. |
 
 ## Folder routes
@@ -186,6 +187,7 @@ title: API Routes
 | POST | `/api/datasources/{id}/alertmanager/silences` | Yes | - | CreateSilence proxies POST /api/datasources/{id}/alertmanager/silences to AlertManager. |
 | DELETE | `/api/datasources/{id}/alertmanager/silences/{silenceId}` | Yes | - | ExpireSilence proxies DELETE /api/datasources/{id}/alertmanager/silences/{silenceId} to AlertManager. |
 | GET | `/api/datasources/{id}/alertmanager/receivers` | Yes | - | ListReceivers proxies GET /api/datasources/{id}/alertmanager/receivers to AlertManager. |
+| GET | `/api/datasources/{id}/alertmanager/status` | Yes | - | Status proxies GET /api/datasources/{id}/alertmanager/status to AlertManager. |
 | GET | `/api/datasources/{id}/alertmanager/health` | Yes | - | Health proxies GET /api/datasources/{id}/alertmanager/health to AlertManager. |
 
 ## GitHub Copilot auth routes


### PR DESCRIPTION
## Summary

Implements per-dashboard settings and AI dashboard generation for the React frontend (#306).

### Features
- Dashboard settings route at `/app/dashboards/:id/settings/:section` (general, YAML, permissions)
- YAML editor with validation and save against the backend v2 flat CaC schema
- Permission management UI (admin-only, matching the backend API)
- AI dashboard generation at `/app/dashboards/new/ai` that produces a saved dashboard
- RTL coverage for settings save and AI gen happy paths

### Review fixes (mandatory)
1. **YAML v2 flat schema** — frontend validation now expects `version: 2` / top-level `title` / `panels` (not nested `schema_version`/`dashboard:`)
2. **Full-body YAML save** — `PUT /api/dashboards/{id}/import` replaces metadata + panels atomically; settings save uses `replaceDashboardYaml` instead of title/description-only update
3. **Admin-only permissions** — permissions section is gated to org `admin` (editors no longer get a false-writable UI)

### Thermo-nuclear follow-ups applied
- Shared `frontend/src/utils/dashboardYaml.ts` for v2 validate/preview helpers (settings + import modal)
- Safer JSON error encoding on panel import failures

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run test` (389 tests)
- [x] `go test ./internal/handlers/ -run 'DashboardHandler_(Export|Import|ReplaceImport)'`
- [ ] Manual: open settings YAML for an exported dashboard, edit panel, save, reload
- [ ] Manual: confirm editor role cannot see Permissions tab; admin can

Closes #306