### PR TITLE
feat(frontend): services overview and alerts management (#307)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -294,6 +294,7 @@ func main() {
 	mux.HandleFunc("POST /api/datasources/{id}/alertmanager/silences", auth.RequireAuth(jwtManager, alertManagerHandler.CreateSilence))
 	mux.HandleFunc("DELETE /api/datasources/{id}/alertmanager/silences/{silenceId}", auth.RequireAuth(jwtManager, alertManagerHandler.ExpireSilence))
 	mux.HandleFunc("GET /api/datasources/{id}/alertmanager/receivers", auth.RequireAuth(jwtManager, alertManagerHandler.ListReceivers))
+	mux.HandleFunc("GET /api/datasources/{id}/alertmanager/status", auth.RequireAuth(jwtManager, alertManagerHandler.Status))
 	mux.HandleFunc("GET /api/datasources/{id}/alertmanager/health", auth.RequireAuth(jwtManager, alertManagerHandler.Health))
 
 	// GitHub Copilot auth routes

--- a/backend/internal/datasource/alertmanager.go
+++ b/backend/internal/datasource/alertmanager.go
@@ -98,12 +98,12 @@ type AMReceiver struct {
 
 // AMVersionInfo holds version information from the status endpoint.
 type AMVersionInfo struct {
-	Version            string `json:"version"`
-	Revision           string `json:"revision,omitempty"`
-	Branch             string `json:"branch,omitempty"`
-	BuildUser          string `json:"buildUser,omitempty"`
-	BuildDate          string `json:"buildDate,omitempty"`
-	GoVersion          string `json:"goVersion,omitempty"`
+	Version   string `json:"version"`
+	Revision  string `json:"revision,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	BuildUser string `json:"buildUser,omitempty"`
+	BuildDate string `json:"buildDate,omitempty"`
+	GoVersion string `json:"goVersion,omitempty"`
 }
 
 // AMClusterStatus holds cluster status info.

--- a/backend/internal/datasource/alertmanager.go
+++ b/backend/internal/datasource/alertmanager.go
@@ -98,18 +98,30 @@ type AMReceiver struct {
 
 // AMVersionInfo holds version information from the status endpoint.
 type AMVersionInfo struct {
-	Version string `json:"version"`
+	Version            string `json:"version"`
+	Revision           string `json:"revision,omitempty"`
+	Branch             string `json:"branch,omitempty"`
+	BuildUser          string `json:"buildUser,omitempty"`
+	BuildDate          string `json:"buildDate,omitempty"`
+	GoVersion          string `json:"goVersion,omitempty"`
 }
 
 // AMClusterStatus holds cluster status info.
 type AMClusterStatus struct {
 	Status string `json:"status"`
+	Name   string `json:"name,omitempty"`
+}
+
+// AMConfig holds the AlertManager configuration payload from /api/v2/status.
+type AMConfig struct {
+	Original string `json:"original"`
 }
 
 // AMStatus represents the status response from AlertManager.
 type AMStatus struct {
 	Cluster     AMClusterStatus `json:"cluster"`
 	VersionInfo AMVersionInfo   `json:"versionInfo"`
+	Config      AMConfig        `json:"config"`
 	Uptime      time.Time       `json:"uptime"`
 }
 

--- a/backend/internal/handlers/alertmanager.go
+++ b/backend/internal/handlers/alertmanager.go
@@ -25,17 +25,18 @@ func NewAlertManagerHandler(pool *pgxpool.Pool) *AlertManagerHandler {
 }
 
 // resolveAlertManagerDatasource loads the datasource, verifies membership and type.
-func (h *AlertManagerHandler) resolveAlertManagerDatasource(w http.ResponseWriter, r *http.Request) (*models.DataSource, bool) {
+// The membership role is returned so callers can apply role-sensitive redaction.
+func (h *AlertManagerHandler) resolveAlertManagerDatasource(w http.ResponseWriter, r *http.Request) (*models.DataSource, string, bool) {
 	userID, ok := auth.GetUserID(r.Context())
 	if !ok {
 		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
-		return nil, false
+		return nil, "", false
 	}
 
 	id, err := uuid.Parse(r.PathValue("id"))
 	if err != nil {
 		http.Error(w, `{"error":"invalid datasource id"}`, http.StatusBadRequest)
-		return nil, false
+		return nil, "", false
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
@@ -48,7 +49,7 @@ func (h *AlertManagerHandler) resolveAlertManagerDatasource(w http.ResponseWrite
 	).Scan(&ds.ID, &ds.OrganizationID, &ds.Name, &ds.Type, &ds.URL, &ds.IsDefault, &ds.AuthType, &ds.AuthConfig, &ds.CreatedAt, &ds.UpdatedAt)
 	if err != nil {
 		http.Error(w, `{"error":"datasource not found"}`, http.StatusNotFound)
-		return nil, false
+		return nil, "", false
 	}
 
 	var role string
@@ -58,22 +59,22 @@ func (h *AlertManagerHandler) resolveAlertManagerDatasource(w http.ResponseWrite
 	).Scan(&role)
 	if err != nil {
 		http.Error(w, `{"error":"not a member of this organization"}`, http.StatusForbidden)
-		return nil, false
+		return nil, "", false
 	}
 
 	if ds.Type != models.DataSourceAlertManager {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "datasource is not of type alertmanager"})
-		return nil, false
+		return nil, "", false
 	}
 
-	return &ds, true
+	return &ds, role, true
 }
 
 // ListAlerts proxies GET /api/datasources/{id}/alertmanager/alerts to AlertManager.
 func (h *AlertManagerHandler) ListAlerts(w http.ResponseWriter, r *http.Request) {
-	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	ds, _, ok := h.resolveAlertManagerDatasource(w, r)
 	if !ok {
 		return
 	}
@@ -104,7 +105,7 @@ func (h *AlertManagerHandler) ListAlerts(w http.ResponseWriter, r *http.Request)
 
 // ListSilences proxies GET /api/datasources/{id}/alertmanager/silences to AlertManager.
 func (h *AlertManagerHandler) ListSilences(w http.ResponseWriter, r *http.Request) {
-	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	ds, _, ok := h.resolveAlertManagerDatasource(w, r)
 	if !ok {
 		return
 	}
@@ -131,25 +132,11 @@ func (h *AlertManagerHandler) ListSilences(w http.ResponseWriter, r *http.Reques
 
 // CreateSilence proxies POST /api/datasources/{id}/alertmanager/silences to AlertManager.
 func (h *AlertManagerHandler) CreateSilence(w http.ResponseWriter, r *http.Request) {
-	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	ds, role, ok := h.resolveAlertManagerDatasource(w, r)
 	if !ok {
 		return
 	}
 
-	userID, _ := auth.GetUserID(r.Context())
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
-	defer cancel()
-	var role string
-	err := h.pool.QueryRow(ctx,
-		`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
-		userID, ds.OrganizationID,
-	).Scan(&role)
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to check membership"})
-		return
-	}
 	if role == "auditor" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
@@ -191,25 +178,11 @@ func (h *AlertManagerHandler) CreateSilence(w http.ResponseWriter, r *http.Reque
 
 // ExpireSilence proxies DELETE /api/datasources/{id}/alertmanager/silences/{silenceId} to AlertManager.
 func (h *AlertManagerHandler) ExpireSilence(w http.ResponseWriter, r *http.Request) {
-	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	ds, role, ok := h.resolveAlertManagerDatasource(w, r)
 	if !ok {
 		return
 	}
 
-	userID, _ := auth.GetUserID(r.Context())
-	ctx2, cancel2 := context.WithTimeout(r.Context(), 15*time.Second)
-	defer cancel2()
-	var role string
-	err := h.pool.QueryRow(ctx2,
-		`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
-		userID, ds.OrganizationID,
-	).Scan(&role)
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to check membership"})
-		return
-	}
 	if role == "auditor" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
@@ -250,7 +223,7 @@ func (h *AlertManagerHandler) ExpireSilence(w http.ResponseWriter, r *http.Reque
 
 // ListReceivers proxies GET /api/datasources/{id}/alertmanager/receivers to AlertManager.
 func (h *AlertManagerHandler) ListReceivers(w http.ResponseWriter, r *http.Request) {
-	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	ds, _, ok := h.resolveAlertManagerDatasource(w, r)
 	if !ok {
 		return
 	}
@@ -277,7 +250,7 @@ func (h *AlertManagerHandler) ListReceivers(w http.ResponseWriter, r *http.Reque
 
 // Health proxies GET /api/datasources/{id}/alertmanager/health to AlertManager.
 func (h *AlertManagerHandler) Health(w http.ResponseWriter, r *http.Request) {
-	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	ds, _, ok := h.resolveAlertManagerDatasource(w, r)
 	if !ok {
 		return
 	}
@@ -306,9 +279,11 @@ func (h *AlertManagerHandler) Health(w http.ResponseWriter, r *http.Request) {
 }
 
 // Status proxies GET /api/datasources/{id}/alertmanager/status to AlertManager.
-// Returns cluster, version, uptime, and the original configuration YAML when available.
+// Returns cluster, version, uptime, and (for org admins only) the original
+// configuration YAML. Non-admins get an empty config.original because the raw
+// YAML commonly embeds receiver secrets (webhook URLs, SMTP passwords, tokens).
 func (h *AlertManagerHandler) Status(w http.ResponseWriter, r *http.Request) {
-	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	ds, role, ok := h.resolveAlertManagerDatasource(w, r)
 	if !ok {
 		return
 	}
@@ -327,6 +302,10 @@ func (h *AlertManagerHandler) Status(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch alertmanager status: " + err.Error()})
 		return
+	}
+
+	if role != string(models.RoleAdmin) {
+		result.Config.Original = ""
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/backend/internal/handlers/alertmanager.go
+++ b/backend/internal/handlers/alertmanager.go
@@ -304,3 +304,31 @@ func (h *AlertManagerHandler) Health(w http.ResponseWriter, r *http.Request) {
 		Status: "success",
 	})
 }
+
+// Status proxies GET /api/datasources/{id}/alertmanager/status to AlertManager.
+// Returns cluster, version, uptime, and the original configuration YAML when available.
+func (h *AlertManagerHandler) Status(w http.ResponseWriter, r *http.Request) {
+	ds, ok := h.resolveAlertManagerDatasource(w, r)
+	if !ok {
+		return
+	}
+
+	client, err := datasource.NewAlertManagerClient(*ds)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create alertmanager client: " + err.Error()})
+		return
+	}
+
+	result, err := client.GetStatus(r.Context())
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch alertmanager status: " + err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}

--- a/frontend/src/api/alertmanager.ts
+++ b/frontend/src/api/alertmanager.ts
@@ -1,0 +1,88 @@
+import type { AMAlert, AMReceiver, AMSilence, AMSilenceCreate } from '@/types/datasource'
+import { API_BASE } from './base'
+
+function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token')
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+export async function fetchAlertManagerAlerts(
+  datasourceId: string,
+  filters: { active: boolean; silenced: boolean; inhibited: boolean },
+): Promise<AMAlert[]> {
+  const params = new URLSearchParams({
+    active: String(filters.active),
+    silenced: String(filters.silenced),
+    inhibited: String(filters.inhibited),
+  })
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/alerts?${params}`,
+    { headers: getAuthHeaders() },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch alerts')
+  }
+  return response.json() as Promise<AMAlert[]>
+}
+
+export async function fetchSilences(datasourceId: string): Promise<AMSilence[]> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/silences`,
+    { headers: getAuthHeaders() },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch silences')
+  }
+  return response.json() as Promise<AMSilence[]>
+}
+
+export async function createSilence(
+  datasourceId: string,
+  silence: AMSilenceCreate,
+): Promise<string> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/silences`,
+    {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(silence),
+    },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to create silence')
+  }
+  const result = (await response.json()) as { silenceID: string }
+  return result.silenceID
+}
+
+export async function expireSilence(datasourceId: string, silenceId: string): Promise<void> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/silences/${silenceId}`,
+    {
+      method: 'DELETE',
+      headers: getAuthHeaders(),
+    },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to expire silence')
+  }
+}
+
+export async function fetchReceivers(datasourceId: string): Promise<AMReceiver[]> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/receivers`,
+    { headers: getAuthHeaders() },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch receivers')
+  }
+  return response.json() as Promise<AMReceiver[]>
+}

--- a/frontend/src/api/alertmanager.ts
+++ b/frontend/src/api/alertmanager.ts
@@ -1,4 +1,10 @@
-import type { AMAlert, AMReceiver, AMSilence, AMSilenceCreate } from '@/types/datasource'
+import type {
+  AMAlert,
+  AMReceiver,
+  AMSilence,
+  AMSilenceCreate,
+  AMStatus,
+} from '@/types/datasource'
 import { API_BASE } from './base'
 
 function getAuthHeaders(): HeadersInit {
@@ -85,4 +91,16 @@ export async function fetchReceivers(datasourceId: string): Promise<AMReceiver[]
     throw new Error((err as { error?: string }).error || 'Failed to fetch receivers')
   }
   return response.json() as Promise<AMReceiver[]>
+}
+
+export async function fetchAlertManagerStatus(datasourceId: string): Promise<AMStatus> {
+  const response = await fetch(
+    `${API_BASE}/api/datasources/${datasourceId}/alertmanager/status`,
+    { headers: getAuthHeaders() },
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch Alertmanager status')
+  }
+  return response.json() as Promise<AMStatus>
 }

--- a/frontend/src/api/vmalert.ts
+++ b/frontend/src/api/vmalert.ts
@@ -1,0 +1,32 @@
+import type { VMAlertAlertsResponse, VMAlertGroupsResponse } from '@/types/datasource'
+import { API_BASE } from './base'
+
+function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token')
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+export async function fetchVMAlerts(datasourceId: string): Promise<VMAlertAlertsResponse> {
+  const response = await fetch(`${API_BASE}/api/datasources/${datasourceId}/vmalert/alerts`, {
+    headers: getAuthHeaders(),
+  })
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch alerts')
+  }
+  return response.json() as Promise<VMAlertAlertsResponse>
+}
+
+export async function fetchVMAlertGroups(datasourceId: string): Promise<VMAlertGroupsResponse> {
+  const response = await fetch(`${API_BASE}/api/datasources/${datasourceId}/vmalert/groups`, {
+    headers: getAuthHeaders(),
+  })
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error || 'Failed to fetch rule groups')
+  }
+  return response.json() as Promise<VMAlertGroupsResponse>
+}

--- a/frontend/src/components/AiAlertTriage.tsx
+++ b/frontend/src/components/AiAlertTriage.tsx
@@ -1,0 +1,65 @@
+import { Sparkles } from 'lucide-react'
+import { useAiSidebarStore } from '@/stores/aiSidebarStore'
+
+type AiAlertTriageProps = {
+  alertCount: number
+  alertNames?: string[]
+  className?: string
+}
+
+export function AiAlertTriage({ alertCount, alertNames, className }: AiAlertTriageProps) {
+  const open = useAiSidebarStore(state => state.open)
+
+  function handleInvestigate() {
+    const names = alertNames?.join(', ') || `${alertCount} alerts`
+    open({
+      message: `Investigate the currently firing alerts: ${names}. Analyze root causes, correlate with recent deployments or changes, assess severity, and suggest remediation steps.`,
+    })
+  }
+
+  return (
+    <div
+      data-testid="ai-alert-triage"
+      className={`overflow-hidden rounded-lg ${className ?? ''}`}
+      style={{
+        borderLeft: '2px solid var(--color-primary)',
+        backgroundColor: 'var(--color-primary-muted)',
+      }}
+    >
+      <div className="px-3 py-2.5">
+        <div className="mb-1.5 flex items-center gap-1.5">
+          <Sparkles size={12} style={{ color: 'var(--color-primary)' }} aria-hidden />
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '10px',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              color: 'var(--color-primary)',
+            }}
+          >
+            AI Triage
+          </span>
+        </div>
+
+        <p className="mb-2 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+          {alertCount} alert{alertCount !== 1 ? 's' : ''} firing. Open Copilot for root cause
+          analysis, impact assessment, and suggested remediation.
+        </p>
+
+        <button
+          type="button"
+          className="cursor-pointer rounded border-none px-2.5 py-1 text-xs font-medium"
+          style={{
+            backgroundColor: 'var(--color-primary)',
+            color: '#0B0D0F',
+          }}
+          onClick={handleInvestigate}
+        >
+          Investigate with Copilot
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/alerts/AlertManagerPanels.tsx
+++ b/frontend/src/components/alerts/AlertManagerPanels.tsx
@@ -390,7 +390,7 @@ export function AMConfigPanel({ status, loading, error }: AMConfigPanelProps) {
             color: 'var(--color-on-surface)',
           }}
         >
-          {status.config?.original?.trim() || '# No configuration payload returned by Alertmanager'}
+          {status.config?.original?.trim() || '# Configuration YAML is only available to organization admins (secrets redacted for other roles).'}
         </pre>
       </div>
     </div>

--- a/frontend/src/components/alerts/AlertManagerPanels.tsx
+++ b/frontend/src/components/alerts/AlertManagerPanels.tsx
@@ -1,0 +1,423 @@
+import { BellOff, Plus, Radio, Star, Trash2 } from 'lucide-react'
+import { StatusDot } from '@/components/StatusDot'
+import { formatDateShort, matcherOperator, stateToStatusDot, truncateId } from '@/lib/alerts'
+import type { AMAlert, AMReceiver, AMSilence, AMStatus } from '@/types/datasource'
+
+type AMAlertsPanelProps = {
+  sortedAMAlerts: AMAlert[]
+  selectedDatasourceId: string
+  amFilterActive: boolean
+  amFilterSilenced: boolean
+  amFilterInhibited: boolean
+  isFavorite: (id: string) => boolean
+  onToggleFavorite: (id: string, title: string) => void
+  onFilterActive: (v: boolean) => void
+  onFilterSilenced: (v: boolean) => void
+  onFilterInhibited: (v: boolean) => void
+}
+
+export function AMAlertsPanel({
+  sortedAMAlerts,
+  selectedDatasourceId,
+  amFilterActive,
+  amFilterSilenced,
+  amFilterInhibited,
+  isFavorite,
+  onToggleFavorite,
+  onFilterActive,
+  onFilterSilenced,
+  onFilterInhibited,
+}: AMAlertsPanelProps) {
+  return (
+    <div>
+      <div className="mb-4 flex items-center gap-2">
+        <span className="text-xs font-medium" style={{ color: 'var(--color-outline)' }}>
+          Show:
+        </span>
+        {(
+          [
+            ['Active', amFilterActive, onFilterActive, 'alerts-filter-active-btn'],
+            ['Silenced', amFilterSilenced, onFilterSilenced, 'alerts-filter-silenced-btn'],
+            ['Inhibited', amFilterInhibited, onFilterInhibited, 'alerts-filter-inhibited-btn'],
+          ] as const
+        ).map(([label, on, setOn, testId]) => (
+          <button
+            key={label}
+            type="button"
+            className="cursor-pointer rounded-sm px-2.5 py-1 text-xs transition"
+            style={{
+              backgroundColor: on
+                ? 'color-mix(in srgb, var(--color-primary) 15%, transparent)'
+                : 'var(--color-surface-container-high)',
+              color: on ? 'var(--color-primary)' : 'var(--color-outline)',
+              border: on
+                ? '1px solid var(--color-primary)'
+                : '1px solid var(--color-outline-variant)',
+            }}
+            data-testid={testId}
+            onClick={() => setOn(!on)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {sortedAMAlerts.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+          <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+          <h3 className="m-0 text-lg font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+            No alerts
+          </h3>
+          <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            No alerts matching current filters.
+          </p>
+        </div>
+      ) : (
+        <table className="w-full border-collapse" data-testid="am-alert-table">
+          <thead>
+            <tr>
+              {['Status', 'Alert', 'Severity', 'Started'].map((label, i) => (
+                <th
+                  key={label}
+                  className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase ${i === 3 ? 'text-right' : 'text-left'}`}
+                  style={{ color: 'var(--color-outline)' }}
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedAMAlerts.map(alert => {
+              const favoriteId = alert.fingerprint
+                ? `alert::${selectedDatasourceId}::${alert.fingerprint}`
+                : null
+              const favorited = favoriteId ? isFavorite(favoriteId) : false
+              const rowKey =
+                alert.fingerprint ||
+                `${alert.labels?.alertname ?? 'alert'}|${alert.startsAt}|${alert.status?.state ?? ''}`
+              return (
+                <tr key={rowKey} className="transition-colors hover:opacity-90">
+                  <td className="px-4 py-3">
+                    <StatusDot status={stateToStatusDot(alert.status?.state || '')} size={8} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+                        {alert.labels?.alertname || '--'}
+                      </span>
+                      {favoriteId ? (
+                        <button
+                          type="button"
+                          className="shrink-0 cursor-pointer border-none bg-transparent p-0.5"
+                          title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+                          onClick={() =>
+                            onToggleFavorite(favoriteId, alert.labels?.alertname || 'Alert')
+                          }
+                        >
+                          <Star
+                            size={12}
+                            fill={favorited ? 'currentColor' : 'none'}
+                            style={{
+                              color: favorited
+                                ? 'var(--color-primary)'
+                                : 'var(--color-outline)',
+                            }}
+                          />
+                        </button>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="font-mono text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                      {alert.labels?.severity || 'none'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <span className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
+                      {formatDateShort(alert.startsAt)}
+                    </span>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+type AMSilencesPanelProps = {
+  amSilences: AMSilence[]
+  onNewSilence: () => void
+  onExpireSilence: (id: string) => void
+}
+
+export function AMSilencesPanel({
+  amSilences,
+  onNewSilence,
+  onExpireSilence,
+}: AMSilencesPanelProps) {
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="m-0 text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+          Silences
+        </h3>
+        <button
+          type="button"
+          data-testid="alerts-new-silence-btn"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-3 py-1.5 text-sm font-medium transition"
+          style={{
+            background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+            color: '#fff',
+            border: 'none',
+          }}
+          onClick={onNewSilence}
+        >
+          <Plus size={14} aria-hidden />
+          New Silence
+        </button>
+      </div>
+
+      {amSilences.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+          <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+          <h3 className="m-0 text-lg font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+            No silences
+          </h3>
+          <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            No silence rules configured.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {amSilences.map(silence => (
+            <div
+              key={silence.id}
+              className="rounded-lg p-4"
+              style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+              data-testid="silence-card"
+            >
+              <div className="mb-2 flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span
+                    className="shrink-0 font-mono text-xs"
+                    style={{ color: 'var(--color-outline)' }}
+                    title={silence.id}
+                  >
+                    {truncateId(silence.id)}
+                  </span>
+                  <StatusDot
+                    status={
+                      silence.status.state === 'active'
+                        ? 'info'
+                        : silence.status.state === 'pending'
+                          ? 'warning'
+                          : 'healthy'
+                    }
+                    size={6}
+                  />
+                  <span
+                    className="text-xs font-semibold"
+                    style={{ color: 'var(--color-on-surface-variant)' }}
+                  >
+                    {silence.status.state}
+                  </span>
+                </div>
+                {silence.status.state === 'active' || silence.status.state === 'pending' ? (
+                  <button
+                    type="button"
+                    className="inline-flex shrink-0 cursor-pointer items-center gap-1 border-none bg-transparent text-sm transition"
+                    style={{ color: 'var(--color-error)' }}
+                    title="Expire silence"
+                    data-testid={`expire-silence-${silence.id}`}
+                    onClick={() => onExpireSilence(silence.id)}
+                  >
+                    <Trash2 size={12} aria-hidden />
+                    Expire
+                  </button>
+                ) : null}
+              </div>
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {silence.matchers.map(m => (
+                  <span
+                    key={`${m.name}${matcherOperator(m)}${m.value}`}
+                    className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container-high)',
+                      color: 'var(--color-on-surface-variant)',
+                    }}
+                  >
+                    {m.name}
+                    {matcherOperator(m)}&quot;{m.value}&quot;
+                  </span>
+                ))}
+              </div>
+              <div className="flex items-center gap-3 text-xs" style={{ color: 'var(--color-outline)' }}>
+                <span>{silence.createdBy}</span>
+                <span className="max-w-[200px] truncate">{silence.comment}</span>
+                <span className="ml-auto shrink-0 font-mono">
+                  ends {formatDateShort(silence.endsAt)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+type AMReceiversPanelProps = {
+  amReceivers: AMReceiver[]
+}
+
+export function AMReceiversPanel({ amReceivers }: AMReceiversPanelProps) {
+  if (amReceivers.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+        <Radio size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+        <h3 className="m-0 text-lg font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+          No receivers
+        </h3>
+        <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+          No receivers configured in AlertManager.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {amReceivers.map(receiver => (
+        <div
+          key={receiver.name}
+          className="flex items-center gap-3 rounded-lg p-4"
+          style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+          data-testid="receiver-card"
+        >
+          <Radio size={16} style={{ color: 'var(--color-outline)' }} className="shrink-0" aria-hidden />
+          <span className="text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+            {receiver.name}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+type AMConfigPanelProps = {
+  status: AMStatus | null
+  loading: boolean
+  error: string | null
+}
+
+export function AMConfigPanel({ status, loading, error }: AMConfigPanelProps) {
+  if (loading && !status) {
+    return (
+      <div className="py-8 text-center text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+        Loading Alertmanager configuration…
+      </div>
+    )
+  }
+
+  if (error && !status) {
+    return (
+      <div
+        className="rounded-sm px-4 py-3 text-sm"
+        style={{
+          backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+          color: 'var(--color-error)',
+        }}
+        data-testid="am-config-error"
+      >
+        {error}
+      </div>
+    )
+  }
+
+  if (!status) {
+    return (
+      <div className="py-8 text-center text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+        No configuration available.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="am-config-panel">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <MetaCard label="Cluster" value={status.cluster?.status || '—'} testId="am-cluster-status" />
+        <MetaCard
+          label="Version"
+          value={status.versionInfo?.version || '—'}
+          testId="am-version"
+        />
+        <MetaCard
+          label="Uptime since"
+          value={status.uptime ? formatDateShort(status.uptime) : '—'}
+          testId="am-uptime"
+        />
+      </div>
+
+      <div
+        className="rounded-sm px-3 py-2 text-xs leading-relaxed"
+        style={{
+          backgroundColor: 'var(--color-surface-container-low)',
+          color: 'var(--color-on-surface-variant)',
+          border: '1px solid var(--color-outline-variant)',
+        }}
+      >
+        Alertmanager configuration is read-only via the v2 API. Edit the Alertmanager config file
+        or configmap outside Ace, then reload Alertmanager to apply changes. Silences remain the
+        supported mutation path here.
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <span
+          className="text-xs font-semibold tracking-wider uppercase"
+          style={{ color: 'var(--color-outline)' }}
+        >
+          config.original
+        </span>
+        <pre
+          data-testid="am-config-yaml"
+          className="max-h-[480px] overflow-auto rounded-sm px-3 py-3 font-mono text-xs whitespace-pre-wrap"
+          style={{
+            backgroundColor: 'var(--color-surface-container-high)',
+            color: 'var(--color-on-surface)',
+          }}
+        >
+          {status.config?.original?.trim() || '# No configuration payload returned by Alertmanager'}
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+function MetaCard({
+  label,
+  value,
+  testId,
+}: {
+  label: string
+  value: string
+  testId: string
+}) {
+  return (
+    <div
+      className="rounded-lg p-3"
+      style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+      data-testid={testId}
+    >
+      <div className="text-xs" style={{ color: 'var(--color-outline)' }}>
+        {label}
+      </div>
+      <div className="mt-1 font-mono text-sm font-medium" style={{ color: 'var(--color-on-surface)' }}>
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/alerts/AlertRow.tsx
+++ b/frontend/src/components/alerts/AlertRow.tsx
@@ -1,0 +1,200 @@
+import { Star } from 'lucide-react'
+import { StatusDot } from '@/components/StatusDot'
+import { stateToStatusDot } from '@/lib/alerts'
+import type { VMAlertAlert } from '@/types/datasource'
+
+type AlertRowProps = {
+  alert: VMAlertAlert
+  expanded: boolean
+  favorited: boolean
+  onToggleExpand: () => void
+  onToggleFavorite: () => void
+}
+
+export function AlertRow({
+  alert,
+  expanded,
+  favorited,
+  onToggleExpand,
+  onToggleFavorite,
+}: AlertRowProps) {
+  return (
+    <>
+      {/* biome-ignore lint/a11y/useSemanticElements: expandable table row pattern */}
+      <tr
+        data-testid="alert-row"
+        className="cursor-pointer transition-colors"
+        style={{
+          backgroundColor: expanded ? 'var(--color-surface-container-high)' : 'transparent',
+        }}
+        onClick={onToggleExpand}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onToggleExpand()
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        <td className="px-4 py-3">
+          <StatusDot status={stateToStatusDot(alert.state)} size={8} />
+        </td>
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+              {alert.name}
+            </span>
+            <button
+              type="button"
+              className="shrink-0 cursor-pointer border-none bg-transparent p-0.5"
+              title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+              onClick={e => {
+                e.stopPropagation()
+                onToggleFavorite()
+              }}
+            >
+              <Star
+                size={12}
+                fill={favorited ? 'currentColor' : 'none'}
+                style={{
+                  color: favorited ? 'var(--color-primary)' : 'var(--color-outline)',
+                }}
+              />
+            </button>
+          </div>
+        </td>
+        <td className="px-4 py-3">
+          {alert.labels && Object.keys(alert.labels).length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {Object.entries(alert.labels).map(([key, value]) => (
+                <span
+                  key={key}
+                  className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                  style={{
+                    backgroundColor: 'var(--color-surface-container-high)',
+                    color: 'var(--color-on-surface-variant)',
+                  }}
+                >
+                  {key}={value}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </td>
+        <td className="px-4 py-3 text-right">
+          <span className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
+            {alert.activeAt || '--'}
+          </span>
+        </td>
+      </tr>
+      {expanded ? (
+        <tr data-testid="alert-detail">
+          <td
+            colSpan={4}
+            className="px-4 py-4"
+            style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+          >
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-3">
+                <span
+                  className="text-xs font-semibold tracking-wider uppercase"
+                  style={{ color: 'var(--color-outline)' }}
+                >
+                  State
+                </span>
+                <span
+                  className="rounded-sm px-2 py-0.5 font-mono text-xs font-semibold"
+                  style={{
+                    backgroundColor:
+                      alert.state === 'firing'
+                        ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                        : alert.state === 'pending'
+                          ? 'color-mix(in srgb, var(--color-tertiary) 15%, transparent)'
+                          : 'var(--color-surface-container-high)',
+                    color:
+                      alert.state === 'firing'
+                        ? 'var(--color-error)'
+                        : alert.state === 'pending'
+                          ? 'var(--color-tertiary)'
+                          : 'var(--color-on-surface-variant)',
+                  }}
+                >
+                  {alert.state}
+                </span>
+              </div>
+              {alert.labels && Object.keys(alert.labels).length > 0 ? (
+                <div>
+                  <span
+                    className="text-xs font-semibold tracking-wider uppercase"
+                    style={{ color: 'var(--color-outline)' }}
+                  >
+                    Labels
+                  </span>
+                  <div className="mt-1 flex flex-wrap gap-1.5">
+                    {Object.entries(alert.labels).map(([key, value]) => (
+                      <span
+                        key={key}
+                        className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                        style={{
+                          backgroundColor: 'var(--color-surface-container-high)',
+                          color: 'var(--color-on-surface-variant)',
+                        }}
+                      >
+                        {key}={value}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {alert.annotations && Object.keys(alert.annotations).length > 0 ? (
+                <div>
+                  <span
+                    className="text-xs font-semibold tracking-wider uppercase"
+                    style={{ color: 'var(--color-outline)' }}
+                  >
+                    Annotations
+                  </span>
+                  <div className="mt-1 flex flex-col gap-1">
+                    {Object.entries(alert.annotations).map(([key, value]) => (
+                      <div
+                        key={key}
+                        className="text-xs leading-relaxed"
+                        style={{ color: 'var(--color-outline)' }}
+                      >
+                        <strong style={{ color: 'var(--color-on-surface-variant)' }}>{key}:</strong>{' '}
+                        {value}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {alert.expression ? (
+                <div>
+                  <span
+                    className="text-xs font-semibold tracking-wider uppercase"
+                    style={{ color: 'var(--color-outline)' }}
+                  >
+                    Expression
+                  </span>
+                  <pre
+                    className="mt-1 overflow-x-auto rounded-sm px-3 py-2 font-mono text-xs whitespace-pre-wrap"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container-high)',
+                      color: 'var(--color-on-surface-variant)',
+                    }}
+                  >
+                    {alert.expression}
+                  </pre>
+                </div>
+              ) : null}
+              <div className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
+                Active since: {alert.activeAt || '--'}
+              </div>
+            </div>
+          </td>
+        </tr>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/alerts/RuleEditorPanel.tsx
+++ b/frontend/src/components/alerts/RuleEditorPanel.tsx
@@ -1,0 +1,251 @@
+import { Check, Copy, FileCode2, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { formatAlertDuration, ruleToYaml } from '@/lib/alerts'
+import type { VMAlertRule } from '@/types/datasource'
+
+type RuleEditorPanelProps = {
+  rule: VMAlertRule
+  groupName: string
+  onClose: () => void
+}
+
+/**
+ * Structured rule editor for VMAlert rules.
+ *
+ * VMAlert loads rules from files / configmaps and exposes only a read API.
+ * Ace therefore provides an editor for inspection, YAML export, and copy —
+ * mutations must be applied in the rule source of truth outside Ace.
+ */
+export function RuleEditorPanel({ rule, groupName, onClose }: RuleEditorPanelProps) {
+  const yaml = useMemo(() => ruleToYaml(rule, groupName), [rule, groupName])
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(yaml)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return createPortal(
+    // biome-ignore lint/a11y/noStaticElementInteractions: modal backdrop dismiss
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center p-4"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      data-testid="rule-editor-modal"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+      onKeyDown={e => {
+        if (e.key === 'Escape') onClose()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rule-editor-title"
+        className="max-h-[90vh] w-full max-w-[720px] overflow-y-auto rounded-lg"
+        style={{
+          backgroundColor: 'var(--color-surface-bright)',
+          border: '1px solid var(--color-outline-variant)',
+        }}
+      >
+        <div
+          className="flex items-center justify-between px-5 py-4"
+          style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <FileCode2 size={18} style={{ color: 'var(--color-primary)' }} aria-hidden />
+            <div className="min-w-0">
+              <h2
+                id="rule-editor-title"
+                className="m-0 truncate font-display text-base font-bold"
+                style={{ color: 'var(--color-on-surface)' }}
+              >
+                Rule editor — {rule.name}
+              </h2>
+              <p className="m-0 truncate text-xs" style={{ color: 'var(--color-outline)' }}>
+                Group: {groupName}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent transition"
+            style={{ color: 'var(--color-outline)' }}
+            onClick={onClose}
+            aria-label="Close rule editor"
+            data-testid="rule-editor-close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4 px-5 py-5">
+          <div
+            className="rounded-sm px-3 py-2 text-xs leading-relaxed"
+            style={{
+              backgroundColor: 'color-mix(in srgb, var(--color-tertiary) 10%, transparent)',
+              color: 'var(--color-on-surface-variant)',
+              border: '1px solid color-mix(in srgb, var(--color-tertiary) 25%, transparent)',
+            }}
+            data-testid="rule-editor-readonly-notice"
+          >
+            VMAlert rules are file-managed and Ace only has a read API for them. Use this editor to
+            inspect the live rule and export YAML; apply mutations in your rule source (configmap /
+            file) and reload VMAlert.
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Field label="Name" testId="rule-editor-name">
+              {rule.name}
+            </Field>
+            <Field label="Type" testId="rule-editor-type">
+              {rule.type || 'alerting'}
+            </Field>
+            <Field label="State" testId="rule-editor-state">
+              {rule.state || '—'}
+            </Field>
+            <Field label="For / duration" testId="rule-editor-duration">
+              {rule.duration > 0 ? formatAlertDuration(rule.duration) : '—'}
+            </Field>
+            {rule.health ? (
+              <Field label="Health" testId="rule-editor-health">
+                {rule.health}
+              </Field>
+            ) : null}
+            {rule.lastError ? (
+              <Field label="Last error" testId="rule-editor-last-error">
+                {rule.lastError}
+              </Field>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-semibold tracking-wider uppercase" style={{ color: 'var(--color-outline)' }}>
+              Expression
+            </span>
+            <pre
+              data-testid="rule-editor-query"
+              className="overflow-x-auto rounded-sm px-3 py-2 font-mono text-xs whitespace-pre-wrap"
+              style={{
+                backgroundColor: 'var(--color-surface-container-high)',
+                color: 'var(--color-on-surface)',
+              }}
+            >
+              {rule.query}
+            </pre>
+          </div>
+
+          {rule.labels && Object.keys(rule.labels).length > 0 ? (
+            <div className="flex flex-col gap-1.5">
+              <span
+                className="text-xs font-semibold tracking-wider uppercase"
+                style={{ color: 'var(--color-outline)' }}
+              >
+                Labels
+              </span>
+              <div className="flex flex-wrap gap-1.5" data-testid="rule-editor-labels">
+                {Object.entries(rule.labels).map(([key, value]) => (
+                  <span
+                    key={key}
+                    className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container-high)',
+                      color: 'var(--color-on-surface-variant)',
+                    }}
+                  >
+                    {key}={value}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {rule.annotations && Object.keys(rule.annotations).length > 0 ? (
+            <div className="flex flex-col gap-1.5">
+              <span
+                className="text-xs font-semibold tracking-wider uppercase"
+                style={{ color: 'var(--color-outline)' }}
+              >
+                Annotations
+              </span>
+              <div className="flex flex-col gap-1" data-testid="rule-editor-annotations">
+                {Object.entries(rule.annotations).map(([key, value]) => (
+                  <div key={key} className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    <strong>{key}:</strong> {value}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <span
+                className="text-xs font-semibold tracking-wider uppercase"
+                style={{ color: 'var(--color-outline)' }}
+              >
+                YAML export
+              </span>
+              <button
+                type="button"
+                data-testid="rule-editor-copy-yaml"
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs font-medium transition"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  color: 'var(--color-on-surface)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+                onClick={() => void handleCopy()}
+              >
+                {copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
+                {copied ? 'Copied' : 'Copy YAML'}
+              </button>
+            </div>
+            <pre
+              data-testid="rule-editor-yaml"
+              className="overflow-x-auto rounded-sm px-3 py-2 font-mono text-xs whitespace-pre-wrap"
+              style={{
+                backgroundColor: 'var(--color-surface-container-high)',
+                color: 'var(--color-on-surface-variant)',
+              }}
+            >
+              {yaml}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function Field({
+  label,
+  children,
+  testId,
+}: {
+  label: string
+  children: string
+  testId?: string
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-semibold tracking-wider uppercase" style={{ color: 'var(--color-outline)' }}>
+        {label}
+      </span>
+      <span
+        data-testid={testId}
+        className="font-mono text-sm"
+        style={{ color: 'var(--color-on-surface)' }}
+      >
+        {children}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/alerts/SilenceModal.tsx
+++ b/frontend/src/components/alerts/SilenceModal.tsx
@@ -1,0 +1,359 @@
+import { AlertCircle, Loader2, Plus, X } from 'lucide-react'
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { AMMatcher } from '@/types/datasource'
+
+export type SilenceFormState = {
+  matchers: Array<AMMatcher & { key: string }>
+  start: string
+  end: string
+  createdBy: string
+  comment: string
+}
+
+type SilenceModalProps = {
+  form: SilenceFormState
+  saving: boolean
+  error: string | null
+  onChange: (next: SilenceFormState) => void
+  onClose: () => void
+  onSubmit: () => void
+}
+
+export function SilenceModal({
+  form,
+  saving,
+  error,
+  onChange,
+  onClose,
+  onSubmit,
+}: SilenceModalProps) {
+  const [localError, setLocalError] = useState<string | null>(null)
+  const displayError = error || localError
+
+  function updateMatcher(key: string, patch: Partial<AMMatcher>) {
+    onChange({
+      ...form,
+      matchers: form.matchers.map(m => (m.key === key ? { ...m, ...patch } : m)),
+    })
+  }
+
+  function handleSubmit() {
+    setLocalError(null)
+    const validMatchers = form.matchers.filter(m => m.name.trim() !== '')
+    if (validMatchers.length === 0) {
+      setLocalError('At least one matcher is required')
+      return
+    }
+    if (!form.comment.trim()) {
+      setLocalError('Comment is required')
+      return
+    }
+    const startDate = new Date(form.start)
+    const endDate = new Date(form.end)
+    if (endDate <= startDate) {
+      setLocalError('End time must be after start time')
+      return
+    }
+    onSubmit()
+  }
+
+  return createPortal(
+    // biome-ignore lint/a11y/noStaticElementInteractions: modal backdrop dismiss
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+      onKeyDown={e => {
+        if (e.key === 'Escape') onClose()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="silence-modal-title"
+        className="max-h-[90vh] w-full max-w-[560px] overflow-y-auto rounded-lg"
+        style={{
+          backgroundColor: 'var(--color-surface-bright)',
+          border: '1px solid var(--color-outline-variant)',
+        }}
+      >
+        <div
+          className="flex items-center justify-between px-5 py-4"
+          style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
+        >
+          <h2
+            id="silence-modal-title"
+            className="m-0 font-display text-base font-bold"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            Create Silence
+          </h2>
+          <button
+            type="button"
+            className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent transition"
+            style={{ color: 'var(--color-outline)' }}
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4 px-5 py-5">
+          <div className="flex flex-col gap-1.5">
+            <div className="text-sm font-medium" style={{ color: 'var(--color-on-surface-variant)' }}>
+              Matchers <span style={{ color: 'var(--color-error)' }}>*</span>
+            </div>
+            <div className="mb-2 flex flex-col gap-2">
+              {form.matchers.map((m, idx) => (
+                <div key={m.key} className="flex items-center gap-2">
+                  <input
+                    value={m.name}
+                    onChange={e => updateMatcher(m.key, { name: e.target.value })}
+                    type="text"
+                    placeholder="Label name"
+                    data-testid={`silence-matcher-name-${idx}`}
+                    className="flex-1 rounded-sm px-2.5 py-1.5 font-mono text-sm focus:outline-none"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container-high)',
+                      color: 'var(--color-on-surface)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                  />
+                  <select
+                    value={m.isEqual ? 'eq' : 'neq'}
+                    onChange={e => updateMatcher(m.key, { isEqual: e.target.value === 'eq' })}
+                    className="w-13 rounded-sm px-1.5 py-1.5 text-center font-mono text-sm focus:outline-none"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container-high)',
+                      color: 'var(--color-on-surface)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                  >
+                    <option value="eq">{m.isRegex ? '=~' : '='}</option>
+                    <option value="neq">{m.isRegex ? '!~' : '!='}</option>
+                  </select>
+                  <input
+                    value={m.value}
+                    onChange={e => updateMatcher(m.key, { value: e.target.value })}
+                    type="text"
+                    placeholder="Value"
+                    data-testid={`silence-matcher-value-${idx}`}
+                    className="flex-1 rounded-sm px-2.5 py-1.5 font-mono text-sm focus:outline-none"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container-high)',
+                      color: 'var(--color-on-surface)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                  />
+                  <label
+                    className="flex cursor-pointer items-center gap-1 text-xs whitespace-nowrap"
+                    style={{ color: 'var(--color-outline)' }}
+                    title="Regex match"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={m.isRegex}
+                      onChange={e => updateMatcher(m.key, { isRegex: e.target.checked })}
+                      className="h-3.5 w-3.5"
+                    />
+                    Regex
+                  </label>
+                  <button
+                    type="button"
+                    className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent transition disabled:cursor-not-allowed disabled:opacity-40"
+                    style={{ color: 'var(--color-outline)' }}
+                    disabled={form.matchers.length <= 1}
+                    onClick={() => {
+                      if (form.matchers.length > 1) {
+                        onChange({
+                          ...form,
+                          matchers: form.matchers.filter(item => item.key !== m.key),
+                        })
+                      }
+                    }}
+                    title="Remove matcher"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="inline-flex cursor-pointer items-center gap-1 self-start border-none bg-transparent text-sm transition"
+              style={{ color: 'var(--color-primary)' }}
+              onClick={() =>
+                onChange({
+                  ...form,
+                  matchers: [
+                    ...form.matchers,
+                    {
+                      key: `matcher-${Date.now()}-${form.matchers.length}`,
+                      name: '',
+                      value: '',
+                      isRegex: false,
+                      isEqual: true,
+                    },
+                  ],
+                })
+              }
+            >
+              <Plus size={12} aria-hidden />
+              Add Matcher
+            </button>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="silence-start"
+                className="text-sm font-medium"
+                style={{ color: 'var(--color-on-surface-variant)' }}
+              >
+                Start
+              </label>
+              <input
+                id="silence-start"
+                data-testid="silence-start-input"
+                value={form.start}
+                onChange={e => onChange({ ...form, start: e.target.value })}
+                type="datetime-local"
+                className="rounded-sm px-3 py-2 text-sm focus:outline-none"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  color: 'var(--color-on-surface)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="silence-end"
+                className="text-sm font-medium"
+                style={{ color: 'var(--color-on-surface-variant)' }}
+              >
+                End
+              </label>
+              <input
+                id="silence-end"
+                data-testid="silence-end-input"
+                value={form.end}
+                onChange={e => onChange({ ...form, end: e.target.value })}
+                type="datetime-local"
+                className="rounded-sm px-3 py-2 text-sm focus:outline-none"
+                style={{
+                  backgroundColor: 'var(--color-surface-container-high)',
+                  color: 'var(--color-on-surface)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="silence-created-by"
+              className="text-sm font-medium"
+              style={{ color: 'var(--color-on-surface-variant)' }}
+            >
+              Created By
+            </label>
+            <input
+              id="silence-created-by"
+              data-testid="silence-created-by-input"
+              value={form.createdBy}
+              onChange={e => onChange({ ...form, createdBy: e.target.value })}
+              type="text"
+              placeholder="your-name@example.com"
+              className="rounded-sm px-3 py-2 text-sm focus:outline-none"
+              style={{
+                backgroundColor: 'var(--color-surface-container-high)',
+                color: 'var(--color-on-surface)',
+                border: '1px solid var(--color-outline-variant)',
+              }}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="silence-comment"
+              className="text-sm font-medium"
+              style={{ color: 'var(--color-on-surface-variant)' }}
+            >
+              Comment <span style={{ color: 'var(--color-error)' }}>*</span>
+            </label>
+            <textarea
+              id="silence-comment"
+              data-testid="silence-comment-input"
+              value={form.comment}
+              onChange={e => onChange({ ...form, comment: e.target.value })}
+              rows={3}
+              placeholder="Reason for silencing..."
+              className="min-h-[68px] resize-y rounded-sm px-3 py-2 text-sm focus:outline-none"
+              style={{
+                backgroundColor: 'var(--color-surface-container-high)',
+                color: 'var(--color-on-surface)',
+                border: '1px solid var(--color-outline-variant)',
+                fontFamily: 'inherit',
+              }}
+            />
+          </div>
+
+          {displayError ? (
+            <div
+              className="flex items-center gap-2 rounded-sm px-4 py-3 text-sm"
+              style={{
+                backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+                color: 'var(--color-error)',
+              }}
+              data-testid="silence-error"
+            >
+              <AlertCircle size={14} aria-hidden />
+              {displayError}
+            </div>
+          ) : null}
+        </div>
+
+        <div
+          className="flex justify-end gap-2.5 px-5 py-4"
+          style={{ borderTop: '1px solid var(--color-outline-variant)' }}
+        >
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-3 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface-variant)',
+              border: '1px solid var(--color-outline-variant)',
+            }}
+            data-testid="silence-cancel-btn"
+            onClick={onClose}
+            disabled={saving}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              background: 'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+              color: '#fff',
+              border: 'none',
+            }}
+            data-testid="silence-create-btn"
+            onClick={handleSubmit}
+            disabled={saving}
+          >
+            {saving ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
+            {saving ? 'Creating...' : 'Create Silence'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/components/alerts/VMAlertPanels.tsx
+++ b/frontend/src/components/alerts/VMAlertPanels.tsx
@@ -1,0 +1,275 @@
+import { BellOff, ChevronDown, ChevronRight, FileCode2 } from 'lucide-react'
+import { AiAlertTriage } from '@/components/AiAlertTriage'
+import { AlertRow } from '@/components/alerts/AlertRow'
+import { formatAlertDuration, formatAlertInterval } from '@/lib/alerts'
+import type { VMAlertAlert, VMAlertRule, VMAlertRuleGroup } from '@/types/datasource'
+
+type VMAlertAlertsPanelProps = {
+  sortedAlerts: VMAlertAlert[]
+  firingAlerts: VMAlertAlert[]
+  expandedAlertIdx: number | null
+  selectedDatasourceId: string
+  isFavorite: (id: string) => boolean
+  onToggleExpand: (idx: number) => void
+  onToggleFavorite: (id: string, title: string) => void
+}
+
+export function VMAlertAlertsPanel({
+  sortedAlerts,
+  firingAlerts,
+  expandedAlertIdx,
+  selectedDatasourceId,
+  isFavorite,
+  onToggleExpand,
+  onToggleFavorite,
+}: VMAlertAlertsPanelProps) {
+  return (
+    <div>
+      {firingAlerts.length > 0 ? (
+        <AiAlertTriage
+          alertCount={firingAlerts.length}
+          alertNames={firingAlerts
+            .map(a => a.name)
+            .filter((v, i, arr) => arr.indexOf(v) === i)
+            .slice(0, 5)}
+          className="mb-4"
+        />
+      ) : null}
+
+      {sortedAlerts.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+          <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+          <h3 className="m-0 text-lg font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+            No alerts firing
+          </h3>
+          <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            All quiet -- no active or pending alerts.
+          </p>
+        </div>
+      ) : (
+        <table className="w-full border-collapse" data-testid="alert-table">
+          <thead data-testid="alert-table-header">
+            <tr>
+              {['Status', 'Alert', 'Labels', 'Active Since'].map((label, i) => (
+                <th
+                  key={label}
+                  className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase ${i === 3 ? 'text-right' : 'text-left'}`}
+                  style={{ color: 'var(--color-outline)' }}
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedAlerts.map((alert, idx) => {
+              const favoriteId = `alert::${selectedDatasourceId}::${alert.name}`
+              const favorited = isFavorite(favoriteId)
+              const rowKey = `${alert.name}|${alert.state}|${alert.activeAt}|${JSON.stringify(alert.labels ?? {})}`
+              return (
+                <AlertRow
+                  key={rowKey}
+                  alert={alert}
+                  expanded={expandedAlertIdx === idx}
+                  favorited={favorited}
+                  onToggleExpand={() => onToggleExpand(idx)}
+                  onToggleFavorite={() => onToggleFavorite(favoriteId, alert.name)}
+                />
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+type VMAlertGroupsPanelProps = {
+  groups: VMAlertRuleGroup[]
+  expandedGroups: Record<string, boolean>
+  onToggleGroup: (groupName: string) => void
+  onOpenRuleEditor: (rule: VMAlertRule, groupName: string) => void
+}
+
+export function VMAlertGroupsPanel({
+  groups,
+  expandedGroups,
+  onToggleGroup,
+  onOpenRuleEditor,
+}: VMAlertGroupsPanelProps) {
+  if (groups.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+        <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+        <h3 className="m-0 text-lg font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+          No rule groups
+        </h3>
+        <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+          No alerting or recording rule groups found.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {groups.map(group => {
+        const expanded = !!expandedGroups[group.name]
+        return (
+          <div
+            key={group.name}
+            className="overflow-hidden rounded-lg"
+            style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+            data-testid="rule-group"
+          >
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-center justify-between border-none bg-transparent px-4 py-3 text-left transition hover:opacity-90"
+              onClick={() => onToggleGroup(group.name)}
+            >
+              <div className="flex items-center gap-2">
+                {expanded ? (
+                  <ChevronDown size={16} style={{ color: 'var(--color-outline)' }} />
+                ) : (
+                  <ChevronRight size={16} style={{ color: 'var(--color-outline)' }} />
+                )}
+                <span className="text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+                  {group.name}
+                </span>
+              </div>
+              <span className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
+                {group.rules.length} rule{group.rules.length !== 1 ? 's' : ''} · every{' '}
+                {formatAlertInterval(group.interval)}
+              </span>
+            </button>
+
+            {expanded ? (
+              <div className="px-4 py-3" style={{ borderTop: '1px solid var(--color-outline-variant)' }}>
+                <div className="flex flex-col">
+                  {group.rules.map((rule, rIdx) => (
+                    <div
+                      key={`${group.name}:${rule.name}:${rule.type}:${rule.query}:${rule.duration}`}
+                      className="py-3"
+                      style={
+                        rIdx > 0 ? { borderTop: '1px solid var(--color-outline-variant)' } : undefined
+                      }
+                      data-testid="rule-item"
+                    >
+                      <div className="mb-2 flex flex-wrap items-center gap-2">
+                        <span
+                          className="text-sm font-semibold"
+                          style={{ color: 'var(--color-on-surface)' }}
+                        >
+                          {rule.name}
+                        </span>
+                        <span
+                          className="rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase"
+                          style={{
+                            backgroundColor:
+                              rule.type === 'alerting'
+                                ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                                : 'color-mix(in srgb, var(--color-primary) 15%, transparent)',
+                            color:
+                              rule.type === 'alerting'
+                                ? 'var(--color-error)'
+                                : 'var(--color-primary)',
+                          }}
+                        >
+                          {rule.type}
+                        </span>
+                        {rule.state ? (
+                          <span
+                            className="rounded-sm px-2 py-0.5 text-xs font-semibold"
+                            style={{
+                              backgroundColor:
+                                rule.state === 'firing'
+                                  ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                                  : rule.state === 'pending'
+                                    ? 'color-mix(in srgb, var(--color-tertiary) 15%, transparent)'
+                                    : 'var(--color-surface-container-high)',
+                              color:
+                                rule.state === 'firing'
+                                  ? 'var(--color-error)'
+                                  : rule.state === 'pending'
+                                    ? 'var(--color-tertiary)'
+                                    : 'var(--color-on-surface-variant)',
+                            }}
+                          >
+                            {rule.state}
+                          </span>
+                        ) : null}
+                        <button
+                          type="button"
+                          data-testid={`open-rule-editor-${rule.name}`}
+                          className="ml-auto inline-flex cursor-pointer items-center gap-1 rounded-sm px-2 py-1 text-xs font-medium transition"
+                          style={{
+                            backgroundColor: 'var(--color-surface-container-high)',
+                            color: 'var(--color-primary)',
+                            border: '1px solid var(--color-outline-variant)',
+                          }}
+                          onClick={() => onOpenRuleEditor(rule, group.name)}
+                        >
+                          <FileCode2 size={12} aria-hidden />
+                          Open editor
+                        </button>
+                      </div>
+                      <div
+                        className="mb-2 overflow-x-auto rounded-sm px-3 py-2"
+                        style={{ backgroundColor: 'var(--color-surface-container-high)' }}
+                      >
+                        <code
+                          className="font-mono text-xs break-all whitespace-pre-wrap"
+                          style={{ color: 'var(--color-on-surface-variant)' }}
+                        >
+                          {rule.query}
+                        </code>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {rule.duration > 0 ? (
+                          <span className="mr-1 text-xs" style={{ color: 'var(--color-outline)' }}>
+                            <strong>for:</strong> {formatAlertDuration(rule.duration)}
+                          </span>
+                        ) : null}
+                        {Object.entries(rule.labels ?? {}).map(([key, value]) => (
+                          <span
+                            key={key}
+                            className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                            style={{
+                              backgroundColor: 'var(--color-surface-container-high)',
+                              color: 'var(--color-on-surface-variant)',
+                            }}
+                          >
+                            {key}={value}
+                          </span>
+                        ))}
+                      </div>
+                      {rule.annotations && Object.keys(rule.annotations).length > 0 ? (
+                        <div
+                          className="mt-2 pt-2"
+                          style={{ borderTop: '1px solid var(--color-outline-variant)' }}
+                        >
+                          {Object.entries(rule.annotations).map(([key, value]) => (
+                            <div
+                              key={key}
+                              className="text-xs leading-relaxed"
+                              style={{ color: 'var(--color-outline)' }}
+                            >
+                              <strong style={{ color: 'var(--color-on-surface-variant)' }}>
+                                {key}:
+                              </strong>{' '}
+                              {value}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAlertingDatasources.ts
+++ b/frontend/src/hooks/useAlertingDatasources.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { useDatasources } from '@/hooks/useDatasources'
+import { isAlertingType } from '@/types/datasource'
+
+export function useAlertingDatasources(orgId: string | null) {
+  const query = useDatasources(orgId)
+
+  const alertingDatasources = useMemo(
+    () => (query.data ?? []).filter(ds => isAlertingType(ds.type)),
+    [query.data],
+  )
+
+  return {
+    ...query,
+    alertingDatasources,
+  }
+}

--- a/frontend/src/lib/alerts.spec.ts
+++ b/frontend/src/lib/alerts.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatAlertDuration,
+  matcherOperator,
+  ruleToYaml,
+  stateToStatusDot,
+} from '@/lib/alerts'
+import type { VMAlertRule } from '@/types/datasource'
+
+describe('alerts helpers', () => {
+  it('maps alert states to status dots', () => {
+    expect(stateToStatusDot('firing')).toBe('critical')
+    expect(stateToStatusDot('pending')).toBe('warning')
+    expect(stateToStatusDot('inactive')).toBe('healthy')
+  })
+
+  it('formats durations and matcher operators', () => {
+    expect(formatAlertDuration(45)).toBe('45s')
+    expect(formatAlertDuration(120)).toBe('2m')
+    expect(matcherOperator({ name: 'a', value: 'b', isEqual: true, isRegex: false })).toBe('=')
+    expect(matcherOperator({ name: 'a', value: 'b', isEqual: false, isRegex: true })).toBe('!~')
+  })
+
+  it('serializes rules to YAML', () => {
+    const rule: VMAlertRule = {
+      name: 'HighCPU',
+      type: 'alerting',
+      state: 'firing',
+      query: 'cpu > 0.9',
+      duration: 60,
+      labels: { severity: 'critical' },
+      annotations: { summary: 'CPU high' },
+    }
+    const yaml = ruleToYaml(rule, 'node.rules')
+    expect(yaml).toContain('# group: node.rules')
+    expect(yaml).toContain('- alert: HighCPU')
+    expect(yaml).toContain('expr: cpu > 0.9')
+    expect(yaml).toContain('for: 1m')
+    expect(yaml).toContain('severity: "critical"')
+  })
+})

--- a/frontend/src/lib/alerts.ts
+++ b/frontend/src/lib/alerts.ts
@@ -1,0 +1,84 @@
+import type { AMMatcher, VMAlertRule } from '@/types/datasource'
+
+export type AlertStatusDot = 'healthy' | 'warning' | 'critical' | 'info'
+
+export function stateToStatusDot(state: string): AlertStatusDot {
+  switch (state) {
+    case 'firing':
+    case 'active':
+      return 'critical'
+    case 'pending':
+    case 'suppressed':
+      return 'warning'
+    default:
+      return 'healthy'
+  }
+}
+
+export function formatAlertDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
+}
+
+export function formatAlertInterval(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  return `${Math.floor(seconds / 60)}m`
+}
+
+export function truncateId(id: string): string {
+  return id.length > 8 ? `${id.substring(0, 8)}...` : id
+}
+
+export function formatDateShort(dateStr: string): string {
+  if (!dateStr) return '--'
+  const d = new Date(dateStr)
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function toLocalDatetimeString(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+export function matcherOperator(m: AMMatcher): string {
+  if (m.isEqual) return m.isRegex ? '=~' : '='
+  return m.isRegex ? '!~' : '!='
+}
+
+/** Serialize a VMAlert rule into Prometheus-style YAML for copy/export. */
+export function ruleToYaml(rule: VMAlertRule, groupName?: string): string {
+  const lines: string[] = []
+  if (groupName) {
+    lines.push(`# group: ${groupName}`)
+  }
+  if (rule.type === 'recording') {
+    lines.push(`- record: ${rule.name}`)
+  } else {
+    lines.push(`- alert: ${rule.name}`)
+  }
+  lines.push(`  expr: ${rule.query}`)
+  if (rule.duration > 0 && rule.type !== 'recording') {
+    lines.push(`  for: ${formatAlertDuration(rule.duration)}`)
+  }
+  const labels = Object.entries(rule.labels ?? {})
+  if (labels.length > 0) {
+    lines.push('  labels:')
+    for (const [key, value] of labels) {
+      lines.push(`    ${key}: ${JSON.stringify(value)}`)
+    }
+  }
+  const annotations = Object.entries(rule.annotations ?? {})
+  if (annotations.length > 0) {
+    lines.push('  annotations:')
+    for (const [key, value] of annotations) {
+      lines.push(`    ${key}: ${JSON.stringify(value)}`)
+    }
+  }
+  return lines.join('\n')
+}

--- a/frontend/src/lib/serviceHealth.spec.ts
+++ b/frontend/src/lib/serviceHealth.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveServiceHealth,
+  formatErrorRate,
+  formatLatencyMs,
+  healthLabel,
+} from '@/lib/serviceHealth'
+import type { TraceSummary } from '@/types/datasource'
+
+function summary(overrides: Partial<TraceSummary> = {}): TraceSummary {
+  return {
+    traceId: 't1',
+    startTimeUnixNano: 0,
+    durationNano: 10_000_000,
+    spanCount: 3,
+    serviceCount: 1,
+    errorSpanCount: 0,
+    ...overrides,
+  }
+}
+
+describe('deriveServiceHealth', () => {
+  it('returns unknown when there are no samples', () => {
+    expect(deriveServiceHealth([])).toEqual({
+      sampleCount: 0,
+      errorRate: null,
+      latencyP50Ms: null,
+      latencyP95Ms: null,
+      health: 'unknown',
+    })
+  })
+
+  it('computes latency percentiles and healthy status', () => {
+    const metrics = deriveServiceHealth([
+      summary({ durationNano: 10_000_000 }),
+      summary({ durationNano: 20_000_000 }),
+      summary({ durationNano: 30_000_000 }),
+      summary({ durationNano: 40_000_000 }),
+    ])
+    expect(metrics.sampleCount).toBe(4)
+    expect(metrics.errorRate).toBe(0)
+    expect(metrics.latencyP50Ms).toBe(25)
+    expect(metrics.health).toBe('healthy')
+  })
+
+  it('marks critical when error rate is high', () => {
+    const metrics = deriveServiceHealth([
+      summary({ errorSpanCount: 1 }),
+      summary({ errorSpanCount: 1 }),
+      summary({ errorSpanCount: 0 }),
+      summary({ errorSpanCount: 1 }),
+    ])
+    expect(metrics.errorRate).toBe(0.75)
+    expect(metrics.health).toBe('critical')
+  })
+})
+
+describe('format helpers', () => {
+  it('formats latency and error rate', () => {
+    expect(formatLatencyMs(null)).toBe('—')
+    expect(formatLatencyMs(0.5)).toBe('500µs')
+    expect(formatLatencyMs(12.3)).toBe('12ms')
+    expect(formatLatencyMs(1500)).toBe('1.50s')
+    expect(formatErrorRate(null)).toBe('—')
+    expect(formatErrorRate(0.125)).toBe('12.5%')
+    expect(healthLabel('warning')).toBe('Degraded')
+  })
+})

--- a/frontend/src/lib/serviceHealth.ts
+++ b/frontend/src/lib/serviceHealth.ts
@@ -1,0 +1,90 @@
+import type { TraceSummary } from '@/types/datasource'
+
+export type ServiceHealthStatus = 'healthy' | 'warning' | 'critical' | 'info' | 'unknown'
+
+export interface ServiceHealthMetrics {
+  sampleCount: number
+  errorRate: number | null
+  latencyP50Ms: number | null
+  latencyP95Ms: number | null
+  health: ServiceHealthStatus
+}
+
+function percentile(sorted: number[], p: number): number | null {
+  if (sorted.length === 0) return null
+  if (sorted.length === 1) return sorted[0]!
+  const index = (sorted.length - 1) * p
+  const lower = Math.floor(index)
+  const upper = Math.ceil(index)
+  if (lower === upper) return sorted[lower]!
+  const weight = index - lower
+  return sorted[lower]! * (1 - weight) + sorted[upper]! * weight
+}
+
+/**
+ * Derive health / latency / error-rate views from recent trace summaries for a service.
+ * Uses real telemetry only — never fabricates sample values.
+ */
+export function deriveServiceHealth(summaries: TraceSummary[]): ServiceHealthMetrics {
+  if (summaries.length === 0) {
+    return {
+      sampleCount: 0,
+      errorRate: null,
+      latencyP50Ms: null,
+      latencyP95Ms: null,
+      health: 'unknown',
+    }
+  }
+
+  const durationsMs = summaries
+    .map(s => s.durationNano / 1_000_000)
+    .filter(v => Number.isFinite(v) && v >= 0)
+    .sort((a, b) => a - b)
+
+  const errorTraces = summaries.filter(s => (s.errorSpanCount ?? 0) > 0).length
+  const errorRate = errorTraces / summaries.length
+  const latencyP50Ms = percentile(durationsMs, 0.5)
+  const latencyP95Ms = percentile(durationsMs, 0.95)
+
+  let health: ServiceHealthStatus = 'healthy'
+  if (errorRate >= 0.25 || (latencyP95Ms !== null && latencyP95Ms >= 5000)) {
+    health = 'critical'
+  } else if (errorRate >= 0.05 || (latencyP95Ms !== null && latencyP95Ms >= 1000)) {
+    health = 'warning'
+  }
+
+  return {
+    sampleCount: summaries.length,
+    errorRate,
+    latencyP50Ms,
+    latencyP95Ms,
+    health,
+  }
+}
+
+export function formatLatencyMs(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms)) return '—'
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}µs`
+  if (ms < 1000) return `${ms.toFixed(ms < 10 ? 1 : 0)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+export function formatErrorRate(rate: number | null): string {
+  if (rate === null || !Number.isFinite(rate)) return '—'
+  return `${(rate * 100).toFixed(rate < 0.01 ? 2 : 1)}%`
+}
+
+export function healthLabel(status: ServiceHealthStatus): string {
+  switch (status) {
+    case 'healthy':
+      return 'Healthy'
+    case 'warning':
+      return 'Degraded'
+    case 'critical':
+      return 'Critical'
+    case 'info':
+      return 'Info'
+    default:
+      return 'Not evaluated'
+  }
+}

--- a/frontend/src/pages/AlertsPage.spec.tsx
+++ b/frontend/src/pages/AlertsPage.spec.tsx
@@ -1,0 +1,313 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as alertmanagerApi from '@/api/alertmanager'
+import * as datasourcesApi from '@/api/datasources'
+import * as vmalertApi from '@/api/vmalert'
+import { AlertsPage } from '@/pages/AlertsPage'
+import { useAuthStore } from '@/stores/authStore'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+import type { AMSilence, DataSource, VMAlertAlert, VMAlertRuleGroup } from '@/types/datasource'
+
+vi.mock('@/analytics', () => ({
+  identifyUser: vi.fn(),
+  resetUserAnalytics: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+const vmalertDatasource: DataSource = {
+  id: 'ds-1',
+  organization_id: 'org-1',
+  name: 'VMAlert',
+  type: 'vmalert',
+  url: 'http://vmalert:8880',
+  is_default: true,
+  auth_type: 'none',
+  trace_id_field: 'trace_id',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const alertmanagerDatasource: DataSource = {
+  id: 'ds-am',
+  organization_id: 'org-1',
+  name: 'AlertManager',
+  type: 'alertmanager',
+  url: 'http://alertmanager:9093',
+  is_default: false,
+  auth_type: 'none',
+  trace_id_field: 'trace_id',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const mockAlerts: VMAlertAlert[] = [
+  {
+    name: 'HighCPU',
+    state: 'firing',
+    labels: { severity: 'critical' },
+    annotations: {},
+    value: '1',
+    activeAt: '2026-03-22T10:00:00Z',
+  },
+  {
+    name: 'DiskFull',
+    state: 'pending',
+    labels: { severity: 'warning' },
+    annotations: {},
+    value: '1',
+    activeAt: '2026-03-22T09:30:00Z',
+  },
+  {
+    name: 'MemoryOK',
+    state: 'inactive',
+    labels: {},
+    annotations: {},
+    value: '0',
+    activeAt: '',
+  },
+]
+
+const mockGroups: VMAlertRuleGroup[] = [
+  {
+    name: 'node.rules',
+    file: 'node.yml',
+    interval: 30,
+    rules: [
+      {
+        name: 'HighCPU',
+        type: 'alerting',
+        state: 'firing',
+        query: 'cpu > 0.9',
+        duration: 60,
+        labels: { severity: 'critical' },
+        annotations: { summary: 'CPU high' },
+      },
+    ],
+  },
+]
+
+function renderAlerts() {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [{ path: '/app/alerts', element: <AlertsPage /> }],
+    { initialEntries: ['/app/alerts'] },
+  )
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  return router
+}
+
+describe('AlertsPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    useOrgStore.setState({ currentOrgId: 'org-1' })
+    useFavoritesStore.setState({ favorites: [], recentDashboards: [] })
+    useAuthStore.setState({
+      user: {
+        id: 'u-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      userOrganizations: [],
+      loading: false,
+      initialized: true,
+      isAuthenticated: true,
+    })
+
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([vmalertDatasource])
+    vi.spyOn(vmalertApi, 'fetchVMAlerts').mockResolvedValue({
+      status: 'success',
+      data: { alerts: mockAlerts },
+    })
+    vi.spyOn(vmalertApi, 'fetchVMAlertGroups').mockResolvedValue({
+      status: 'success',
+      data: { groups: mockGroups },
+    })
+    vi.spyOn(alertmanagerApi, 'fetchAlertManagerAlerts').mockResolvedValue([])
+    vi.spyOn(alertmanagerApi, 'fetchSilences').mockResolvedValue([])
+    vi.spyOn(alertmanagerApi, 'fetchReceivers').mockResolvedValue([])
+    vi.spyOn(alertmanagerApi, 'createSilence').mockResolvedValue('silence-1')
+    vi.spyOn(alertmanagerApi, 'expireSilence').mockResolvedValue()
+  })
+
+  it('renders table header with expected columns', async () => {
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-table-header')).toBeTruthy()
+    })
+
+    const headers = screen.getByTestId('alert-table-header').querySelectorAll('th')
+    expect(headers.length).toBeGreaterThanOrEqual(4)
+    const headerTexts = Array.from(headers).map(h => h.textContent?.toLowerCase() ?? '')
+    expect(headerTexts).toContain('status')
+    expect(headerTexts).toContain('alert')
+  })
+
+  it('renders alert rows from fetched data', async () => {
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('alert-row')).toHaveLength(3)
+    })
+
+    expect(screen.getByText('HighCPU')).toBeTruthy()
+    expect(screen.getByText('DiskFull')).toBeTruthy()
+    expect(screen.getByText('MemoryOK')).toBeTruthy()
+  })
+
+  it('renders StatusDot per alert row', async () => {
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('alert-row')).toHaveLength(3)
+    })
+
+    const dots = screen.getAllByTestId('status-dot')
+    expect(dots.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('expands a row on click to show detail', async () => {
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('alert-row')).toHaveLength(3)
+    })
+
+    fireEvent.click(screen.getAllByTestId('alert-row')[0]!)
+    expect(screen.getByTestId('alert-detail')).toBeTruthy()
+    expect(within(screen.getByTestId('alert-detail')).getByText('firing')).toBeTruthy()
+  })
+
+  it('renders AI alert triage when firing alerts exist', async () => {
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-alert-triage')).toBeTruthy()
+    })
+
+    expect(screen.getByText(/1 alert firing/i)).toBeTruthy()
+  })
+
+  it('shows rule groups and expands rule editor details', async () => {
+    const user = userEvent.setup()
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alerts-tab-groups')).toBeTruthy()
+    })
+
+    await user.click(screen.getByTestId('alerts-tab-groups'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rule-group')).toBeTruthy()
+    })
+
+    expect(screen.getByText('node.rules')).toBeTruthy()
+    await user.click(screen.getByText('node.rules'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rule-item')).toBeTruthy()
+    })
+
+    expect(screen.getByText('cpu > 0.9')).toBeTruthy()
+    expect(screen.getByText('alerting')).toBeTruthy()
+  })
+
+  it('creates and expires Alertmanager silences with mocked API', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([alertmanagerDatasource])
+
+    const silences: AMSilence[] = []
+    vi.spyOn(alertmanagerApi, 'fetchSilences').mockImplementation(async () => [...silences])
+    vi.spyOn(alertmanagerApi, 'createSilence').mockImplementation(async (_id, silence) => {
+      silences.push({
+        id: 'silence-1',
+        matchers: silence.matchers,
+        startsAt: silence.startsAt,
+        endsAt: silence.endsAt,
+        createdBy: silence.createdBy,
+        comment: silence.comment,
+        status: { state: 'active' },
+        updatedAt: new Date().toISOString(),
+      })
+      return 'silence-1'
+    })
+    vi.spyOn(alertmanagerApi, 'expireSilence').mockImplementation(async () => {
+      const idx = silences.findIndex(s => s.id === 'silence-1')
+      if (idx >= 0) silences[idx] = { ...silences[idx]!, status: { state: 'expired' } }
+    })
+
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alerts-tab-am-silences')).toBeTruthy()
+    })
+
+    await user.click(screen.getByTestId('alerts-tab-am-silences'))
+    await user.click(screen.getByTestId('alerts-new-silence-btn'))
+
+    expect(screen.getByRole('dialog', { name: /create silence/i })).toBeTruthy()
+
+    await user.type(screen.getByTestId('silence-matcher-name-0'), 'alertname')
+    await user.type(screen.getByTestId('silence-matcher-value-0'), 'HighCPU')
+    await user.type(screen.getByTestId('silence-comment-input'), 'Investigating spike')
+    await user.click(screen.getByTestId('silence-create-btn'))
+
+    await waitFor(() => {
+      expect(alertmanagerApi.createSilence).toHaveBeenCalledWith(
+        'ds-am',
+        expect.objectContaining({
+          comment: 'Investigating spike',
+          createdBy: 'test@example.com',
+          matchers: [
+            expect.objectContaining({
+              name: 'alertname',
+              value: 'HighCPU',
+              isEqual: true,
+              isRegex: false,
+            }),
+          ],
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('silence-card')).toBeTruthy()
+    })
+
+    expect(screen.getByText('Investigating spike')).toBeTruthy()
+    await user.click(screen.getByTestId('expire-silence-silence-1'))
+
+    await waitFor(() => {
+      expect(alertmanagerApi.expireSilence).toHaveBeenCalledWith('ds-am', 'silence-1')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('expired')).toBeTruthy()
+    })
+  })
+
+  it('shows empty state when no alerting datasources are configured', async () => {
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([])
+
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getByText('No alerting datasources configured')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/pages/AlertsPage.spec.tsx
+++ b/frontend/src/pages/AlertsPage.spec.tsx
@@ -11,7 +11,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { useFavoritesStore } from '@/stores/favoritesStore'
 import { useOrgStore } from '@/stores/orgStore'
 import { createTestQueryClient } from '@/test/renderWithProviders'
-import type { AMSilence, DataSource, VMAlertAlert, VMAlertRuleGroup } from '@/types/datasource'
+import type { AMSilence, AMStatus, DataSource, VMAlertAlert, VMAlertRuleGroup } from '@/types/datasource'
 
 vi.mock('@/analytics', () => ({
   identifyUser: vi.fn(),
@@ -91,6 +91,15 @@ const mockGroups: VMAlertRuleGroup[] = [
   },
 ]
 
+const mockAmStatus: AMStatus = {
+  cluster: { status: 'ready' },
+  versionInfo: { version: '0.27.0' },
+  config: {
+    original: 'route:\n  receiver: default\nreceivers:\n  - name: default\n',
+  },
+  uptime: '2026-03-22T08:00:00Z',
+}
+
 function renderAlerts() {
   const queryClient = createTestQueryClient()
   const router = createMemoryRouter(
@@ -139,6 +148,7 @@ describe('AlertsPage', () => {
     vi.spyOn(alertmanagerApi, 'fetchAlertManagerAlerts').mockResolvedValue([])
     vi.spyOn(alertmanagerApi, 'fetchSilences').mockResolvedValue([])
     vi.spyOn(alertmanagerApi, 'fetchReceivers').mockResolvedValue([])
+    vi.spyOn(alertmanagerApi, 'fetchAlertManagerStatus').mockResolvedValue(mockAmStatus)
     vi.spyOn(alertmanagerApi, 'createSilence').mockResolvedValue('silence-1')
     vi.spyOn(alertmanagerApi, 'expireSilence').mockResolvedValue()
   })
@@ -202,7 +212,7 @@ describe('AlertsPage', () => {
     expect(screen.getByText(/1 alert firing/i)).toBeTruthy()
   })
 
-  it('shows rule groups and expands rule editor details', async () => {
+  it('shows rule groups and opens rule editor', async () => {
     const user = userEvent.setup()
     renderAlerts()
 
@@ -225,6 +235,12 @@ describe('AlertsPage', () => {
 
     expect(screen.getByText('cpu > 0.9')).toBeTruthy()
     expect(screen.getByText('alerting')).toBeTruthy()
+
+    await user.click(screen.getByTestId('open-rule-editor-HighCPU'))
+    expect(screen.getByTestId('rule-editor-modal')).toBeTruthy()
+    expect(screen.getByTestId('rule-editor-query').textContent).toContain('cpu > 0.9')
+    expect(screen.getByTestId('rule-editor-yaml').textContent).toContain('- alert: HighCPU')
+    expect(screen.getByTestId('rule-editor-readonly-notice')).toBeTruthy()
   })
 
   it('creates and expires Alertmanager silences with mocked API', async () => {
@@ -298,6 +314,57 @@ describe('AlertsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('expired')).toBeTruthy()
+    })
+  })
+
+  it('shows Alertmanager configuration from status API', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([alertmanagerDatasource])
+
+    renderAlerts()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alerts-tab-am-config')).toBeTruthy()
+    })
+
+    await user.click(screen.getByTestId('alerts-tab-am-config'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('am-config-panel')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('am-config-yaml').textContent).toContain('receiver: default')
+    expect(screen.getByTestId('am-version').textContent).toContain('0.27.0')
+  })
+
+  it('resets stale datasource selection when org datasources change', async () => {
+    const org2Vmalert: DataSource = {
+      ...vmalertDatasource,
+      id: 'ds-org2',
+      organization_id: 'org-2',
+      name: 'VMAlert Org2',
+    }
+
+    const listSpy = vi
+      .spyOn(datasourcesApi, 'listDataSources')
+      .mockResolvedValueOnce([vmalertDatasource])
+      .mockResolvedValue([org2Vmalert])
+
+    renderAlerts()
+
+    await waitFor(() => {
+      expect((screen.getByTestId('alerts-datasource-select') as HTMLSelectElement).value).toBe(
+        'ds-1',
+      )
+    })
+
+    useOrgStore.setState({ currentOrgId: 'org-2' })
+
+    await waitFor(() => {
+      expect(listSpy).toHaveBeenCalled()
+      expect((screen.getByTestId('alerts-datasource-select') as HTMLSelectElement).value).toBe(
+        'ds-org2',
+      )
     })
   })
 

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -2,99 +2,73 @@ import {
   AlertCircle,
   BellOff,
   BellRing,
-  ChevronDown,
-  ChevronRight,
   Clock,
   Loader2,
-  Plus,
-  Radio,
   RefreshCw,
-  Star,
-  Trash2,
-  X,
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 import {
   createSilence,
   expireSilence,
   fetchAlertManagerAlerts,
+  fetchAlertManagerStatus,
   fetchReceivers,
   fetchSilences,
 } from '@/api/alertmanager'
 import { fetchVMAlertGroups, fetchVMAlerts } from '@/api/vmalert'
-import { AiAlertTriage } from '@/components/AiAlertTriage'
-import { StatusDot } from '@/components/StatusDot'
+import {
+  AMAlertsPanel,
+  AMConfigPanel,
+  AMReceiversPanel,
+  AMSilencesPanel,
+} from '@/components/alerts/AlertManagerPanels'
+import { RuleEditorPanel } from '@/components/alerts/RuleEditorPanel'
+import { SilenceModal, type SilenceFormState } from '@/components/alerts/SilenceModal'
+import { VMAlertAlertsPanel, VMAlertGroupsPanel } from '@/components/alerts/VMAlertPanels'
 import { useAlertingDatasources } from '@/hooks/useAlertingDatasources'
+import { toLocalDatetimeString } from '@/lib/alerts'
 import { useAuthStore } from '@/stores/authStore'
 import { useFavoritesStore } from '@/stores/favoritesStore'
 import { useOrgStore } from '@/stores/orgStore'
 import {
   dataSourceTypeLabels,
   type AMAlert,
-  type AMMatcher,
   type AMReceiver,
   type AMSilence,
+  type AMStatus,
   type DataSource,
   type VMAlertAlert,
+  type VMAlertRule,
   type VMAlertRuleGroup,
 } from '@/types/datasource'
 
-type ActiveTab = 'alerts' | 'groups' | 'am-alerts' | 'am-silences' | 'am-receivers'
+type ActiveTab =
+  | 'alerts'
+  | 'groups'
+  | 'am-alerts'
+  | 'am-silences'
+  | 'am-receivers'
+  | 'am-config'
 
-function stateToStatusDot(state: string): 'healthy' | 'warning' | 'critical' | 'info' {
-  switch (state) {
-    case 'firing':
-    case 'active':
-      return 'critical'
-    case 'pending':
-    case 'suppressed':
-      return 'warning'
-    default:
-      return 'healthy'
+function emptySilenceForm(createdBy: string): SilenceFormState {
+  const now = new Date()
+  const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000)
+  return {
+    matchers: [
+      { key: `matcher-${Date.now()}`, name: '', value: '', isRegex: false, isEqual: true },
+    ],
+    start: toLocalDatetimeString(now),
+    end: toLocalDatetimeString(twoHoursLater),
+    createdBy,
+    comment: '',
   }
-}
-
-function formatDuration(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
-  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
-}
-
-function formatInterval(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
-  return `${Math.floor(seconds / 60)}m`
-}
-
-function truncateId(id: string): string {
-  return id.length > 8 ? `${id.substring(0, 8)}...` : id
-}
-
-function formatDateShort(dateStr: string): string {
-  if (!dateStr) return '--'
-  const d = new Date(dateStr)
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-}
-
-function toLocalDatetimeString(d: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
-function matcherOperator(m: AMMatcher): string {
-  if (m.isEqual) return m.isRegex ? '=~' : '='
-  return m.isRegex ? '!~' : '!='
 }
 
 export function AlertsPage() {
   const currentOrgId = useOrgStore(state => state.currentOrgId)
   const user = useAuthStore(state => state.user)
-  const { alertingDatasources, isLoading: datasourcesLoading } = useAlertingDatasources(currentOrgId)
+  const { alertingDatasources, isLoading: datasourcesLoading } =
+    useAlertingDatasources(currentOrgId)
 
   const toggleFavorite = useFavoritesStore(state => state.toggleFavorite)
   const isFavorite = useFavoritesStore(state => state.isFavorite)
@@ -107,21 +81,24 @@ export function AlertsPage() {
   const [amAlerts, setAmAlerts] = useState<AMAlert[]>([])
   const [amSilences, setAmSilences] = useState<AMSilence[]>([])
   const [amReceivers, setAmReceivers] = useState<AMReceiver[]>([])
+  const [amStatus, setAmStatus] = useState<AMStatus | null>(null)
+  const [amStatusError, setAmStatusError] = useState<string | null>(null)
 
   const [amFilterActive, setAmFilterActive] = useState(true)
   const [amFilterSilenced, setAmFilterSilenced] = useState(true)
   const [amFilterInhibited, setAmFilterInhibited] = useState(true)
 
   const [showSilenceModal, setShowSilenceModal] = useState(false)
-  const [silenceMatchers, setSilenceMatchers] = useState<Array<AMMatcher & { key: string }>>([
-    { key: 'matcher-0', name: '', value: '', isRegex: false, isEqual: true },
-  ])
-  const [silenceStart, setSilenceStart] = useState('')
-  const [silenceEnd, setSilenceEnd] = useState('')
-  const [silenceCreatedBy, setSilenceCreatedBy] = useState('')
-  const [silenceComment, setSilenceComment] = useState('')
+  const [silenceForm, setSilenceForm] = useState<SilenceFormState>(() =>
+    emptySilenceForm(user?.email || user?.name || ''),
+  )
   const [silenceSaving, setSilenceSaving] = useState(false)
   const [silenceError, setSilenceError] = useState<string | null>(null)
+
+  const [editingRule, setEditingRule] = useState<{
+    rule: VMAlertRule
+    groupName: string
+  } | null>(null)
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -130,6 +107,8 @@ export function AlertsPage() {
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({})
   const [expandedAlertIdx, setExpandedAlertIdx] = useState<number | null>(null)
 
+  const loadGeneration = useRef(0)
+
   const selectedDatasource = useMemo<DataSource | undefined>(
     () => alertingDatasources.find(d => d.id === selectedDatasourceId),
     [alertingDatasources, selectedDatasourceId],
@@ -137,6 +116,7 @@ export function AlertsPage() {
 
   const isAlertManager = selectedDatasource?.type === 'alertmanager'
   const isVMAlert = selectedDatasource?.type === 'vmalert'
+  const selectedDatasourceType = selectedDatasource?.type
 
   const firingAlerts = useMemo(() => alerts.filter(a => a.state === 'firing'), [alerts])
   const pendingAlerts = useMemo(() => alerts.filter(a => a.state === 'pending'), [alerts])
@@ -165,17 +145,42 @@ export function AlertsPage() {
 
   const formattedLastRefreshed = lastRefreshed ? lastRefreshed.toLocaleTimeString() : ''
 
-  // Auto-select first alerting datasource
+  // Keep selection valid for the current org's datasource list (fixes org-switch stale selection).
   useEffect(() => {
-    if (alertingDatasources.length > 0 && !selectedDatasourceId) {
+    if (datasourcesLoading) return
+
+    if (alertingDatasources.length === 0) {
+      if (selectedDatasourceId) setSelectedDatasourceId('')
+      return
+    }
+
+    const stillValid = alertingDatasources.some(ds => ds.id === selectedDatasourceId)
+    if (!stillValid) {
       setSelectedDatasourceId(alertingDatasources[0]!.id)
     }
-  }, [alertingDatasources, selectedDatasourceId])
+  }, [alertingDatasources, selectedDatasourceId, datasourcesLoading])
 
-  const selectedDatasourceType = selectedDatasource?.type
+  // Clear page state when org changes so prior-org data never lingers.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally keyed only on org switch
+  useEffect(() => {
+    loadGeneration.current += 1
+    setAlerts([])
+    setGroups([])
+    setAmAlerts([])
+    setAmSilences([])
+    setAmReceivers([])
+    setAmStatus(null)
+    setAmStatusError(null)
+    setError(null)
+    setExpandedGroups({})
+    setExpandedAlertIdx(null)
+    setEditingRule(null)
+    setShowSilenceModal(false)
+    setLastRefreshed(null)
+  }, [currentOrgId])
 
-  // Reset tab when datasource selection/type changes
-  // biome-ignore lint/correctness/useExhaustiveDependencies: only reset when id/type change, not full object identity
+  // Reset tab/data when datasource selection/type changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only reset when id/type change
   useEffect(() => {
     if (!selectedDatasourceType) return
     setActiveTab(selectedDatasourceType === 'alertmanager' ? 'am-alerts' : 'alerts')
@@ -184,9 +189,12 @@ export function AlertsPage() {
     setAmAlerts([])
     setAmSilences([])
     setAmReceivers([])
+    setAmStatus(null)
+    setAmStatusError(null)
     setError(null)
     setExpandedGroups({})
     setExpandedAlertIdx(null)
+    setEditingRule(null)
   }, [selectedDatasourceId, selectedDatasourceType])
 
   const loadVMAlertData = useCallback(async (datasourceId: string) => {
@@ -194,13 +202,15 @@ export function AlertsPage() {
       fetchVMAlerts(datasourceId),
       fetchVMAlertGroups(datasourceId),
     ])
-    setAlerts(alertsRes.data?.alerts ?? [])
-    setGroups(groupsRes.data?.groups ?? [])
+    return {
+      alerts: alertsRes.data?.alerts ?? [],
+      groups: groupsRes.data?.groups ?? [],
+    }
   }, [])
 
   const loadAlertManagerData = useCallback(
     async (datasourceId: string) => {
-      const [alertsRes, silencesRes, receiversRes] = await Promise.all([
+      const [alertsRes, silencesRes, receiversRes, statusRes] = await Promise.allSettled([
         fetchAlertManagerAlerts(datasourceId, {
           active: amFilterActive,
           silenced: amFilterSilenced,
@@ -208,10 +218,25 @@ export function AlertsPage() {
         }),
         fetchSilences(datasourceId),
         fetchReceivers(datasourceId),
+        fetchAlertManagerStatus(datasourceId),
       ])
-      setAmAlerts(alertsRes ?? [])
-      setAmSilences(silencesRes ?? [])
-      setAmReceivers(receiversRes ?? [])
+
+      if (alertsRes.status === 'rejected') throw alertsRes.reason
+      if (silencesRes.status === 'rejected') throw silencesRes.reason
+      if (receiversRes.status === 'rejected') throw receiversRes.reason
+
+      return {
+        alerts: alertsRes.value ?? [],
+        silences: silencesRes.value ?? [],
+        receivers: receiversRes.value ?? [],
+        status: statusRes.status === 'fulfilled' ? statusRes.value : null,
+        statusError:
+          statusRes.status === 'rejected'
+            ? statusRes.reason instanceof Error
+              ? statusRes.reason.message
+              : 'Failed to fetch Alertmanager status'
+            : null,
+      }
     },
     [amFilterActive, amFilterSilenced, amFilterInhibited],
   )
@@ -219,24 +244,39 @@ export function AlertsPage() {
   const loadData = useCallback(async () => {
     if (!selectedDatasourceId || !selectedDatasource) return
 
+    const generation = ++loadGeneration.current
     setLoading(true)
     setError(null)
 
     try {
       if (selectedDatasource.type === 'alertmanager') {
-        await loadAlertManagerData(selectedDatasourceId)
+        const data = await loadAlertManagerData(selectedDatasourceId)
+        if (generation !== loadGeneration.current) return
+        setAmAlerts(data.alerts)
+        setAmSilences(data.silences)
+        setAmReceivers(data.receivers)
+        setAmStatus(data.status)
+        setAmStatusError(data.statusError)
       } else {
-        await loadVMAlertData(selectedDatasourceId)
+        const data = await loadVMAlertData(selectedDatasourceId)
+        if (generation !== loadGeneration.current) return
+        setAlerts(data.alerts)
+        setGroups(data.groups)
       }
-      setLastRefreshed(new Date())
+      if (generation === loadGeneration.current) {
+        setLastRefreshed(new Date())
+      }
     } catch (e) {
+      if (generation !== loadGeneration.current) return
       setError(e instanceof Error ? e.message : 'Failed to fetch data')
     } finally {
-      setLoading(false)
+      if (generation === loadGeneration.current) {
+        setLoading(false)
+      }
     }
   }, [selectedDatasourceId, selectedDatasource, loadAlertManagerData, loadVMAlertData])
 
-  // Load when datasource is selected / type changes
+  // Load when datasource is selected / type changes.
   // biome-ignore lint/correctness/useExhaustiveDependencies: loadData identity changes with filters; only reload on ds switch
   useEffect(() => {
     if (selectedDatasourceId && selectedDatasourceType) {
@@ -244,16 +284,19 @@ export function AlertsPage() {
     }
   }, [selectedDatasourceId, selectedDatasourceType])
 
-  // Re-fetch AM alerts when filter toggles change (skip initial mount)
-  const amFiltersReady = useRef(false)
+  // Re-fetch AM alerts only when filter toggles change — not on datasource switch
+  // (that path is owned by loadData). Uses a dedicated generation so filter reloads
+  // never discard a full load that also populates silences/receivers/status.
+  const amFilterGeneration = useRef(0)
+  const amFilterBaseline = useRef(`${amFilterActive}|${amFilterSilenced}|${amFilterInhibited}`)
   useEffect(() => {
-    if (!amFiltersReady.current) {
-      amFiltersReady.current = true
-      return
-    }
     if (!isAlertManager || !selectedDatasourceId) return
 
-    let cancelled = false
+    const filterKey = `${amFilterActive}|${amFilterSilenced}|${amFilterInhibited}`
+    if (filterKey === amFilterBaseline.current) return
+    amFilterBaseline.current = filterKey
+
+    const generation = ++amFilterGeneration.current
     async function reloadFilters() {
       setLoading(true)
       setError(null)
@@ -263,22 +306,17 @@ export function AlertsPage() {
           silenced: amFilterSilenced,
           inhibited: amFilterInhibited,
         })
-        if (!cancelled) {
-          setAmAlerts(result)
-          setLastRefreshed(new Date())
-        }
+        if (generation !== amFilterGeneration.current) return
+        setAmAlerts(result)
+        setLastRefreshed(new Date())
       } catch (e) {
-        if (!cancelled) {
-          setError(e instanceof Error ? e.message : 'Failed to fetch alerts')
-        }
+        if (generation !== amFilterGeneration.current) return
+        setError(e instanceof Error ? e.message : 'Failed to fetch alerts')
       } finally {
-        if (!cancelled) setLoading(false)
+        if (generation === amFilterGeneration.current) setLoading(false)
       }
     }
     void reloadFilters()
-    return () => {
-      cancelled = true
-    }
   }, [amFilterActive, amFilterSilenced, amFilterInhibited, isAlertManager, selectedDatasourceId])
 
   // Auto-refresh interval
@@ -290,46 +328,17 @@ export function AlertsPage() {
     return () => clearInterval(id)
   }, [autoRefresh, loadData])
 
-  function toggleGroup(groupName: string) {
-    setExpandedGroups(prev => ({ ...prev, [groupName]: !prev[groupName] }))
-  }
-
   function openSilenceModal() {
-    const now = new Date()
-    const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000)
-    setSilenceMatchers([
-      { key: `matcher-${Date.now()}`, name: '', value: '', isRegex: false, isEqual: true },
-    ])
-    setSilenceStart(toLocalDatetimeString(now))
-    setSilenceEnd(toLocalDatetimeString(twoHoursLater))
-    setSilenceCreatedBy(user?.email || user?.name || '')
-    setSilenceComment('')
+    setSilenceForm(emptySilenceForm(user?.email || user?.name || ''))
     setSilenceError(null)
     setShowSilenceModal(true)
   }
 
   async function handleCreateSilence() {
     setSilenceError(null)
-
-    const validMatchers = silenceMatchers.filter(m => m.name.trim() !== '')
-    if (validMatchers.length === 0) {
-      setSilenceError('At least one matcher is required')
-      return
-    }
-    if (!silenceComment.trim()) {
-      setSilenceError('Comment is required')
-      return
-    }
-
-    const startDate = new Date(silenceStart)
-    const endDate = new Date(silenceEnd)
-    if (endDate <= startDate) {
-      setSilenceError('End time must be after start time')
-      return
-    }
-
     setSilenceSaving(true)
     try {
+      const validMatchers = silenceForm.matchers.filter(m => m.name.trim() !== '')
       await createSilence(selectedDatasourceId, {
         matchers: validMatchers.map(m => ({
           name: m.name.trim(),
@@ -337,10 +346,10 @@ export function AlertsPage() {
           isRegex: m.isRegex,
           isEqual: m.isEqual,
         })),
-        startsAt: startDate.toISOString(),
-        endsAt: endDate.toISOString(),
-        createdBy: silenceCreatedBy.trim() || 'unknown',
-        comment: silenceComment.trim(),
+        startsAt: new Date(silenceForm.start).toISOString(),
+        endsAt: new Date(silenceForm.end).toISOString(),
+        createdBy: silenceForm.createdBy.trim() || 'unknown',
+        comment: silenceForm.comment.trim(),
       })
       setShowSilenceModal(false)
       setAmSilences(await fetchSilences(selectedDatasourceId))
@@ -368,7 +377,8 @@ export function AlertsPage() {
     alerts.length === 0 &&
     groups.length === 0 &&
     amAlerts.length === 0 &&
-    amSilences.length === 0
+    amSilences.length === 0 &&
+    !amStatus
 
   return (
     <div className="mx-auto max-w-5xl px-8 py-6" style={{ color: 'var(--color-on-surface)' }}>
@@ -385,7 +395,7 @@ export function AlertsPage() {
             Alerts
           </h1>
           <p className="mt-1 mb-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-            Monitor active alerts and alerting rule groups
+            Monitor active alerts, rule groups, silences, and Alertmanager configuration
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -513,1147 +523,172 @@ export function AlertsPage() {
         </div>
       ) : selectedDatasourceId && isVMAlert ? (
         <>
-          <div
-            className="mb-6 flex gap-1"
-            style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
-          >
-            <button
-              type="button"
-              className="cursor-pointer bg-transparent px-4 py-2.5 text-sm font-medium transition"
-              style={{
-                color: activeTab === 'alerts' ? 'var(--color-primary)' : 'var(--color-outline)',
-                borderBottom:
-                  activeTab === 'alerts'
-                    ? '2px solid var(--color-primary)'
-                    : '2px solid transparent',
-              }}
-              data-testid="alerts-tab-alerts"
-              onClick={() => setActiveTab('alerts')}
-            >
-              Active Alerts
-              {firingAlerts.length > 0 ? (
-                <span
-                  className="ml-1.5 rounded-sm px-2 py-0.5 font-mono text-xs"
-                  style={{
-                    backgroundColor: 'color-mix(in srgb, var(--color-error) 15%, transparent)',
-                    color: 'var(--color-error)',
-                  }}
-                >
-                  {firingAlerts.length}
-                </span>
-              ) : null}
-            </button>
-            <button
-              type="button"
-              className="cursor-pointer bg-transparent px-4 py-2.5 text-sm font-medium transition"
-              style={{
-                color: activeTab === 'groups' ? 'var(--color-primary)' : 'var(--color-outline)',
-                borderBottom:
-                  activeTab === 'groups'
-                    ? '2px solid var(--color-primary)'
-                    : '2px solid transparent',
-              }}
-              data-testid="alerts-tab-groups"
-              onClick={() => setActiveTab('groups')}
-            >
-              Rule Groups
-              {groups.length > 0 ? (
-                <span
-                  className="ml-1.5 rounded-sm px-2 py-0.5 font-mono text-xs"
-                  style={{
-                    backgroundColor: 'var(--color-surface-container-high)',
-                    color: 'var(--color-outline)',
-                  }}
-                >
-                  {groups.length}
-                </span>
-              ) : null}
-            </button>
-          </div>
+          <TabBar
+            tabs={[
+              {
+                id: 'alerts',
+                label: 'Active Alerts',
+                count: firingAlerts.length,
+                emphasize: true,
+              },
+              {
+                id: 'groups',
+                label: 'Rule Groups',
+                count: groups.length,
+                emphasize: false,
+              },
+            ]}
+            activeTab={activeTab}
+            onChange={tab => setActiveTab(tab as ActiveTab)}
+          />
 
           {activeTab === 'alerts' ? (
-            <div>
-              {firingAlerts.length > 0 ? (
-                <AiAlertTriage
-                  alertCount={firingAlerts.length}
-                  alertNames={firingAlerts
-                    .map(a => a.name)
-                    .filter((v, i, arr) => arr.indexOf(v) === i)
-                    .slice(0, 5)}
-                  className="mb-4"
-                />
-              ) : null}
-
-              {sortedAlerts.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
-                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
-                  <h3
-                    className="m-0 text-lg font-semibold"
-                    style={{ color: 'var(--color-on-surface)' }}
-                  >
-                    No alerts firing
-                  </h3>
-                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-                    All quiet -- no active or pending alerts.
-                  </p>
-                </div>
-              ) : (
-                <table className="w-full border-collapse" data-testid="alert-table">
-                  <thead data-testid="alert-table-header">
-                    <tr>
-                      {['Status', 'Alert', 'Labels', 'Active Since'].map((label, i) => (
-                        <th
-                          key={label}
-                          className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase ${i === 3 ? 'text-right' : 'text-left'}`}
-                          style={{ color: 'var(--color-outline)' }}
-                        >
-                          {label}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedAlerts.map((alert, idx) => {
-                      const favoriteId = `alert::${selectedDatasourceId}::${alert.name}`
-                      const favorited = isFavorite(favoriteId)
-                      const rowKey = `${alert.name}|${alert.state}|${alert.activeAt}|${JSON.stringify(alert.labels ?? {})}`
-                      return (
-                        <AlertRow
-                          key={rowKey}
-                          alert={alert}
-                          expanded={expandedAlertIdx === idx}
-                          favorited={favorited}
-                          onToggleExpand={() =>
-                            setExpandedAlertIdx(prev => (prev === idx ? null : idx))
-                          }
-                          onToggleFavorite={() =>
-                            toggleFavorite({
-                              id: favoriteId,
-                              title: alert.name,
-                              type: 'alert',
-                            })
-                          }
-                        />
-                      )
-                    })}
-                  </tbody>
-                </table>
-              )}
-            </div>
+            <VMAlertAlertsPanel
+              sortedAlerts={sortedAlerts}
+              firingAlerts={firingAlerts}
+              expandedAlertIdx={expandedAlertIdx}
+              selectedDatasourceId={selectedDatasourceId}
+              isFavorite={isFavorite}
+              onToggleExpand={idx => setExpandedAlertIdx(prev => (prev === idx ? null : idx))}
+              onToggleFavorite={(id, title) =>
+                toggleFavorite({ id, title, type: 'alert' })
+              }
+            />
           ) : null}
 
           {activeTab === 'groups' ? (
-            <div>
-              {groups.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
-                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
-                  <h3
-                    className="m-0 text-lg font-semibold"
-                    style={{ color: 'var(--color-on-surface)' }}
-                  >
-                    No rule groups
-                  </h3>
-                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-                    No alerting or recording rule groups found.
-                  </p>
-                </div>
-              ) : (
-                <div className="flex flex-col gap-3">
-                  {groups.map(group => {
-                    const expanded = !!expandedGroups[group.name]
-                    return (
-                      <div
-                        key={group.name}
-                        className="overflow-hidden rounded-lg"
-                        style={{ backgroundColor: 'var(--color-surface-container-low)' }}
-                        data-testid="rule-group"
-                      >
-                        <button
-                          type="button"
-                          className="flex w-full cursor-pointer items-center justify-between border-none bg-transparent px-4 py-3 text-left transition hover:opacity-90"
-                          onClick={() => toggleGroup(group.name)}
-                        >
-                          <div className="flex items-center gap-2">
-                            {expanded ? (
-                              <ChevronDown size={16} style={{ color: 'var(--color-outline)' }} />
-                            ) : (
-                              <ChevronRight size={16} style={{ color: 'var(--color-outline)' }} />
-                            )}
-                            <span
-                              className="text-sm font-semibold"
-                              style={{ color: 'var(--color-on-surface)' }}
-                            >
-                              {group.name}
-                            </span>
-                          </div>
-                          <span
-                            className="font-mono text-xs"
-                            style={{ color: 'var(--color-outline)' }}
-                          >
-                            {group.rules.length} rule{group.rules.length !== 1 ? 's' : ''} · every{' '}
-                            {formatInterval(group.interval)}
-                          </span>
-                        </button>
-
-                        {expanded ? (
-                          <div
-                            className="px-4 py-3"
-                            style={{ borderTop: '1px solid var(--color-outline-variant)' }}
-                          >
-                            <div className="flex flex-col">
-                              {group.rules.map((rule, rIdx) => (
-                                <div
-                                  key={`${group.name}:${rule.name}:${rule.type}:${rule.query}:${rule.duration}`}
-                                  className="py-3"
-                                  style={
-                                    rIdx > 0
-                                      ? { borderTop: '1px solid var(--color-outline-variant)' }
-                                      : undefined
-                                  }
-                                  data-testid="rule-item"
-                                >
-                                  <div className="mb-2 flex flex-wrap items-center gap-2">
-                                    <span
-                                      className="text-sm font-semibold"
-                                      style={{ color: 'var(--color-on-surface)' }}
-                                    >
-                                      {rule.name}
-                                    </span>
-                                    <span
-                                      className="rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase"
-                                      style={{
-                                        backgroundColor:
-                                          rule.type === 'alerting'
-                                            ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
-                                            : 'color-mix(in srgb, var(--color-primary) 15%, transparent)',
-                                        color:
-                                          rule.type === 'alerting'
-                                            ? 'var(--color-error)'
-                                            : 'var(--color-primary)',
-                                      }}
-                                    >
-                                      {rule.type}
-                                    </span>
-                                    {rule.state ? (
-                                      <span
-                                        className="rounded-sm px-2 py-0.5 text-xs font-semibold"
-                                        style={{
-                                          backgroundColor:
-                                            rule.state === 'firing'
-                                              ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
-                                              : rule.state === 'pending'
-                                                ? 'color-mix(in srgb, var(--color-tertiary) 15%, transparent)'
-                                                : 'var(--color-surface-container-high)',
-                                          color:
-                                            rule.state === 'firing'
-                                              ? 'var(--color-error)'
-                                              : rule.state === 'pending'
-                                                ? 'var(--color-tertiary)'
-                                                : 'var(--color-on-surface-variant)',
-                                        }}
-                                      >
-                                        {rule.state}
-                                      </span>
-                                    ) : null}
-                                  </div>
-                                  <div
-                                    className="mb-2 overflow-x-auto rounded-sm px-3 py-2"
-                                    style={{
-                                      backgroundColor: 'var(--color-surface-container-high)',
-                                    }}
-                                  >
-                                    <code
-                                      className="font-mono text-xs break-all whitespace-pre-wrap"
-                                      style={{ color: 'var(--color-on-surface-variant)' }}
-                                    >
-                                      {rule.query}
-                                    </code>
-                                  </div>
-                                  <div className="flex flex-wrap items-center gap-1.5">
-                                    {rule.duration > 0 ? (
-                                      <span
-                                        className="mr-1 text-xs"
-                                        style={{ color: 'var(--color-outline)' }}
-                                      >
-                                        <strong>for:</strong> {formatDuration(rule.duration)}
-                                      </span>
-                                    ) : null}
-                                    {Object.entries(rule.labels ?? {}).map(([key, value]) => (
-                                      <span
-                                        key={key}
-                                        className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
-                                        style={{
-                                          backgroundColor: 'var(--color-surface-container-high)',
-                                          color: 'var(--color-on-surface-variant)',
-                                        }}
-                                      >
-                                        {key}={value}
-                                      </span>
-                                    ))}
-                                  </div>
-                                  {rule.annotations && Object.keys(rule.annotations).length > 0 ? (
-                                    <div
-                                      className="mt-2 pt-2"
-                                      style={{
-                                        borderTop: '1px solid var(--color-outline-variant)',
-                                      }}
-                                    >
-                                      {Object.entries(rule.annotations).map(([key, value]) => (
-                                        <div
-                                          key={key}
-                                          className="text-xs leading-relaxed"
-                                          style={{ color: 'var(--color-outline)' }}
-                                        >
-                                          <strong
-                                            style={{ color: 'var(--color-on-surface-variant)' }}
-                                          >
-                                            {key}:
-                                          </strong>{' '}
-                                          {value}
-                                        </div>
-                                      ))}
-                                    </div>
-                                  ) : null}
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        ) : null}
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-            </div>
+            <VMAlertGroupsPanel
+              groups={groups}
+              expandedGroups={expandedGroups}
+              onToggleGroup={name =>
+                setExpandedGroups(prev => ({ ...prev, [name]: !prev[name] }))
+              }
+              onOpenRuleEditor={(rule, groupName) => setEditingRule({ rule, groupName })}
+            />
           ) : null}
         </>
       ) : selectedDatasourceId && isAlertManager ? (
         <>
-          <div
-            className="mb-6 flex gap-1"
-            style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
-          >
-            {(
-              [
-                ['am-alerts', 'Active Alerts', amAlerts.length, true],
-                ['am-silences', 'Silences', activeSilences.length, false],
-                ['am-receivers', 'Receivers', amReceivers.length, false],
-              ] as const
-            ).map(([tab, label, count, isError]) => (
-              <button
-                key={tab}
-                type="button"
-                className="cursor-pointer bg-transparent px-4 py-2.5 text-sm font-medium transition"
-                style={{
-                  color: activeTab === tab ? 'var(--color-primary)' : 'var(--color-outline)',
-                  borderBottom:
-                    activeTab === tab ? '2px solid var(--color-primary)' : '2px solid transparent',
-                }}
-                data-testid={`alerts-tab-${tab}`}
-                onClick={() => setActiveTab(tab)}
-              >
-                {label}
-                {count > 0 ? (
-                  <span
-                    className="ml-1.5 rounded-sm px-2 py-0.5 font-mono text-xs"
-                    style={{
-                      backgroundColor: isError
-                        ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
-                        : 'var(--color-surface-container-high)',
-                      color: isError ? 'var(--color-error)' : 'var(--color-outline)',
-                    }}
-                  >
-                    {count}
-                  </span>
-                ) : null}
-              </button>
-            ))}
-          </div>
+          <TabBar
+            tabs={[
+              { id: 'am-alerts', label: 'Active Alerts', count: amAlerts.length, emphasize: true },
+              {
+                id: 'am-silences',
+                label: 'Silences',
+                count: activeSilences.length,
+                emphasize: false,
+              },
+              {
+                id: 'am-receivers',
+                label: 'Receivers',
+                count: amReceivers.length,
+                emphasize: false,
+              },
+              {
+                id: 'am-config',
+                label: 'Configuration',
+                count: amStatus?.config?.original ? 1 : 0,
+                emphasize: false,
+              },
+            ]}
+            activeTab={activeTab}
+            onChange={tab => setActiveTab(tab as ActiveTab)}
+          />
 
           {activeTab === 'am-alerts' ? (
-            <div>
-              <div className="mb-4 flex items-center gap-2">
-                <span className="text-xs font-medium" style={{ color: 'var(--color-outline)' }}>
-                  Show:
-                </span>
-                {(
-                  [
-                    ['Active', amFilterActive, setAmFilterActive, 'alerts-filter-active-btn'],
-                    [
-                      'Silenced',
-                      amFilterSilenced,
-                      setAmFilterSilenced,
-                      'alerts-filter-silenced-btn',
-                    ],
-                    [
-                      'Inhibited',
-                      amFilterInhibited,
-                      setAmFilterInhibited,
-                      'alerts-filter-inhibited-btn',
-                    ],
-                  ] as const
-                ).map(([label, on, setOn, testId]) => (
-                  <button
-                    key={label}
-                    type="button"
-                    className="cursor-pointer rounded-sm px-2.5 py-1 text-xs transition"
-                    style={{
-                      backgroundColor: on
-                        ? 'color-mix(in srgb, var(--color-primary) 15%, transparent)'
-                        : 'var(--color-surface-container-high)',
-                      color: on ? 'var(--color-primary)' : 'var(--color-outline)',
-                      border: on
-                        ? '1px solid var(--color-primary)'
-                        : '1px solid var(--color-outline-variant)',
-                    }}
-                    data-testid={testId}
-                    onClick={() => setOn(v => !v)}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-
-              {sortedAMAlerts.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
-                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
-                  <h3
-                    className="m-0 text-lg font-semibold"
-                    style={{ color: 'var(--color-on-surface)' }}
-                  >
-                    No alerts
-                  </h3>
-                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-                    No alerts matching current filters.
-                  </p>
-                </div>
-              ) : (
-                <table className="w-full border-collapse" data-testid="am-alert-table">
-                  <thead>
-                    <tr>
-                      {['Status', 'Alert', 'Severity', 'Started'].map((label, i) => (
-                        <th
-                          key={label}
-                          className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase ${i === 3 ? 'text-right' : 'text-left'}`}
-                          style={{ color: 'var(--color-outline)' }}
-                        >
-                          {label}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedAMAlerts.map(alert => {
-                      const favoriteId = alert.fingerprint
-                        ? `alert::${selectedDatasourceId}::${alert.fingerprint}`
-                        : null
-                      const favorited = favoriteId ? isFavorite(favoriteId) : false
-                      const rowKey =
-                        alert.fingerprint ||
-                        `${alert.labels?.alertname ?? 'alert'}|${alert.startsAt}|${alert.status?.state ?? ''}`
-                      return (
-                        <tr key={rowKey} className="transition-colors hover:opacity-90">
-                          <td className="px-4 py-3">
-                            <StatusDot
-                              status={stateToStatusDot(alert.status?.state || '')}
-                              size={8}
-                            />
-                          </td>
-                          <td className="px-4 py-3">
-                            <div className="flex items-center gap-2">
-                              <span
-                                className="text-sm font-semibold"
-                                style={{ color: 'var(--color-on-surface)' }}
-                              >
-                                {alert.labels?.alertname || '--'}
-                              </span>
-                              {favoriteId ? (
-                                <button
-                                  type="button"
-                                  className="shrink-0 cursor-pointer border-none bg-transparent p-0.5"
-                                  title={favorited ? 'Remove from favorites' : 'Add to favorites'}
-                                  onClick={() =>
-                                    toggleFavorite({
-                                      id: favoriteId,
-                                      title: alert.labels?.alertname || 'Alert',
-                                      type: 'alert',
-                                    })
-                                  }
-                                >
-                                  <Star
-                                    size={12}
-                                    fill={favorited ? 'currentColor' : 'none'}
-                                    style={{
-                                      color: favorited
-                                        ? 'var(--color-primary)'
-                                        : 'var(--color-outline)',
-                                    }}
-                                  />
-                                </button>
-                              ) : null}
-                            </div>
-                          </td>
-                          <td className="px-4 py-3">
-                            <span
-                              className="font-mono text-xs"
-                              style={{ color: 'var(--color-on-surface-variant)' }}
-                            >
-                              {alert.labels?.severity || 'none'}
-                            </span>
-                          </td>
-                          <td className="px-4 py-3 text-right">
-                            <span
-                              className="font-mono text-xs"
-                              style={{ color: 'var(--color-outline)' }}
-                            >
-                              {formatDateShort(alert.startsAt)}
-                            </span>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              )}
-            </div>
+            <AMAlertsPanel
+              sortedAMAlerts={sortedAMAlerts}
+              selectedDatasourceId={selectedDatasourceId}
+              amFilterActive={amFilterActive}
+              amFilterSilenced={amFilterSilenced}
+              amFilterInhibited={amFilterInhibited}
+              isFavorite={isFavorite}
+              onToggleFavorite={(id, title) => toggleFavorite({ id, title, type: 'alert' })}
+              onFilterActive={setAmFilterActive}
+              onFilterSilenced={setAmFilterSilenced}
+              onFilterInhibited={setAmFilterInhibited}
+            />
           ) : null}
 
           {activeTab === 'am-silences' ? (
-            <div>
-              <div className="mb-4 flex items-center justify-between">
-                <h3
-                  className="m-0 text-sm font-semibold"
-                  style={{ color: 'var(--color-on-surface)' }}
-                >
-                  Silences
-                </h3>
-                <button
-                  type="button"
-                  data-testid="alerts-new-silence-btn"
-                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-3 py-1.5 text-sm font-medium transition"
-                  style={{
-                    background:
-                      'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
-                    color: '#fff',
-                    border: 'none',
-                  }}
-                  onClick={openSilenceModal}
-                >
-                  <Plus size={14} aria-hidden />
-                  New Silence
-                </button>
-              </div>
-
-              {amSilences.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
-                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
-                  <h3
-                    className="m-0 text-lg font-semibold"
-                    style={{ color: 'var(--color-on-surface)' }}
-                  >
-                    No silences
-                  </h3>
-                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-                    No silence rules configured.
-                  </p>
-                </div>
-              ) : (
-                <div className="flex flex-col gap-3">
-                  {amSilences.map(silence => (
-                    <div
-                      key={silence.id}
-                      className="rounded-lg p-4"
-                      style={{ backgroundColor: 'var(--color-surface-container-low)' }}
-                      data-testid="silence-card"
-                    >
-                      <div className="mb-2 flex items-start justify-between gap-3">
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span
-                            className="shrink-0 font-mono text-xs"
-                            style={{ color: 'var(--color-outline)' }}
-                            title={silence.id}
-                          >
-                            {truncateId(silence.id)}
-                          </span>
-                          <StatusDot
-                            status={
-                              silence.status.state === 'active'
-                                ? 'info'
-                                : silence.status.state === 'pending'
-                                  ? 'warning'
-                                  : 'healthy'
-                            }
-                            size={6}
-                          />
-                          <span
-                            className="text-xs font-semibold"
-                            style={{ color: 'var(--color-on-surface-variant)' }}
-                          >
-                            {silence.status.state}
-                          </span>
-                        </div>
-                        {silence.status.state === 'active' || silence.status.state === 'pending' ? (
-                          <button
-                            type="button"
-                            className="inline-flex shrink-0 cursor-pointer items-center gap-1 border-none bg-transparent text-sm transition"
-                            style={{ color: 'var(--color-error)' }}
-                            title="Expire silence"
-                            data-testid={`expire-silence-${silence.id}`}
-                            onClick={() => void handleExpireSilence(silence.id)}
-                          >
-                            <Trash2 size={12} aria-hidden />
-                            Expire
-                          </button>
-                        ) : null}
-                      </div>
-                      <div className="mb-2 flex flex-wrap gap-1.5">
-                        {silence.matchers.map(m => (
-                          <span
-                            key={`${m.name}${matcherOperator(m)}${m.value}`}
-                            className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
-                            style={{
-                              backgroundColor: 'var(--color-surface-container-high)',
-                              color: 'var(--color-on-surface-variant)',
-                            }}
-                          >
-                            {m.name}
-                            {matcherOperator(m)}&quot;{m.value}&quot;
-                          </span>
-                        ))}
-                      </div>
-                      <div
-                        className="flex items-center gap-3 text-xs"
-                        style={{ color: 'var(--color-outline)' }}
-                      >
-                        <span>{silence.createdBy}</span>
-                        <span className="max-w-[200px] truncate">{silence.comment}</span>
-                        <span className="ml-auto shrink-0 font-mono">
-                          ends {formatDateShort(silence.endsAt)}
-                        </span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+            <AMSilencesPanel
+              amSilences={amSilences}
+              onNewSilence={openSilenceModal}
+              onExpireSilence={id => void handleExpireSilence(id)}
+            />
           ) : null}
 
-          {activeTab === 'am-receivers' ? (
-            <div>
-              {amReceivers.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
-                  <Radio size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
-                  <h3
-                    className="m-0 text-lg font-semibold"
-                    style={{ color: 'var(--color-on-surface)' }}
-                  >
-                    No receivers
-                  </h3>
-                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-                    No receivers configured in AlertManager.
-                  </p>
-                </div>
-              ) : (
-                <div className="flex flex-col gap-3">
-                  {amReceivers.map(receiver => (
-                    <div
-                      key={receiver.name}
-                      className="flex items-center gap-3 rounded-lg p-4"
-                      style={{ backgroundColor: 'var(--color-surface-container-low)' }}
-                      data-testid="receiver-card"
-                    >
-                      <Radio
-                        size={16}
-                        style={{ color: 'var(--color-outline)' }}
-                        className="shrink-0"
-                        aria-hidden
-                      />
-                      <span
-                        className="text-sm font-semibold"
-                        style={{ color: 'var(--color-on-surface)' }}
-                      >
-                        {receiver.name}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+          {activeTab === 'am-receivers' ? <AMReceiversPanel amReceivers={amReceivers} /> : null}
+
+          {activeTab === 'am-config' ? (
+            <AMConfigPanel status={amStatus} loading={loading} error={amStatusError} />
           ) : null}
         </>
       ) : null}
 
-      {showSilenceModal
-        ? createPortal(
-            // biome-ignore lint/a11y/noStaticElementInteractions: modal backdrop dismiss
-            <div
-              className="fixed inset-0 z-[1000] flex items-center justify-center"
-              style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
-              onClick={e => {
-                if (e.target === e.currentTarget) setShowSilenceModal(false)
-              }}
-              onKeyDown={e => {
-                if (e.key === 'Escape') setShowSilenceModal(false)
-              }}
-            >
-              <div
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby="silence-modal-title"
-                className="max-h-[90vh] w-full max-w-[560px] overflow-y-auto rounded-lg"
-                style={{
-                  backgroundColor: 'var(--color-surface-bright)',
-                  border: '1px solid var(--color-outline-variant)',
-                }}
-              >
-                <div
-                  className="flex items-center justify-between px-5 py-4"
-                  style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
-                >
-                  <h2
-                    id="silence-modal-title"
-                    className="m-0 font-display text-base font-bold"
-                    style={{ color: 'var(--color-on-surface)' }}
-                  >
-                    Create Silence
-                  </h2>
-                  <button
-                    type="button"
-                    className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent transition"
-                    style={{ color: 'var(--color-outline)' }}
-                    onClick={() => setShowSilenceModal(false)}
-                    aria-label="Close"
-                  >
-                    <X size={18} />
-                  </button>
-                </div>
+      {showSilenceModal ? (
+        <SilenceModal
+          form={silenceForm}
+          saving={silenceSaving}
+          error={silenceError}
+          onChange={setSilenceForm}
+          onClose={() => setShowSilenceModal(false)}
+          onSubmit={() => void handleCreateSilence()}
+        />
+      ) : null}
 
-                <div className="flex flex-col gap-4 px-5 py-5">
-                  <div className="flex flex-col gap-1.5">
-                    <div
-                      className="text-sm font-medium"
-                      style={{ color: 'var(--color-on-surface-variant)' }}
-                    >
-                      Matchers <span style={{ color: 'var(--color-error)' }}>*</span>
-                    </div>
-                    <div className="mb-2 flex flex-col gap-2">
-                      {silenceMatchers.map((m, idx) => (
-                        <div key={m.key} className="flex items-center gap-2">
-                          <input
-                            value={m.name}
-                            onChange={e => {
-                              const next = [...silenceMatchers]
-                              next[idx] = { ...m, name: e.target.value }
-                              setSilenceMatchers(next)
-                            }}
-                            type="text"
-                            placeholder="Label name"
-                            data-testid={`silence-matcher-name-${idx}`}
-                            className="flex-1 rounded-sm px-2.5 py-1.5 font-mono text-sm focus:outline-none"
-                            style={{
-                              backgroundColor: 'var(--color-surface-container-high)',
-                              color: 'var(--color-on-surface)',
-                              border: '1px solid var(--color-outline-variant)',
-                            }}
-                          />
-                          <select
-                            value={m.isEqual ? 'eq' : 'neq'}
-                            onChange={e => {
-                              const next = [...silenceMatchers]
-                              next[idx] = { ...m, isEqual: e.target.value === 'eq' }
-                              setSilenceMatchers(next)
-                            }}
-                            className="w-13 rounded-sm px-1.5 py-1.5 text-center font-mono text-sm focus:outline-none"
-                            style={{
-                              backgroundColor: 'var(--color-surface-container-high)',
-                              color: 'var(--color-on-surface)',
-                              border: '1px solid var(--color-outline-variant)',
-                            }}
-                          >
-                            <option value="eq">{m.isRegex ? '=~' : '='}</option>
-                            <option value="neq">{m.isRegex ? '!~' : '!='}</option>
-                          </select>
-                          <input
-                            value={m.value}
-                            onChange={e => {
-                              const next = [...silenceMatchers]
-                              next[idx] = { ...m, value: e.target.value }
-                              setSilenceMatchers(next)
-                            }}
-                            type="text"
-                            placeholder="Value"
-                            data-testid={`silence-matcher-value-${idx}`}
-                            className="flex-1 rounded-sm px-2.5 py-1.5 font-mono text-sm focus:outline-none"
-                            style={{
-                              backgroundColor: 'var(--color-surface-container-high)',
-                              color: 'var(--color-on-surface)',
-                              border: '1px solid var(--color-outline-variant)',
-                            }}
-                          />
-                          <label
-                            className="flex cursor-pointer items-center gap-1 text-xs whitespace-nowrap"
-                            style={{ color: 'var(--color-outline)' }}
-                            title="Regex match"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={m.isRegex}
-                              onChange={e => {
-                                const next = [...silenceMatchers]
-                                next[idx] = { ...m, isRegex: e.target.checked }
-                                setSilenceMatchers(next)
-                              }}
-                              className="h-3.5 w-3.5"
-                            />
-                            Regex
-                          </label>
-                          <button
-                            type="button"
-                            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent transition disabled:cursor-not-allowed disabled:opacity-40"
-                            style={{ color: 'var(--color-outline)' }}
-                            disabled={silenceMatchers.length <= 1}
-                            onClick={() => {
-                              if (silenceMatchers.length > 1) {
-                                setSilenceMatchers(silenceMatchers.filter(item => item.key !== m.key))
-                              }
-                            }}
-                            title="Remove matcher"
-                          >
-                            <X size={14} />
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                    <button
-                      type="button"
-                      className="inline-flex cursor-pointer items-center gap-1 self-start border-none bg-transparent text-sm transition"
-                      style={{ color: 'var(--color-primary)' }}
-                      onClick={() =>
-                        setSilenceMatchers([
-                          ...silenceMatchers,
-                          {
-                            key: `matcher-${Date.now()}-${silenceMatchers.length}`,
-                            name: '',
-                            value: '',
-                            isRegex: false,
-                            isEqual: true,
-                          },
-                        ])
-                      }
-                    >
-                      <Plus size={12} aria-hidden />
-                      Add Matcher
-                    </button>
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="flex flex-col gap-1.5">
-                      <label
-                        htmlFor="silence-start"
-                        className="text-sm font-medium"
-                        style={{ color: 'var(--color-on-surface-variant)' }}
-                      >
-                        Start
-                      </label>
-                      <input
-                        id="silence-start"
-                        data-testid="silence-start-input"
-                        value={silenceStart}
-                        onChange={e => setSilenceStart(e.target.value)}
-                        type="datetime-local"
-                        className="rounded-sm px-3 py-2 text-sm focus:outline-none"
-                        style={{
-                          backgroundColor: 'var(--color-surface-container-high)',
-                          color: 'var(--color-on-surface)',
-                          border: '1px solid var(--color-outline-variant)',
-                        }}
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                      <label
-                        htmlFor="silence-end"
-                        className="text-sm font-medium"
-                        style={{ color: 'var(--color-on-surface-variant)' }}
-                      >
-                        End
-                      </label>
-                      <input
-                        id="silence-end"
-                        data-testid="silence-end-input"
-                        value={silenceEnd}
-                        onChange={e => setSilenceEnd(e.target.value)}
-                        type="datetime-local"
-                        className="rounded-sm px-3 py-2 text-sm focus:outline-none"
-                        style={{
-                          backgroundColor: 'var(--color-surface-container-high)',
-                          color: 'var(--color-on-surface)',
-                          border: '1px solid var(--color-outline-variant)',
-                        }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-1.5">
-                    <label
-                      htmlFor="silence-created-by"
-                      className="text-sm font-medium"
-                      style={{ color: 'var(--color-on-surface-variant)' }}
-                    >
-                      Created By
-                    </label>
-                    <input
-                      id="silence-created-by"
-                      data-testid="silence-created-by-input"
-                      value={silenceCreatedBy}
-                      onChange={e => setSilenceCreatedBy(e.target.value)}
-                      type="text"
-                      placeholder="your-name@example.com"
-                      className="rounded-sm px-3 py-2 text-sm focus:outline-none"
-                      style={{
-                        backgroundColor: 'var(--color-surface-container-high)',
-                        color: 'var(--color-on-surface)',
-                        border: '1px solid var(--color-outline-variant)',
-                      }}
-                    />
-                  </div>
-
-                  <div className="flex flex-col gap-1.5">
-                    <label
-                      htmlFor="silence-comment"
-                      className="text-sm font-medium"
-                      style={{ color: 'var(--color-on-surface-variant)' }}
-                    >
-                      Comment <span style={{ color: 'var(--color-error)' }}>*</span>
-                    </label>
-                    <textarea
-                      id="silence-comment"
-                      data-testid="silence-comment-input"
-                      value={silenceComment}
-                      onChange={e => setSilenceComment(e.target.value)}
-                      rows={3}
-                      placeholder="Reason for silencing..."
-                      className="min-h-[68px] resize-y rounded-sm px-3 py-2 text-sm focus:outline-none"
-                      style={{
-                        backgroundColor: 'var(--color-surface-container-high)',
-                        color: 'var(--color-on-surface)',
-                        border: '1px solid var(--color-outline-variant)',
-                        fontFamily: 'inherit',
-                      }}
-                    />
-                  </div>
-
-                  {silenceError ? (
-                    <div
-                      className="flex items-center gap-2 rounded-sm px-4 py-3 text-sm"
-                      style={{
-                        backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
-                        color: 'var(--color-error)',
-                      }}
-                      data-testid="silence-error"
-                    >
-                      <AlertCircle size={14} aria-hidden />
-                      {silenceError}
-                    </div>
-                  ) : null}
-                </div>
-
-                <div
-                  className="flex justify-end gap-2.5 px-5 py-4"
-                  style={{ borderTop: '1px solid var(--color-outline-variant)' }}
-                >
-                  <button
-                    type="button"
-                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-3 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
-                    style={{
-                      backgroundColor: 'var(--color-surface-container-high)',
-                      color: 'var(--color-on-surface-variant)',
-                      border: '1px solid var(--color-outline-variant)',
-                    }}
-                    data-testid="silence-cancel-btn"
-                    onClick={() => setShowSilenceModal(false)}
-                    disabled={silenceSaving}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
-                    style={{
-                      background:
-                        'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
-                      color: '#fff',
-                      border: 'none',
-                    }}
-                    data-testid="silence-create-btn"
-                    onClick={() => void handleCreateSilence()}
-                    disabled={silenceSaving}
-                  >
-                    {silenceSaving ? (
-                      <Loader2 size={14} className="animate-spin" aria-hidden />
-                    ) : null}
-                    {silenceSaving ? 'Creating...' : 'Create Silence'}
-                  </button>
-                </div>
-              </div>
-            </div>,
-            document.body,
-          )
-        : null}
+      {editingRule ? (
+        <RuleEditorPanel
+          rule={editingRule.rule}
+          groupName={editingRule.groupName}
+          onClose={() => setEditingRule(null)}
+        />
+      ) : null}
     </div>
   )
 }
 
-type AlertRowProps = {
-  alert: VMAlertAlert
-  expanded: boolean
-  favorited: boolean
-  onToggleExpand: () => void
-  onToggleFavorite: () => void
+type TabBarProps = {
+  tabs: Array<{ id: string; label: string; count: number; emphasize: boolean }>
+  activeTab: string
+  onChange: (id: string) => void
 }
 
-function AlertRow({
-  alert,
-  expanded,
-  favorited,
-  onToggleExpand,
-  onToggleFavorite,
-}: AlertRowProps) {
+function TabBar({ tabs, activeTab, onChange }: TabBarProps) {
   return (
-    <>
-      {/* biome-ignore lint/a11y/useSemanticElements: expandable table row pattern */}
-      <tr
-        data-testid="alert-row"
-        className="cursor-pointer transition-colors"
-        style={{
-          backgroundColor: expanded ? 'var(--color-surface-container-high)' : 'transparent',
-        }}
-        onClick={onToggleExpand}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            onToggleExpand()
-          }
-        }}
-        role="button"
-        tabIndex={0}
-      >
-        <td className="px-4 py-3">
-          <StatusDot status={stateToStatusDot(alert.state)} size={8} />
-        </td>
-        <td className="px-4 py-3">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
-              {alert.name}
-            </span>
-            <button
-              type="button"
-              className="shrink-0 cursor-pointer border-none bg-transparent p-0.5"
-              title={favorited ? 'Remove from favorites' : 'Add to favorites'}
-              onClick={e => {
-                e.stopPropagation()
-                onToggleFavorite()
+    <div
+      className="mb-6 flex flex-wrap gap-1"
+      style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
+    >
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          type="button"
+          className="cursor-pointer bg-transparent px-4 py-2.5 text-sm font-medium transition"
+          style={{
+            color: activeTab === tab.id ? 'var(--color-primary)' : 'var(--color-outline)',
+            borderBottom:
+              activeTab === tab.id ? '2px solid var(--color-primary)' : '2px solid transparent',
+          }}
+          data-testid={`alerts-tab-${tab.id}`}
+          onClick={() => onChange(tab.id)}
+        >
+          {tab.label}
+          {tab.count > 0 ? (
+            <span
+              className="ml-1.5 rounded-sm px-2 py-0.5 font-mono text-xs"
+              style={{
+                backgroundColor: tab.emphasize
+                  ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                  : 'var(--color-surface-container-high)',
+                color: tab.emphasize ? 'var(--color-error)' : 'var(--color-outline)',
               }}
             >
-              <Star
-                size={12}
-                fill={favorited ? 'currentColor' : 'none'}
-                style={{
-                  color: favorited ? 'var(--color-primary)' : 'var(--color-outline)',
-                }}
-              />
-            </button>
-          </div>
-        </td>
-        <td className="px-4 py-3">
-          {alert.labels && Object.keys(alert.labels).length > 0 ? (
-            <div className="flex flex-wrap gap-1.5">
-              {Object.entries(alert.labels).map(([key, value]) => (
-                <span
-                  key={key}
-                  className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
-                  style={{
-                    backgroundColor: 'var(--color-surface-container-high)',
-                    color: 'var(--color-on-surface-variant)',
-                  }}
-                >
-                  {key}={value}
-                </span>
-              ))}
-            </div>
+              {tab.count}
+            </span>
           ) : null}
-        </td>
-        <td className="px-4 py-3 text-right">
-          <span className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
-            {alert.activeAt || '--'}
-          </span>
-        </td>
-      </tr>
-      {expanded ? (
-        <tr data-testid="alert-detail">
-          <td
-            colSpan={4}
-            className="px-4 py-4"
-            style={{ backgroundColor: 'var(--color-surface-container-low)' }}
-          >
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-3">
-                <span
-                  className="text-xs font-semibold tracking-wider uppercase"
-                  style={{ color: 'var(--color-outline)' }}
-                >
-                  State
-                </span>
-                <span
-                  className="rounded-sm px-2 py-0.5 font-mono text-xs font-semibold"
-                  style={{
-                    backgroundColor:
-                      alert.state === 'firing'
-                        ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
-                        : alert.state === 'pending'
-                          ? 'color-mix(in srgb, var(--color-tertiary) 15%, transparent)'
-                          : 'var(--color-surface-container-high)',
-                    color:
-                      alert.state === 'firing'
-                        ? 'var(--color-error)'
-                        : alert.state === 'pending'
-                          ? 'var(--color-tertiary)'
-                          : 'var(--color-on-surface-variant)',
-                  }}
-                >
-                  {alert.state}
-                </span>
-              </div>
-              {alert.labels && Object.keys(alert.labels).length > 0 ? (
-                <div>
-                  <span
-                    className="text-xs font-semibold tracking-wider uppercase"
-                    style={{ color: 'var(--color-outline)' }}
-                  >
-                    Labels
-                  </span>
-                  <div className="mt-1 flex flex-wrap gap-1.5">
-                    {Object.entries(alert.labels).map(([key, value]) => (
-                      <span
-                        key={key}
-                        className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
-                        style={{
-                          backgroundColor: 'var(--color-surface-container-high)',
-                          color: 'var(--color-on-surface-variant)',
-                        }}
-                      >
-                        {key}={value}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-              <div className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
-                Active since: {alert.activeAt || '--'}
-              </div>
-            </div>
-          </td>
-        </tr>
-      ) : null}
-    </>
+        </button>
+      ))}
+    </div>
   )
 }

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -89,6 +89,7 @@ export function AlertsPage() {
   const [amFilterInhibited, setAmFilterInhibited] = useState(true)
 
   const [showSilenceModal, setShowSilenceModal] = useState(false)
+  const [silenceDatasourceId, setSilenceDatasourceId] = useState('')
   const [silenceForm, setSilenceForm] = useState<SilenceFormState>(() =>
     emptySilenceForm(user?.email || user?.name || ''),
   )
@@ -329,17 +330,25 @@ export function AlertsPage() {
   }, [autoRefresh, loadData])
 
   function openSilenceModal() {
+    // Capture the datasource at open time so a selector change while the modal
+    // is open cannot create the silence against a different Alertmanager.
+    setSilenceDatasourceId(selectedDatasourceId)
     setSilenceForm(emptySilenceForm(user?.email || user?.name || ''))
     setSilenceError(null)
     setShowSilenceModal(true)
   }
 
   async function handleCreateSilence() {
+    const datasourceId = silenceDatasourceId || selectedDatasourceId
+    if (!datasourceId) {
+      setSilenceError('No Alertmanager datasource selected')
+      return
+    }
     setSilenceError(null)
     setSilenceSaving(true)
     try {
       const validMatchers = silenceForm.matchers.filter(m => m.name.trim() !== '')
-      await createSilence(selectedDatasourceId, {
+      await createSilence(datasourceId, {
         matchers: validMatchers.map(m => ({
           name: m.name.trim(),
           value: m.value.trim(),
@@ -352,7 +361,10 @@ export function AlertsPage() {
         comment: silenceForm.comment.trim(),
       })
       setShowSilenceModal(false)
-      setAmSilences(await fetchSilences(selectedDatasourceId))
+      setSilenceDatasourceId('')
+      if (selectedDatasourceId === datasourceId) {
+        setAmSilences(await fetchSilences(datasourceId))
+      }
     } catch (e) {
       setSilenceError(e instanceof Error ? e.message : 'Failed to create silence')
     } finally {

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -1,0 +1,1659 @@
+import {
+  AlertCircle,
+  BellOff,
+  BellRing,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Loader2,
+  Plus,
+  Radio,
+  RefreshCw,
+  Star,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  createSilence,
+  expireSilence,
+  fetchAlertManagerAlerts,
+  fetchReceivers,
+  fetchSilences,
+} from '@/api/alertmanager'
+import { fetchVMAlertGroups, fetchVMAlerts } from '@/api/vmalert'
+import { AiAlertTriage } from '@/components/AiAlertTriage'
+import { StatusDot } from '@/components/StatusDot'
+import { useAlertingDatasources } from '@/hooks/useAlertingDatasources'
+import { useAuthStore } from '@/stores/authStore'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import {
+  dataSourceTypeLabels,
+  type AMAlert,
+  type AMMatcher,
+  type AMReceiver,
+  type AMSilence,
+  type DataSource,
+  type VMAlertAlert,
+  type VMAlertRuleGroup,
+} from '@/types/datasource'
+
+type ActiveTab = 'alerts' | 'groups' | 'am-alerts' | 'am-silences' | 'am-receivers'
+
+function stateToStatusDot(state: string): 'healthy' | 'warning' | 'critical' | 'info' {
+  switch (state) {
+    case 'firing':
+    case 'active':
+      return 'critical'
+    case 'pending':
+    case 'suppressed':
+      return 'warning'
+    default:
+      return 'healthy'
+  }
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
+}
+
+function formatInterval(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  return `${Math.floor(seconds / 60)}m`
+}
+
+function truncateId(id: string): string {
+  return id.length > 8 ? `${id.substring(0, 8)}...` : id
+}
+
+function formatDateShort(dateStr: string): string {
+  if (!dateStr) return '--'
+  const d = new Date(dateStr)
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function toLocalDatetimeString(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function matcherOperator(m: AMMatcher): string {
+  if (m.isEqual) return m.isRegex ? '=~' : '='
+  return m.isRegex ? '!~' : '!='
+}
+
+export function AlertsPage() {
+  const currentOrgId = useOrgStore(state => state.currentOrgId)
+  const user = useAuthStore(state => state.user)
+  const { alertingDatasources, isLoading: datasourcesLoading } = useAlertingDatasources(currentOrgId)
+
+  const toggleFavorite = useFavoritesStore(state => state.toggleFavorite)
+  const isFavorite = useFavoritesStore(state => state.isFavorite)
+
+  const [selectedDatasourceId, setSelectedDatasourceId] = useState('')
+  const [activeTab, setActiveTab] = useState<ActiveTab>('alerts')
+
+  const [alerts, setAlerts] = useState<VMAlertAlert[]>([])
+  const [groups, setGroups] = useState<VMAlertRuleGroup[]>([])
+  const [amAlerts, setAmAlerts] = useState<AMAlert[]>([])
+  const [amSilences, setAmSilences] = useState<AMSilence[]>([])
+  const [amReceivers, setAmReceivers] = useState<AMReceiver[]>([])
+
+  const [amFilterActive, setAmFilterActive] = useState(true)
+  const [amFilterSilenced, setAmFilterSilenced] = useState(true)
+  const [amFilterInhibited, setAmFilterInhibited] = useState(true)
+
+  const [showSilenceModal, setShowSilenceModal] = useState(false)
+  const [silenceMatchers, setSilenceMatchers] = useState<Array<AMMatcher & { key: string }>>([
+    { key: 'matcher-0', name: '', value: '', isRegex: false, isEqual: true },
+  ])
+  const [silenceStart, setSilenceStart] = useState('')
+  const [silenceEnd, setSilenceEnd] = useState('')
+  const [silenceCreatedBy, setSilenceCreatedBy] = useState('')
+  const [silenceComment, setSilenceComment] = useState('')
+  const [silenceSaving, setSilenceSaving] = useState(false)
+  const [silenceError, setSilenceError] = useState<string | null>(null)
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [autoRefresh, setAutoRefresh] = useState(false)
+  const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({})
+  const [expandedAlertIdx, setExpandedAlertIdx] = useState<number | null>(null)
+
+  const selectedDatasource = useMemo<DataSource | undefined>(
+    () => alertingDatasources.find(d => d.id === selectedDatasourceId),
+    [alertingDatasources, selectedDatasourceId],
+  )
+
+  const isAlertManager = selectedDatasource?.type === 'alertmanager'
+  const isVMAlert = selectedDatasource?.type === 'vmalert'
+
+  const firingAlerts = useMemo(() => alerts.filter(a => a.state === 'firing'), [alerts])
+  const pendingAlerts = useMemo(() => alerts.filter(a => a.state === 'pending'), [alerts])
+  const inactiveAlerts = useMemo(
+    () => alerts.filter(a => a.state !== 'firing' && a.state !== 'pending'),
+    [alerts],
+  )
+  const sortedAlerts = useMemo(
+    () => [...firingAlerts, ...pendingAlerts, ...inactiveAlerts],
+    [firingAlerts, pendingAlerts, inactiveAlerts],
+  )
+
+  const sortedAMAlerts = useMemo(() => {
+    const stateOrder: Record<string, number> = { active: 0, suppressed: 1, unprocessed: 2 }
+    return [...amAlerts].sort((a, b) => {
+      const aState = a.status?.state ?? 'unprocessed'
+      const bState = b.status?.state ?? 'unprocessed'
+      return (stateOrder[aState] ?? 3) - (stateOrder[bState] ?? 3)
+    })
+  }, [amAlerts])
+
+  const activeSilences = useMemo(
+    () => amSilences.filter(s => s.status.state === 'active' || s.status.state === 'pending'),
+    [amSilences],
+  )
+
+  const formattedLastRefreshed = lastRefreshed ? lastRefreshed.toLocaleTimeString() : ''
+
+  // Auto-select first alerting datasource
+  useEffect(() => {
+    if (alertingDatasources.length > 0 && !selectedDatasourceId) {
+      setSelectedDatasourceId(alertingDatasources[0]!.id)
+    }
+  }, [alertingDatasources, selectedDatasourceId])
+
+  const selectedDatasourceType = selectedDatasource?.type
+
+  // Reset tab when datasource selection/type changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only reset when id/type change, not full object identity
+  useEffect(() => {
+    if (!selectedDatasourceType) return
+    setActiveTab(selectedDatasourceType === 'alertmanager' ? 'am-alerts' : 'alerts')
+    setAlerts([])
+    setGroups([])
+    setAmAlerts([])
+    setAmSilences([])
+    setAmReceivers([])
+    setError(null)
+    setExpandedGroups({})
+    setExpandedAlertIdx(null)
+  }, [selectedDatasourceId, selectedDatasourceType])
+
+  const loadVMAlertData = useCallback(async (datasourceId: string) => {
+    const [alertsRes, groupsRes] = await Promise.all([
+      fetchVMAlerts(datasourceId),
+      fetchVMAlertGroups(datasourceId),
+    ])
+    setAlerts(alertsRes.data?.alerts ?? [])
+    setGroups(groupsRes.data?.groups ?? [])
+  }, [])
+
+  const loadAlertManagerData = useCallback(
+    async (datasourceId: string) => {
+      const [alertsRes, silencesRes, receiversRes] = await Promise.all([
+        fetchAlertManagerAlerts(datasourceId, {
+          active: amFilterActive,
+          silenced: amFilterSilenced,
+          inhibited: amFilterInhibited,
+        }),
+        fetchSilences(datasourceId),
+        fetchReceivers(datasourceId),
+      ])
+      setAmAlerts(alertsRes ?? [])
+      setAmSilences(silencesRes ?? [])
+      setAmReceivers(receiversRes ?? [])
+    },
+    [amFilterActive, amFilterSilenced, amFilterInhibited],
+  )
+
+  const loadData = useCallback(async () => {
+    if (!selectedDatasourceId || !selectedDatasource) return
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      if (selectedDatasource.type === 'alertmanager') {
+        await loadAlertManagerData(selectedDatasourceId)
+      } else {
+        await loadVMAlertData(selectedDatasourceId)
+      }
+      setLastRefreshed(new Date())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch data')
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedDatasourceId, selectedDatasource, loadAlertManagerData, loadVMAlertData])
+
+  // Load when datasource is selected / type changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: loadData identity changes with filters; only reload on ds switch
+  useEffect(() => {
+    if (selectedDatasourceId && selectedDatasourceType) {
+      void loadData()
+    }
+  }, [selectedDatasourceId, selectedDatasourceType])
+
+  // Re-fetch AM alerts when filter toggles change (skip initial mount)
+  const amFiltersReady = useRef(false)
+  useEffect(() => {
+    if (!amFiltersReady.current) {
+      amFiltersReady.current = true
+      return
+    }
+    if (!isAlertManager || !selectedDatasourceId) return
+
+    let cancelled = false
+    async function reloadFilters() {
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await fetchAlertManagerAlerts(selectedDatasourceId, {
+          active: amFilterActive,
+          silenced: amFilterSilenced,
+          inhibited: amFilterInhibited,
+        })
+        if (!cancelled) {
+          setAmAlerts(result)
+          setLastRefreshed(new Date())
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to fetch alerts')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void reloadFilters()
+    return () => {
+      cancelled = true
+    }
+  }, [amFilterActive, amFilterSilenced, amFilterInhibited, isAlertManager, selectedDatasourceId])
+
+  // Auto-refresh interval
+  useEffect(() => {
+    if (!autoRefresh) return
+    const id = setInterval(() => {
+      void loadData()
+    }, 30_000)
+    return () => clearInterval(id)
+  }, [autoRefresh, loadData])
+
+  function toggleGroup(groupName: string) {
+    setExpandedGroups(prev => ({ ...prev, [groupName]: !prev[groupName] }))
+  }
+
+  function openSilenceModal() {
+    const now = new Date()
+    const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000)
+    setSilenceMatchers([
+      { key: `matcher-${Date.now()}`, name: '', value: '', isRegex: false, isEqual: true },
+    ])
+    setSilenceStart(toLocalDatetimeString(now))
+    setSilenceEnd(toLocalDatetimeString(twoHoursLater))
+    setSilenceCreatedBy(user?.email || user?.name || '')
+    setSilenceComment('')
+    setSilenceError(null)
+    setShowSilenceModal(true)
+  }
+
+  async function handleCreateSilence() {
+    setSilenceError(null)
+
+    const validMatchers = silenceMatchers.filter(m => m.name.trim() !== '')
+    if (validMatchers.length === 0) {
+      setSilenceError('At least one matcher is required')
+      return
+    }
+    if (!silenceComment.trim()) {
+      setSilenceError('Comment is required')
+      return
+    }
+
+    const startDate = new Date(silenceStart)
+    const endDate = new Date(silenceEnd)
+    if (endDate <= startDate) {
+      setSilenceError('End time must be after start time')
+      return
+    }
+
+    setSilenceSaving(true)
+    try {
+      await createSilence(selectedDatasourceId, {
+        matchers: validMatchers.map(m => ({
+          name: m.name.trim(),
+          value: m.value.trim(),
+          isRegex: m.isRegex,
+          isEqual: m.isEqual,
+        })),
+        startsAt: startDate.toISOString(),
+        endsAt: endDate.toISOString(),
+        createdBy: silenceCreatedBy.trim() || 'unknown',
+        comment: silenceComment.trim(),
+      })
+      setShowSilenceModal(false)
+      setAmSilences(await fetchSilences(selectedDatasourceId))
+    } catch (e) {
+      setSilenceError(e instanceof Error ? e.message : 'Failed to create silence')
+    } finally {
+      setSilenceSaving(false)
+    }
+  }
+
+  async function handleExpireSilence(silenceId: string) {
+    try {
+      await expireSilence(selectedDatasourceId, silenceId)
+      setAmSilences(await fetchSilences(selectedDatasourceId))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to expire silence')
+    }
+  }
+
+  const emptyDatasourceState =
+    !selectedDatasourceId && alertingDatasources.length === 0 && !datasourcesLoading
+
+  const showLoadingSkeleton =
+    loading &&
+    alerts.length === 0 &&
+    groups.length === 0 &&
+    amAlerts.length === 0 &&
+    amSilences.length === 0
+
+  return (
+    <div className="mx-auto max-w-5xl px-8 py-6" style={{ color: 'var(--color-on-surface)' }}>
+      <header
+        className="mb-6 flex items-center justify-between gap-4 rounded-lg px-5 py-4"
+        style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+      >
+        <div>
+          <h1
+            className="m-0 flex items-center gap-2 font-display text-base font-bold tracking-wide"
+            style={{ color: 'var(--color-on-surface)' }}
+          >
+            <BellRing size={20} aria-hidden />
+            Alerts
+          </h1>
+          <p className="mt-1 mb-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            Monitor active alerts and alerting rule groups
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={selectedDatasourceId}
+            onChange={e => setSelectedDatasourceId(e.target.value)}
+            data-testid="alerts-datasource-select"
+            className="appearance-none rounded-sm px-3 py-2 pr-8 text-sm focus:outline-none"
+            style={{
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface)',
+              border: '1px solid var(--color-outline-variant)',
+            }}
+            disabled={alertingDatasources.length === 0}
+          >
+            <option value="" disabled>
+              {alertingDatasources.length === 0 ? 'No alerting datasources' : 'Select datasource'}
+            </option>
+            {alertingDatasources.map(ds => (
+              <option key={ds.id} value={ds.id}>
+                {ds.name} ({dataSourceTypeLabels[ds.type]})
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-sm px-2.5 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface-variant)',
+              border: '1px solid var(--color-outline-variant)',
+            }}
+            data-testid="alerts-refresh-btn"
+            disabled={!selectedDatasourceId || loading}
+            onClick={() => void loadData()}
+            title="Refresh"
+          >
+            {loading ? (
+              <Loader2 size={14} className="animate-spin" aria-hidden />
+            ) : (
+              <RefreshCw size={14} aria-hidden />
+            )}
+          </button>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-sm px-2.5 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              backgroundColor: autoRefresh
+                ? 'color-mix(in srgb, var(--color-primary) 15%, transparent)'
+                : 'var(--color-surface-container-high)',
+              color: autoRefresh ? 'var(--color-primary)' : 'var(--color-on-surface)',
+              border: autoRefresh
+                ? '1px solid var(--color-primary)'
+                : '1px solid var(--color-outline-variant)',
+            }}
+            data-testid="alerts-auto-refresh-btn"
+            disabled={!selectedDatasourceId}
+            onClick={() => setAutoRefresh(v => !v)}
+            title="Auto-refresh every 30s"
+          >
+            <Clock size={14} aria-hidden />
+            Auto
+          </button>
+          {lastRefreshed ? (
+            <span
+              className="flex items-center gap-2 font-mono text-xs"
+              style={{ color: 'var(--color-outline)' }}
+            >
+              {autoRefresh ? (
+                <span
+                  className="h-1.5 w-1.5 rounded-full"
+                  style={{ backgroundColor: 'var(--color-primary)' }}
+                />
+              ) : null}
+              {formattedLastRefreshed}
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      {emptyDatasourceState ? (
+        <div className="flex flex-col items-center justify-center gap-4 px-8 py-16 text-center">
+          <BellOff size={48} style={{ color: 'var(--color-outline)' }} aria-hidden />
+          <h3 className="m-0 text-lg font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+            No alerting datasources configured
+          </h3>
+          <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+            Add a VMAlert or AlertManager datasource in Data Sources settings to view alerts.
+          </p>
+        </div>
+      ) : error ? (
+        <div
+          className="mb-4 flex items-center gap-2 rounded-sm px-4 py-3 text-sm"
+          style={{
+            backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+            color: 'var(--color-error)',
+          }}
+          data-testid="alerts-error"
+        >
+          <AlertCircle size={16} aria-hidden />
+          {error}
+        </div>
+      ) : showLoadingSkeleton ? (
+        <div className="flex flex-col gap-3 py-4" data-testid="alerts-loading">
+          {['a', 'b', 'c', 'd', 'e'].map(row => (
+            <div key={row} className="flex items-center gap-4">
+              <div
+                className="h-3.5 w-40 animate-pulse rounded"
+                style={{ backgroundColor: 'var(--color-surface-container-high)' }}
+              />
+              <div
+                className="h-3.5 w-15 animate-pulse rounded"
+                style={{ backgroundColor: 'var(--color-surface-container-high)' }}
+              />
+              <div
+                className="h-3.5 w-55 animate-pulse rounded"
+                style={{ backgroundColor: 'var(--color-surface-container-high)' }}
+              />
+              <div
+                className="h-3.5 w-32 animate-pulse rounded"
+                style={{ backgroundColor: 'var(--color-surface-container-high)' }}
+              />
+            </div>
+          ))}
+        </div>
+      ) : selectedDatasourceId && isVMAlert ? (
+        <>
+          <div
+            className="mb-6 flex gap-1"
+            style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
+          >
+            <button
+              type="button"
+              className="cursor-pointer bg-transparent px-4 py-2.5 text-sm font-medium transition"
+              style={{
+                color: activeTab === 'alerts' ? 'var(--color-primary)' : 'var(--color-outline)',
+                borderBottom:
+                  activeTab === 'alerts'
+                    ? '2px solid var(--color-primary)'
+                    : '2px solid transparent',
+              }}
+              data-testid="alerts-tab-alerts"
+              onClick={() => setActiveTab('alerts')}
+            >
+              Active Alerts
+              {firingAlerts.length > 0 ? (
+                <span
+                  className="ml-1.5 rounded-sm px-2 py-0.5 font-mono text-xs"
+                  style={{
+                    backgroundColor: 'color-mix(in srgb, var(--color-error) 15%, transparent)',
+                    color: 'var(--color-error)',
+                  }}
+                >
+                  {firingAlerts.length}
+                </span>
+              ) : null}
+            </button>
+            <button
+              type="button"
+              className="cursor-pointer bg-transparent px-4 py-2.5 text-sm font-medium transition"
+              style={{
+                color: activeTab === 'groups' ? 'var(--color-primary)' : 'var(--color-outline)',
+                borderBottom:
+                  activeTab === 'groups'
+                    ? '2px solid var(--color-primary)'
+                    : '2px solid transparent',
+              }}
+              data-testid="alerts-tab-groups"
+              onClick={() => setActiveTab('groups')}
+            >
+              Rule Groups
+              {groups.length > 0 ? (
+                <span
+                  className="ml-1.5 rounded-sm px-2 py-0.5 font-mono text-xs"
+                  style={{
+                    backgroundColor: 'var(--color-surface-container-high)',
+                    color: 'var(--color-outline)',
+                  }}
+                >
+                  {groups.length}
+                </span>
+              ) : null}
+            </button>
+          </div>
+
+          {activeTab === 'alerts' ? (
+            <div>
+              {firingAlerts.length > 0 ? (
+                <AiAlertTriage
+                  alertCount={firingAlerts.length}
+                  alertNames={firingAlerts
+                    .map(a => a.name)
+                    .filter((v, i, arr) => arr.indexOf(v) === i)
+                    .slice(0, 5)}
+                  className="mb-4"
+                />
+              ) : null}
+
+              {sortedAlerts.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+                  <h3
+                    className="m-0 text-lg font-semibold"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    No alerts firing
+                  </h3>
+                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    All quiet -- no active or pending alerts.
+                  </p>
+                </div>
+              ) : (
+                <table className="w-full border-collapse" data-testid="alert-table">
+                  <thead data-testid="alert-table-header">
+                    <tr>
+                      {['Status', 'Alert', 'Labels', 'Active Since'].map((label, i) => (
+                        <th
+                          key={label}
+                          className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase ${i === 3 ? 'text-right' : 'text-left'}`}
+                          style={{ color: 'var(--color-outline)' }}
+                        >
+                          {label}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedAlerts.map((alert, idx) => {
+                      const favoriteId = `alert::${selectedDatasourceId}::${alert.name}`
+                      const favorited = isFavorite(favoriteId)
+                      const rowKey = `${alert.name}|${alert.state}|${alert.activeAt}|${JSON.stringify(alert.labels ?? {})}`
+                      return (
+                        <AlertRow
+                          key={rowKey}
+                          alert={alert}
+                          expanded={expandedAlertIdx === idx}
+                          favorited={favorited}
+                          onToggleExpand={() =>
+                            setExpandedAlertIdx(prev => (prev === idx ? null : idx))
+                          }
+                          onToggleFavorite={() =>
+                            toggleFavorite({
+                              id: favoriteId,
+                              title: alert.name,
+                              type: 'alert',
+                            })
+                          }
+                        />
+                      )
+                    })}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          ) : null}
+
+          {activeTab === 'groups' ? (
+            <div>
+              {groups.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+                  <h3
+                    className="m-0 text-lg font-semibold"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    No rule groups
+                  </h3>
+                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    No alerting or recording rule groups found.
+                  </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  {groups.map(group => {
+                    const expanded = !!expandedGroups[group.name]
+                    return (
+                      <div
+                        key={group.name}
+                        className="overflow-hidden rounded-lg"
+                        style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+                        data-testid="rule-group"
+                      >
+                        <button
+                          type="button"
+                          className="flex w-full cursor-pointer items-center justify-between border-none bg-transparent px-4 py-3 text-left transition hover:opacity-90"
+                          onClick={() => toggleGroup(group.name)}
+                        >
+                          <div className="flex items-center gap-2">
+                            {expanded ? (
+                              <ChevronDown size={16} style={{ color: 'var(--color-outline)' }} />
+                            ) : (
+                              <ChevronRight size={16} style={{ color: 'var(--color-outline)' }} />
+                            )}
+                            <span
+                              className="text-sm font-semibold"
+                              style={{ color: 'var(--color-on-surface)' }}
+                            >
+                              {group.name}
+                            </span>
+                          </div>
+                          <span
+                            className="font-mono text-xs"
+                            style={{ color: 'var(--color-outline)' }}
+                          >
+                            {group.rules.length} rule{group.rules.length !== 1 ? 's' : ''} · every{' '}
+                            {formatInterval(group.interval)}
+                          </span>
+                        </button>
+
+                        {expanded ? (
+                          <div
+                            className="px-4 py-3"
+                            style={{ borderTop: '1px solid var(--color-outline-variant)' }}
+                          >
+                            <div className="flex flex-col">
+                              {group.rules.map((rule, rIdx) => (
+                                <div
+                                  key={`${group.name}:${rule.name}:${rule.type}:${rule.query}:${rule.duration}`}
+                                  className="py-3"
+                                  style={
+                                    rIdx > 0
+                                      ? { borderTop: '1px solid var(--color-outline-variant)' }
+                                      : undefined
+                                  }
+                                  data-testid="rule-item"
+                                >
+                                  <div className="mb-2 flex flex-wrap items-center gap-2">
+                                    <span
+                                      className="text-sm font-semibold"
+                                      style={{ color: 'var(--color-on-surface)' }}
+                                    >
+                                      {rule.name}
+                                    </span>
+                                    <span
+                                      className="rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase"
+                                      style={{
+                                        backgroundColor:
+                                          rule.type === 'alerting'
+                                            ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                                            : 'color-mix(in srgb, var(--color-primary) 15%, transparent)',
+                                        color:
+                                          rule.type === 'alerting'
+                                            ? 'var(--color-error)'
+                                            : 'var(--color-primary)',
+                                      }}
+                                    >
+                                      {rule.type}
+                                    </span>
+                                    {rule.state ? (
+                                      <span
+                                        className="rounded-sm px-2 py-0.5 text-xs font-semibold"
+                                        style={{
+                                          backgroundColor:
+                                            rule.state === 'firing'
+                                              ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                                              : rule.state === 'pending'
+                                                ? 'color-mix(in srgb, var(--color-tertiary) 15%, transparent)'
+                                                : 'var(--color-surface-container-high)',
+                                          color:
+                                            rule.state === 'firing'
+                                              ? 'var(--color-error)'
+                                              : rule.state === 'pending'
+                                                ? 'var(--color-tertiary)'
+                                                : 'var(--color-on-surface-variant)',
+                                        }}
+                                      >
+                                        {rule.state}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                  <div
+                                    className="mb-2 overflow-x-auto rounded-sm px-3 py-2"
+                                    style={{
+                                      backgroundColor: 'var(--color-surface-container-high)',
+                                    }}
+                                  >
+                                    <code
+                                      className="font-mono text-xs break-all whitespace-pre-wrap"
+                                      style={{ color: 'var(--color-on-surface-variant)' }}
+                                    >
+                                      {rule.query}
+                                    </code>
+                                  </div>
+                                  <div className="flex flex-wrap items-center gap-1.5">
+                                    {rule.duration > 0 ? (
+                                      <span
+                                        className="mr-1 text-xs"
+                                        style={{ color: 'var(--color-outline)' }}
+                                      >
+                                        <strong>for:</strong> {formatDuration(rule.duration)}
+                                      </span>
+                                    ) : null}
+                                    {Object.entries(rule.labels ?? {}).map(([key, value]) => (
+                                      <span
+                                        key={key}
+                                        className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                                        style={{
+                                          backgroundColor: 'var(--color-surface-container-high)',
+                                          color: 'var(--color-on-surface-variant)',
+                                        }}
+                                      >
+                                        {key}={value}
+                                      </span>
+                                    ))}
+                                  </div>
+                                  {rule.annotations && Object.keys(rule.annotations).length > 0 ? (
+                                    <div
+                                      className="mt-2 pt-2"
+                                      style={{
+                                        borderTop: '1px solid var(--color-outline-variant)',
+                                      }}
+                                    >
+                                      {Object.entries(rule.annotations).map(([key, value]) => (
+                                        <div
+                                          key={key}
+                                          className="text-xs leading-relaxed"
+                                          style={{ color: 'var(--color-outline)' }}
+                                        >
+                                          <strong
+                                            style={{ color: 'var(--color-on-surface-variant)' }}
+                                          >
+                                            {key}:
+                                          </strong>{' '}
+                                          {value}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : null}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          ) : null}
+        </>
+      ) : selectedDatasourceId && isAlertManager ? (
+        <>
+          <div
+            className="mb-6 flex gap-1"
+            style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
+          >
+            {(
+              [
+                ['am-alerts', 'Active Alerts', amAlerts.length, true],
+                ['am-silences', 'Silences', activeSilences.length, false],
+                ['am-receivers', 'Receivers', amReceivers.length, false],
+              ] as const
+            ).map(([tab, label, count, isError]) => (
+              <button
+                key={tab}
+                type="button"
+                className="cursor-pointer bg-transparent px-4 py-2.5 text-sm font-medium transition"
+                style={{
+                  color: activeTab === tab ? 'var(--color-primary)' : 'var(--color-outline)',
+                  borderBottom:
+                    activeTab === tab ? '2px solid var(--color-primary)' : '2px solid transparent',
+                }}
+                data-testid={`alerts-tab-${tab}`}
+                onClick={() => setActiveTab(tab)}
+              >
+                {label}
+                {count > 0 ? (
+                  <span
+                    className="ml-1.5 rounded-sm px-2 py-0.5 font-mono text-xs"
+                    style={{
+                      backgroundColor: isError
+                        ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                        : 'var(--color-surface-container-high)',
+                      color: isError ? 'var(--color-error)' : 'var(--color-outline)',
+                    }}
+                  >
+                    {count}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>
+
+          {activeTab === 'am-alerts' ? (
+            <div>
+              <div className="mb-4 flex items-center gap-2">
+                <span className="text-xs font-medium" style={{ color: 'var(--color-outline)' }}>
+                  Show:
+                </span>
+                {(
+                  [
+                    ['Active', amFilterActive, setAmFilterActive, 'alerts-filter-active-btn'],
+                    [
+                      'Silenced',
+                      amFilterSilenced,
+                      setAmFilterSilenced,
+                      'alerts-filter-silenced-btn',
+                    ],
+                    [
+                      'Inhibited',
+                      amFilterInhibited,
+                      setAmFilterInhibited,
+                      'alerts-filter-inhibited-btn',
+                    ],
+                  ] as const
+                ).map(([label, on, setOn, testId]) => (
+                  <button
+                    key={label}
+                    type="button"
+                    className="cursor-pointer rounded-sm px-2.5 py-1 text-xs transition"
+                    style={{
+                      backgroundColor: on
+                        ? 'color-mix(in srgb, var(--color-primary) 15%, transparent)'
+                        : 'var(--color-surface-container-high)',
+                      color: on ? 'var(--color-primary)' : 'var(--color-outline)',
+                      border: on
+                        ? '1px solid var(--color-primary)'
+                        : '1px solid var(--color-outline-variant)',
+                    }}
+                    data-testid={testId}
+                    onClick={() => setOn(v => !v)}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              {sortedAMAlerts.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+                  <h3
+                    className="m-0 text-lg font-semibold"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    No alerts
+                  </h3>
+                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    No alerts matching current filters.
+                  </p>
+                </div>
+              ) : (
+                <table className="w-full border-collapse" data-testid="am-alert-table">
+                  <thead>
+                    <tr>
+                      {['Status', 'Alert', 'Severity', 'Started'].map((label, i) => (
+                        <th
+                          key={label}
+                          className={`px-4 py-3 text-xs font-semibold tracking-wider uppercase ${i === 3 ? 'text-right' : 'text-left'}`}
+                          style={{ color: 'var(--color-outline)' }}
+                        >
+                          {label}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedAMAlerts.map(alert => {
+                      const favoriteId = alert.fingerprint
+                        ? `alert::${selectedDatasourceId}::${alert.fingerprint}`
+                        : null
+                      const favorited = favoriteId ? isFavorite(favoriteId) : false
+                      const rowKey =
+                        alert.fingerprint ||
+                        `${alert.labels?.alertname ?? 'alert'}|${alert.startsAt}|${alert.status?.state ?? ''}`
+                      return (
+                        <tr key={rowKey} className="transition-colors hover:opacity-90">
+                          <td className="px-4 py-3">
+                            <StatusDot
+                              status={stateToStatusDot(alert.status?.state || '')}
+                              size={8}
+                            />
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <span
+                                className="text-sm font-semibold"
+                                style={{ color: 'var(--color-on-surface)' }}
+                              >
+                                {alert.labels?.alertname || '--'}
+                              </span>
+                              {favoriteId ? (
+                                <button
+                                  type="button"
+                                  className="shrink-0 cursor-pointer border-none bg-transparent p-0.5"
+                                  title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+                                  onClick={() =>
+                                    toggleFavorite({
+                                      id: favoriteId,
+                                      title: alert.labels?.alertname || 'Alert',
+                                      type: 'alert',
+                                    })
+                                  }
+                                >
+                                  <Star
+                                    size={12}
+                                    fill={favorited ? 'currentColor' : 'none'}
+                                    style={{
+                                      color: favorited
+                                        ? 'var(--color-primary)'
+                                        : 'var(--color-outline)',
+                                    }}
+                                  />
+                                </button>
+                              ) : null}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span
+                              className="font-mono text-xs"
+                              style={{ color: 'var(--color-on-surface-variant)' }}
+                            >
+                              {alert.labels?.severity || 'none'}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            <span
+                              className="font-mono text-xs"
+                              style={{ color: 'var(--color-outline)' }}
+                            >
+                              {formatDateShort(alert.startsAt)}
+                            </span>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          ) : null}
+
+          {activeTab === 'am-silences' ? (
+            <div>
+              <div className="mb-4 flex items-center justify-between">
+                <h3
+                  className="m-0 text-sm font-semibold"
+                  style={{ color: 'var(--color-on-surface)' }}
+                >
+                  Silences
+                </h3>
+                <button
+                  type="button"
+                  data-testid="alerts-new-silence-btn"
+                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-3 py-1.5 text-sm font-medium transition"
+                  style={{
+                    background:
+                      'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+                    color: '#fff',
+                    border: 'none',
+                  }}
+                  onClick={openSilenceModal}
+                >
+                  <Plus size={14} aria-hidden />
+                  New Silence
+                </button>
+              </div>
+
+              {amSilences.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+                  <BellOff size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+                  <h3
+                    className="m-0 text-lg font-semibold"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    No silences
+                  </h3>
+                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    No silence rules configured.
+                  </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  {amSilences.map(silence => (
+                    <div
+                      key={silence.id}
+                      className="rounded-lg p-4"
+                      style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+                      data-testid="silence-card"
+                    >
+                      <div className="mb-2 flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <span
+                            className="shrink-0 font-mono text-xs"
+                            style={{ color: 'var(--color-outline)' }}
+                            title={silence.id}
+                          >
+                            {truncateId(silence.id)}
+                          </span>
+                          <StatusDot
+                            status={
+                              silence.status.state === 'active'
+                                ? 'info'
+                                : silence.status.state === 'pending'
+                                  ? 'warning'
+                                  : 'healthy'
+                            }
+                            size={6}
+                          />
+                          <span
+                            className="text-xs font-semibold"
+                            style={{ color: 'var(--color-on-surface-variant)' }}
+                          >
+                            {silence.status.state}
+                          </span>
+                        </div>
+                        {silence.status.state === 'active' || silence.status.state === 'pending' ? (
+                          <button
+                            type="button"
+                            className="inline-flex shrink-0 cursor-pointer items-center gap-1 border-none bg-transparent text-sm transition"
+                            style={{ color: 'var(--color-error)' }}
+                            title="Expire silence"
+                            data-testid={`expire-silence-${silence.id}`}
+                            onClick={() => void handleExpireSilence(silence.id)}
+                          >
+                            <Trash2 size={12} aria-hidden />
+                            Expire
+                          </button>
+                        ) : null}
+                      </div>
+                      <div className="mb-2 flex flex-wrap gap-1.5">
+                        {silence.matchers.map(m => (
+                          <span
+                            key={`${m.name}${matcherOperator(m)}${m.value}`}
+                            className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                            style={{
+                              backgroundColor: 'var(--color-surface-container-high)',
+                              color: 'var(--color-on-surface-variant)',
+                            }}
+                          >
+                            {m.name}
+                            {matcherOperator(m)}&quot;{m.value}&quot;
+                          </span>
+                        ))}
+                      </div>
+                      <div
+                        className="flex items-center gap-3 text-xs"
+                        style={{ color: 'var(--color-outline)' }}
+                      >
+                        <span>{silence.createdBy}</span>
+                        <span className="max-w-[200px] truncate">{silence.comment}</span>
+                        <span className="ml-auto shrink-0 font-mono">
+                          ends {formatDateShort(silence.endsAt)}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : null}
+
+          {activeTab === 'am-receivers' ? (
+            <div>
+              {amReceivers.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+                  <Radio size={36} style={{ color: 'var(--color-outline)' }} aria-hidden />
+                  <h3
+                    className="m-0 text-lg font-semibold"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    No receivers
+                  </h3>
+                  <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+                    No receivers configured in AlertManager.
+                  </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  {amReceivers.map(receiver => (
+                    <div
+                      key={receiver.name}
+                      className="flex items-center gap-3 rounded-lg p-4"
+                      style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+                      data-testid="receiver-card"
+                    >
+                      <Radio
+                        size={16}
+                        style={{ color: 'var(--color-outline)' }}
+                        className="shrink-0"
+                        aria-hidden
+                      />
+                      <span
+                        className="text-sm font-semibold"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        {receiver.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+
+      {showSilenceModal
+        ? createPortal(
+            // biome-ignore lint/a11y/noStaticElementInteractions: modal backdrop dismiss
+            <div
+              className="fixed inset-0 z-[1000] flex items-center justify-center"
+              style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+              onClick={e => {
+                if (e.target === e.currentTarget) setShowSilenceModal(false)
+              }}
+              onKeyDown={e => {
+                if (e.key === 'Escape') setShowSilenceModal(false)
+              }}
+            >
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="silence-modal-title"
+                className="max-h-[90vh] w-full max-w-[560px] overflow-y-auto rounded-lg"
+                style={{
+                  backgroundColor: 'var(--color-surface-bright)',
+                  border: '1px solid var(--color-outline-variant)',
+                }}
+              >
+                <div
+                  className="flex items-center justify-between px-5 py-4"
+                  style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
+                >
+                  <h2
+                    id="silence-modal-title"
+                    className="m-0 font-display text-base font-bold"
+                    style={{ color: 'var(--color-on-surface)' }}
+                  >
+                    Create Silence
+                  </h2>
+                  <button
+                    type="button"
+                    className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent transition"
+                    style={{ color: 'var(--color-outline)' }}
+                    onClick={() => setShowSilenceModal(false)}
+                    aria-label="Close"
+                  >
+                    <X size={18} />
+                  </button>
+                </div>
+
+                <div className="flex flex-col gap-4 px-5 py-5">
+                  <div className="flex flex-col gap-1.5">
+                    <div
+                      className="text-sm font-medium"
+                      style={{ color: 'var(--color-on-surface-variant)' }}
+                    >
+                      Matchers <span style={{ color: 'var(--color-error)' }}>*</span>
+                    </div>
+                    <div className="mb-2 flex flex-col gap-2">
+                      {silenceMatchers.map((m, idx) => (
+                        <div key={m.key} className="flex items-center gap-2">
+                          <input
+                            value={m.name}
+                            onChange={e => {
+                              const next = [...silenceMatchers]
+                              next[idx] = { ...m, name: e.target.value }
+                              setSilenceMatchers(next)
+                            }}
+                            type="text"
+                            placeholder="Label name"
+                            data-testid={`silence-matcher-name-${idx}`}
+                            className="flex-1 rounded-sm px-2.5 py-1.5 font-mono text-sm focus:outline-none"
+                            style={{
+                              backgroundColor: 'var(--color-surface-container-high)',
+                              color: 'var(--color-on-surface)',
+                              border: '1px solid var(--color-outline-variant)',
+                            }}
+                          />
+                          <select
+                            value={m.isEqual ? 'eq' : 'neq'}
+                            onChange={e => {
+                              const next = [...silenceMatchers]
+                              next[idx] = { ...m, isEqual: e.target.value === 'eq' }
+                              setSilenceMatchers(next)
+                            }}
+                            className="w-13 rounded-sm px-1.5 py-1.5 text-center font-mono text-sm focus:outline-none"
+                            style={{
+                              backgroundColor: 'var(--color-surface-container-high)',
+                              color: 'var(--color-on-surface)',
+                              border: '1px solid var(--color-outline-variant)',
+                            }}
+                          >
+                            <option value="eq">{m.isRegex ? '=~' : '='}</option>
+                            <option value="neq">{m.isRegex ? '!~' : '!='}</option>
+                          </select>
+                          <input
+                            value={m.value}
+                            onChange={e => {
+                              const next = [...silenceMatchers]
+                              next[idx] = { ...m, value: e.target.value }
+                              setSilenceMatchers(next)
+                            }}
+                            type="text"
+                            placeholder="Value"
+                            data-testid={`silence-matcher-value-${idx}`}
+                            className="flex-1 rounded-sm px-2.5 py-1.5 font-mono text-sm focus:outline-none"
+                            style={{
+                              backgroundColor: 'var(--color-surface-container-high)',
+                              color: 'var(--color-on-surface)',
+                              border: '1px solid var(--color-outline-variant)',
+                            }}
+                          />
+                          <label
+                            className="flex cursor-pointer items-center gap-1 text-xs whitespace-nowrap"
+                            style={{ color: 'var(--color-outline)' }}
+                            title="Regex match"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={m.isRegex}
+                              onChange={e => {
+                                const next = [...silenceMatchers]
+                                next[idx] = { ...m, isRegex: e.target.checked }
+                                setSilenceMatchers(next)
+                              }}
+                              className="h-3.5 w-3.5"
+                            />
+                            Regex
+                          </label>
+                          <button
+                            type="button"
+                            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent transition disabled:cursor-not-allowed disabled:opacity-40"
+                            style={{ color: 'var(--color-outline)' }}
+                            disabled={silenceMatchers.length <= 1}
+                            onClick={() => {
+                              if (silenceMatchers.length > 1) {
+                                setSilenceMatchers(silenceMatchers.filter(item => item.key !== m.key))
+                              }
+                            }}
+                            title="Remove matcher"
+                          >
+                            <X size={14} />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 self-start border-none bg-transparent text-sm transition"
+                      style={{ color: 'var(--color-primary)' }}
+                      onClick={() =>
+                        setSilenceMatchers([
+                          ...silenceMatchers,
+                          {
+                            key: `matcher-${Date.now()}-${silenceMatchers.length}`,
+                            name: '',
+                            value: '',
+                            isRegex: false,
+                            isEqual: true,
+                          },
+                        ])
+                      }
+                    >
+                      <Plus size={12} aria-hidden />
+                      Add Matcher
+                    </button>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1.5">
+                      <label
+                        htmlFor="silence-start"
+                        className="text-sm font-medium"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      >
+                        Start
+                      </label>
+                      <input
+                        id="silence-start"
+                        data-testid="silence-start-input"
+                        value={silenceStart}
+                        onChange={e => setSilenceStart(e.target.value)}
+                        type="datetime-local"
+                        className="rounded-sm px-3 py-2 text-sm focus:outline-none"
+                        style={{
+                          backgroundColor: 'var(--color-surface-container-high)',
+                          color: 'var(--color-on-surface)',
+                          border: '1px solid var(--color-outline-variant)',
+                        }}
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <label
+                        htmlFor="silence-end"
+                        className="text-sm font-medium"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      >
+                        End
+                      </label>
+                      <input
+                        id="silence-end"
+                        data-testid="silence-end-input"
+                        value={silenceEnd}
+                        onChange={e => setSilenceEnd(e.target.value)}
+                        type="datetime-local"
+                        className="rounded-sm px-3 py-2 text-sm focus:outline-none"
+                        style={{
+                          backgroundColor: 'var(--color-surface-container-high)',
+                          color: 'var(--color-on-surface)',
+                          border: '1px solid var(--color-outline-variant)',
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-1.5">
+                    <label
+                      htmlFor="silence-created-by"
+                      className="text-sm font-medium"
+                      style={{ color: 'var(--color-on-surface-variant)' }}
+                    >
+                      Created By
+                    </label>
+                    <input
+                      id="silence-created-by"
+                      data-testid="silence-created-by-input"
+                      value={silenceCreatedBy}
+                      onChange={e => setSilenceCreatedBy(e.target.value)}
+                      type="text"
+                      placeholder="your-name@example.com"
+                      className="rounded-sm px-3 py-2 text-sm focus:outline-none"
+                      style={{
+                        backgroundColor: 'var(--color-surface-container-high)',
+                        color: 'var(--color-on-surface)',
+                        border: '1px solid var(--color-outline-variant)',
+                      }}
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1.5">
+                    <label
+                      htmlFor="silence-comment"
+                      className="text-sm font-medium"
+                      style={{ color: 'var(--color-on-surface-variant)' }}
+                    >
+                      Comment <span style={{ color: 'var(--color-error)' }}>*</span>
+                    </label>
+                    <textarea
+                      id="silence-comment"
+                      data-testid="silence-comment-input"
+                      value={silenceComment}
+                      onChange={e => setSilenceComment(e.target.value)}
+                      rows={3}
+                      placeholder="Reason for silencing..."
+                      className="min-h-[68px] resize-y rounded-sm px-3 py-2 text-sm focus:outline-none"
+                      style={{
+                        backgroundColor: 'var(--color-surface-container-high)',
+                        color: 'var(--color-on-surface)',
+                        border: '1px solid var(--color-outline-variant)',
+                        fontFamily: 'inherit',
+                      }}
+                    />
+                  </div>
+
+                  {silenceError ? (
+                    <div
+                      className="flex items-center gap-2 rounded-sm px-4 py-3 text-sm"
+                      style={{
+                        backgroundColor: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+                        color: 'var(--color-error)',
+                      }}
+                      data-testid="silence-error"
+                    >
+                      <AlertCircle size={14} aria-hidden />
+                      {silenceError}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div
+                  className="flex justify-end gap-2.5 px-5 py-4"
+                  style={{ borderTop: '1px solid var(--color-outline-variant)' }}
+                >
+                  <button
+                    type="button"
+                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-3 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+                    style={{
+                      backgroundColor: 'var(--color-surface-container-high)',
+                      color: 'var(--color-on-surface-variant)',
+                      border: '1px solid var(--color-outline-variant)',
+                    }}
+                    data-testid="silence-cancel-btn"
+                    onClick={() => setShowSilenceModal(false)}
+                    disabled={silenceSaving}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+                    style={{
+                      background:
+                        'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
+                      color: '#fff',
+                      border: 'none',
+                    }}
+                    data-testid="silence-create-btn"
+                    onClick={() => void handleCreateSilence()}
+                    disabled={silenceSaving}
+                  >
+                    {silenceSaving ? (
+                      <Loader2 size={14} className="animate-spin" aria-hidden />
+                    ) : null}
+                    {silenceSaving ? 'Creating...' : 'Create Silence'}
+                  </button>
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
+  )
+}
+
+type AlertRowProps = {
+  alert: VMAlertAlert
+  expanded: boolean
+  favorited: boolean
+  onToggleExpand: () => void
+  onToggleFavorite: () => void
+}
+
+function AlertRow({
+  alert,
+  expanded,
+  favorited,
+  onToggleExpand,
+  onToggleFavorite,
+}: AlertRowProps) {
+  return (
+    <>
+      {/* biome-ignore lint/a11y/useSemanticElements: expandable table row pattern */}
+      <tr
+        data-testid="alert-row"
+        className="cursor-pointer transition-colors"
+        style={{
+          backgroundColor: expanded ? 'var(--color-surface-container-high)' : 'transparent',
+        }}
+        onClick={onToggleExpand}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onToggleExpand()
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        <td className="px-4 py-3">
+          <StatusDot status={stateToStatusDot(alert.state)} size={8} />
+        </td>
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+              {alert.name}
+            </span>
+            <button
+              type="button"
+              className="shrink-0 cursor-pointer border-none bg-transparent p-0.5"
+              title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+              onClick={e => {
+                e.stopPropagation()
+                onToggleFavorite()
+              }}
+            >
+              <Star
+                size={12}
+                fill={favorited ? 'currentColor' : 'none'}
+                style={{
+                  color: favorited ? 'var(--color-primary)' : 'var(--color-outline)',
+                }}
+              />
+            </button>
+          </div>
+        </td>
+        <td className="px-4 py-3">
+          {alert.labels && Object.keys(alert.labels).length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {Object.entries(alert.labels).map(([key, value]) => (
+                <span
+                  key={key}
+                  className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                  style={{
+                    backgroundColor: 'var(--color-surface-container-high)',
+                    color: 'var(--color-on-surface-variant)',
+                  }}
+                >
+                  {key}={value}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </td>
+        <td className="px-4 py-3 text-right">
+          <span className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
+            {alert.activeAt || '--'}
+          </span>
+        </td>
+      </tr>
+      {expanded ? (
+        <tr data-testid="alert-detail">
+          <td
+            colSpan={4}
+            className="px-4 py-4"
+            style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+          >
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-3">
+                <span
+                  className="text-xs font-semibold tracking-wider uppercase"
+                  style={{ color: 'var(--color-outline)' }}
+                >
+                  State
+                </span>
+                <span
+                  className="rounded-sm px-2 py-0.5 font-mono text-xs font-semibold"
+                  style={{
+                    backgroundColor:
+                      alert.state === 'firing'
+                        ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                        : alert.state === 'pending'
+                          ? 'color-mix(in srgb, var(--color-tertiary) 15%, transparent)'
+                          : 'var(--color-surface-container-high)',
+                    color:
+                      alert.state === 'firing'
+                        ? 'var(--color-error)'
+                        : alert.state === 'pending'
+                          ? 'var(--color-tertiary)'
+                          : 'var(--color-on-surface-variant)',
+                  }}
+                >
+                  {alert.state}
+                </span>
+              </div>
+              {alert.labels && Object.keys(alert.labels).length > 0 ? (
+                <div>
+                  <span
+                    className="text-xs font-semibold tracking-wider uppercase"
+                    style={{ color: 'var(--color-outline)' }}
+                  >
+                    Labels
+                  </span>
+                  <div className="mt-1 flex flex-wrap gap-1.5">
+                    {Object.entries(alert.labels).map(([key, value]) => (
+                      <span
+                        key={key}
+                        className="inline-flex rounded-sm px-2 py-0.5 font-mono text-xs"
+                        style={{
+                          backgroundColor: 'var(--color-surface-container-high)',
+                          color: 'var(--color-on-surface-variant)',
+                        }}
+                      >
+                        {key}={value}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              <div className="font-mono text-xs" style={{ color: 'var(--color-outline)' }}>
+                Active since: {alert.activeAt || '--'}
+              </div>
+            </div>
+          </td>
+        </tr>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/pages/ServicesPage.spec.tsx
+++ b/frontend/src/pages/ServicesPage.spec.tsx
@@ -1,0 +1,154 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as datasourcesApi from '@/api/datasources'
+import { ServicesPage } from '@/pages/ServicesPage'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+import type { DataSource } from '@/types/datasource'
+
+vi.mock('@/analytics', () => ({
+  identifyUser: vi.fn(),
+  resetUserAnalytics: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+function makeDatasource(overrides: Partial<DataSource> = {}): DataSource {
+  return {
+    id: 'ds-1',
+    organization_id: 'org-1',
+    name: 'Tempo Prod',
+    type: 'tempo',
+    url: 'http://tempo:3200',
+    is_default: true,
+    auth_type: 'none',
+    trace_id_field: 'trace_id',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderServices() {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [
+      { path: '/app/services', element: <ServicesPage /> },
+      { path: '/app/settings/datasources', element: <div>Datasources</div> },
+      { path: '/app/explore/traces', element: <div>Traces</div> },
+    ],
+    { initialEntries: ['/app/services'] },
+  )
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  return router
+}
+
+describe('ServicesPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    useOrgStore.setState({ currentOrgId: 'org-1' })
+    useFavoritesStore.setState({ favorites: [], recentDashboards: [] })
+  })
+
+  it('renders services discovered from tracing datasources', async () => {
+    const tempo = makeDatasource({ id: 'tempo-1', name: 'Tempo Prod', type: 'tempo' })
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([tempo])
+    vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServices').mockResolvedValue([
+      'checkout-api',
+      'payments-worker',
+    ])
+
+    renderServices()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('service-card')).toHaveLength(2)
+    })
+
+    expect(screen.getByText('checkout-api')).toBeTruthy()
+    expect(screen.getByText('payments-worker')).toBeTruthy()
+    expect(screen.getAllByText('Tempo Prod').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Inventory only').length).toBeGreaterThan(0)
+    expect(screen.getByText(/not show sample health data/i)).toBeTruthy()
+  })
+
+  it('does not render previous hardcoded demo services as live data', async () => {
+    const tempo = makeDatasource({ id: 'tempo-1' })
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([tempo])
+    vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServices').mockResolvedValue(['checkout-api'])
+
+    renderServices()
+
+    await waitFor(() => {
+      expect(screen.getByText('checkout-api')).toBeTruthy()
+    })
+
+    expect(screen.queryByText('API Gateway')).toBeNull()
+    expect(screen.queryByText('Payment Service')).toBeNull()
+    expect(screen.queryByText('Analytics Pipeline')).toBeNull()
+    expect(screen.queryAllByTestId('service-ai-chip')).toHaveLength(0)
+  })
+
+  it('shows an honest empty state when no datasources are configured', async () => {
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([])
+
+    renderServices()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state-title').textContent).toBe(
+        'No service telemetry configured',
+      )
+    })
+
+    expect(screen.getByTestId('empty-state-description').textContent).toContain(
+      'will not show hardcoded sample services',
+    )
+    expect(screen.getByTestId('empty-state-action').textContent).toBe('Add Data Source')
+  })
+
+  it('asks for tracing datasource when only non-tracing datasources exist', async () => {
+    const prometheus = makeDatasource({
+      id: 'prom-1',
+      name: 'Prometheus Prod',
+      type: 'prometheus',
+    })
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([prometheus])
+
+    renderServices()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state-title').textContent).toBe(
+        'No tracing datasource configured',
+      )
+    })
+
+    expect(screen.getByTestId('empty-state-description').textContent).toContain(
+      'Tempo, VictoriaTraces, or ClickHouse',
+    )
+  })
+
+  it('shows discovery error instead of falling back to sample services', async () => {
+    const tempo = makeDatasource({ id: 'tempo-1' })
+    vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([tempo])
+    vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServices').mockRejectedValue(
+      new Error('trace endpoint unavailable'),
+    )
+
+    renderServices()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('services-discovery-error')).toBeTruthy()
+    })
+
+    expect(screen.getByText(/Service discovery failed for 1 tracing datasource/)).toBeTruthy()
+    expect(screen.queryAllByTestId('service-card')).toHaveLength(0)
+  })
+})

--- a/frontend/src/pages/ServicesPage.spec.tsx
+++ b/frontend/src/pages/ServicesPage.spec.tsx
@@ -7,7 +7,7 @@ import { ServicesPage } from '@/pages/ServicesPage'
 import { useFavoritesStore } from '@/stores/favoritesStore'
 import { useOrgStore } from '@/stores/orgStore'
 import { createTestQueryClient } from '@/test/renderWithProviders'
-import type { DataSource } from '@/types/datasource'
+import type { DataSource, TraceSummary } from '@/types/datasource'
 
 vi.mock('@/analytics', () => ({
   identifyUser: vi.fn(),
@@ -27,6 +27,18 @@ function makeDatasource(overrides: Partial<DataSource> = {}): DataSource {
     trace_id_field: 'trace_id',
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeTrace(overrides: Partial<TraceSummary> = {}): TraceSummary {
+  return {
+    traceId: 'trace-1',
+    startTimeUnixNano: 0,
+    durationNano: 25_000_000,
+    spanCount: 4,
+    serviceCount: 1,
+    errorSpanCount: 0,
     ...overrides,
   }
 }
@@ -59,13 +71,25 @@ describe('ServicesPage', () => {
     useFavoritesStore.setState({ favorites: [], recentDashboards: [] })
   })
 
-  it('renders services discovered from tracing datasources', async () => {
+  it('renders services with health, latency, and error rate views', async () => {
     const tempo = makeDatasource({ id: 'tempo-1', name: 'Tempo Prod', type: 'tempo' })
     vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([tempo])
     vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServices').mockResolvedValue([
       'checkout-api',
       'payments-worker',
     ])
+    vi.spyOn(datasourcesApi, 'searchDataSourceTraces').mockImplementation(async (_id, req) => {
+      if (req.service === 'checkout-api') {
+        return [
+          makeTrace({ durationNano: 20_000_000, errorSpanCount: 0 }),
+          makeTrace({ durationNano: 40_000_000, errorSpanCount: 0 }),
+        ]
+      }
+      return [
+        makeTrace({ durationNano: 2_000_000_000, errorSpanCount: 1 }),
+        makeTrace({ durationNano: 3_000_000_000, errorSpanCount: 1 }),
+      ]
+    })
 
     renderServices()
 
@@ -75,15 +99,19 @@ describe('ServicesPage', () => {
 
     expect(screen.getByText('checkout-api')).toBeTruthy()
     expect(screen.getByText('payments-worker')).toBeTruthy()
-    expect(screen.getAllByText('Tempo Prod').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('Inventory only').length).toBeGreaterThan(0)
-    expect(screen.getByText(/not show sample health data/i)).toBeTruthy()
+    expect(screen.getByTestId('services-health-summary')).toBeTruthy()
+    expect(screen.getAllByTestId('service-latency-p50').length).toBe(2)
+    expect(screen.getAllByTestId('service-error-rate').length).toBe(2)
+    expect(screen.getByText(/health, latency \(p50\/p95\), and error rate/i)).toBeTruthy()
   })
 
   it('does not render previous hardcoded demo services as live data', async () => {
     const tempo = makeDatasource({ id: 'tempo-1' })
     vi.spyOn(datasourcesApi, 'listDataSources').mockResolvedValue([tempo])
     vi.spyOn(datasourcesApi, 'fetchDataSourceTraceServices').mockResolvedValue(['checkout-api'])
+    vi.spyOn(datasourcesApi, 'searchDataSourceTraces').mockResolvedValue([
+      makeTrace({ durationNano: 15_000_000 }),
+    ])
 
     renderServices()
 

--- a/frontend/src/pages/ServicesPage.tsx
+++ b/frontend/src/pages/ServicesPage.tsx
@@ -104,7 +104,7 @@ export function ServicesPage() {
 
             const serviceItems = await Promise.all(
               uniqueNames.map(async name => {
-                let metrics
+                let metrics: ServiceHealthMetrics
                 try {
                   const summaries = await searchDataSourceTraces(source.id, {
                     service: name,

--- a/frontend/src/pages/ServicesPage.tsx
+++ b/frontend/src/pages/ServicesPage.tsx
@@ -1,9 +1,20 @@
 import { Activity, AlertCircle, Star } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
-import { fetchDataSourceTraceServices } from '@/api/datasources'
+import {
+  fetchDataSourceTraceServices,
+  searchDataSourceTraces,
+} from '@/api/datasources'
 import { EmptyState } from '@/components/EmptyState'
 import { StatusDot } from '@/components/StatusDot'
 import { useTracingDatasources } from '@/hooks/useTracingDatasources'
+import {
+  deriveServiceHealth,
+  formatErrorRate,
+  formatLatencyMs,
+  healthLabel,
+  type ServiceHealthMetrics,
+  type ServiceHealthStatus,
+} from '@/lib/serviceHealth'
 import { useFavoritesStore } from '@/stores/favoritesStore'
 import { useOrgStore } from '@/stores/orgStore'
 import { dataSourceTypeLabels, type DataSource } from '@/types/datasource'
@@ -14,12 +25,21 @@ interface ServiceInventoryItem {
   sourceId: string
   sourceName: string
   sourceTypeLabel: string
-  status: 'info'
+  status: ServiceHealthStatus
+  metrics: ServiceHealthMetrics
 }
 
 function labelForDataSource(source: DataSource): string {
   return source.name || dataSourceTypeLabels[source.type]
 }
+
+function statusDotForHealth(status: ServiceHealthStatus): 'healthy' | 'warning' | 'critical' | 'info' {
+  if (status === 'unknown') return 'info'
+  return status
+}
+
+const HEALTH_WINDOW_MS = 60 * 60 * 1000
+const TRACE_SAMPLE_LIMIT = 50
 
 export function ServicesPage() {
   const currentOrgId = useOrgStore(state => state.currentOrgId)
@@ -36,6 +56,7 @@ export function ServicesPage() {
   const [services, setServices] = useState<ServiceInventoryItem[]>([])
   const [loadingServices, setLoadingServices] = useState(false)
   const [discoveryError, setDiscoveryError] = useState<string | null>(null)
+  const [metricsPartial, setMetricsPartial] = useState(false)
 
   const hasDataSources = datasources.length > 0
   const hasTracingSources = tracingDatasources.length > 0
@@ -47,15 +68,17 @@ export function ServicesPage() {
         : null
 
   const tracingSourceKey = useMemo(
-    () => tracingDatasources.map(source => `${source.id}:${source.name}:${source.type}`).join('|'),
-    [tracingDatasources],
+    () =>
+      `${currentOrgId ?? 'none'}|${tracingDatasources.map(source => `${source.id}:${source.name}:${source.type}`).join('|')}`,
+    [currentOrgId, tracingDatasources],
   )
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed by tracingSourceKey to avoid array-identity refetches
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed by tracingSourceKey (includes org) to avoid array-identity refetches
   useEffect(() => {
     if (tracingDatasources.length === 0) {
       setServices([])
       setDiscoveryError(null)
+      setMetricsPartial(false)
       setLoadingServices(false)
       return
     }
@@ -63,42 +86,72 @@ export function ServicesPage() {
     const controller = new AbortController()
     let cancelled = false
     const sources = tracingDatasources
+    const endMs = Date.now()
+    const startMs = endMs - HEALTH_WINDOW_MS
 
     async function loadDiscoveredServices() {
       setLoadingServices(true)
       setDiscoveryError(null)
+      setMetricsPartial(false)
 
       try {
         const results = await Promise.allSettled(
           sources.map(async source => {
             const names = await fetchDataSourceTraceServices(source.id, controller.signal)
-            return names
-              .map(name => name.trim())
-              .filter(Boolean)
-              .map<ServiceInventoryItem>(name => ({
-                id: `${source.id}:${name}`,
-                name,
-                sourceId: source.id,
-                sourceName: labelForDataSource(source),
-                sourceTypeLabel: dataSourceTypeLabels[source.type],
-                status: 'info',
-              }))
+            const uniqueNames = [
+              ...new Set(names.map(name => name.trim()).filter(Boolean)),
+            ]
+
+            const serviceItems = await Promise.all(
+              uniqueNames.map(async name => {
+                let metrics = deriveServiceHealth([])
+                try {
+                  const summaries = await searchDataSourceTraces(source.id, {
+                    service: name,
+                    start: Math.floor(startMs / 1000),
+                    end: Math.floor(endMs / 1000),
+                    limit: TRACE_SAMPLE_LIMIT,
+                  })
+                  if (controller.signal.aborted) {
+                    return null
+                  }
+                  metrics = deriveServiceHealth(summaries)
+                } catch {
+                  // Metrics are best-effort; inventory still renders.
+                  metrics = deriveServiceHealth([])
+                }
+
+                return {
+                  id: `${source.id}:${name}`,
+                  name,
+                  sourceId: source.id,
+                  sourceName: labelForDataSource(source),
+                  sourceTypeLabel: dataSourceTypeLabels[source.type],
+                  status: metrics.health,
+                  metrics,
+                } satisfies ServiceInventoryItem
+              }),
+            )
+
+            return serviceItems.filter((item): item is ServiceInventoryItem => item !== null)
           }),
         )
 
         if (cancelled || controller.signal.aborted) return
 
-        setServices(
-          results
-            .flatMap(result => (result.status === 'fulfilled' ? result.value : []))
-            .sort((left, right) => left.name.localeCompare(right.name)),
+        const fulfilled = results.flatMap(result =>
+          result.status === 'fulfilled' ? result.value : [],
         )
+        setServices(fulfilled.sort((left, right) => left.name.localeCompare(right.name)))
 
         const failedSources = results.filter(result => result.status === 'rejected').length
         setDiscoveryError(
           failedSources
             ? `Service discovery failed for ${failedSources} tracing datasource${failedSources === 1 ? '' : 's'}.`
             : null,
+        )
+        setMetricsPartial(
+          fulfilled.some(service => service.metrics.sampleCount === 0 && service.status === 'unknown'),
         )
       } catch (error) {
         if (cancelled || controller.signal.aborted) return
@@ -121,6 +174,17 @@ export function ServicesPage() {
 
   const loading = datasourcesLoading || loadingServices
 
+  const healthCounts = useMemo(() => {
+    const counts = { healthy: 0, warning: 0, critical: 0, unknown: 0 }
+    for (const service of services) {
+      if (service.status === 'healthy') counts.healthy++
+      else if (service.status === 'warning') counts.warning++
+      else if (service.status === 'critical') counts.critical++
+      else counts.unknown++
+    }
+    return counts
+  }, [services])
+
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-6">
       <div className="mb-6">
@@ -128,8 +192,7 @@ export function ServicesPage() {
           Services
         </h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-          Service inventory discovered from tracing datasources. Ace does not show sample health
-          data here.
+          Service inventory with health, latency, and error rate derived from recent traces.
         </p>
       </div>
 
@@ -143,7 +206,7 @@ export function ServicesPage() {
           }}
         >
           <Activity size={28} aria-hidden />
-          Discovering services from tracing datasources…
+          Discovering services and evaluating health from tracing datasources…
         </div>
       ) : datasourcesError ? (
         <div
@@ -216,6 +279,37 @@ export function ServicesPage() {
           ) : null}
 
           <div
+            data-testid="services-health-summary"
+            className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+          >
+            {(
+              [
+                ['Healthy', healthCounts.healthy, 'var(--color-secondary)'],
+                ['Degraded', healthCounts.warning, 'var(--color-tertiary)'],
+                ['Critical', healthCounts.critical, 'var(--color-error)'],
+                ['Unevaluated', healthCounts.unknown, 'var(--color-outline)'],
+              ] as const
+            ).map(([label, count, color]) => (
+              <div
+                key={label}
+                className="rounded-lg px-4 py-3"
+                style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+              >
+                <div className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                  {label}
+                </div>
+                <div
+                  className="mt-1 font-display text-2xl font-bold tabular-nums"
+                  style={{ color }}
+                  data-testid={`services-count-${label.toLowerCase()}`}
+                >
+                  {count}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div
             data-testid="services-data-notice"
             className="rounded-lg px-4 py-3 text-sm"
             style={{
@@ -224,14 +318,18 @@ export function ServicesPage() {
               color: 'var(--color-on-surface-variant)',
             }}
           >
-            Inventory only: health, latency, error rate, and throughput are not inferred on this
-            page until they are backed by real telemetry queries.
+            Health, latency (p50/p95), and error rate are computed from the last hour of trace
+            summaries per service (up to {TRACE_SAMPLE_LIMIT} samples).
+            {metricsPartial
+              ? ' Some services had no recent traces and show as not evaluated.'
+              : null}
           </div>
 
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {services.map(service => {
               const favoriteId = `svc::${service.name}`
               const favorited = isFavorite(favoriteId)
+              const { metrics } = service
               return (
                 <div
                   key={service.id}
@@ -240,18 +338,32 @@ export function ServicesPage() {
                   style={{ backgroundColor: 'var(--color-surface-container-low)' }}
                 >
                   <span
-                    data-testid="service-inventory-chip"
+                    data-testid="service-health-chip"
                     className="absolute top-3 right-3 rounded-full px-2.5 py-1 text-[10px] font-medium"
                     style={{
-                      backgroundColor: 'color-mix(in srgb, var(--color-primary) 15%, transparent)',
-                      color: 'var(--color-primary)',
+                      backgroundColor:
+                        service.status === 'critical'
+                          ? 'color-mix(in srgb, var(--color-error) 15%, transparent)'
+                          : service.status === 'warning'
+                            ? 'color-mix(in srgb, var(--color-tertiary) 15%, transparent)'
+                            : service.status === 'healthy'
+                              ? 'color-mix(in srgb, var(--color-secondary) 15%, transparent)'
+                              : 'color-mix(in srgb, var(--color-primary) 15%, transparent)',
+                      color:
+                        service.status === 'critical'
+                          ? 'var(--color-error)'
+                          : service.status === 'warning'
+                            ? 'var(--color-tertiary)'
+                            : service.status === 'healthy'
+                              ? 'var(--color-secondary)'
+                              : 'var(--color-primary)',
                     }}
                   >
-                    Inventory only
+                    {healthLabel(service.status)}
                   </span>
 
                   <div className="mb-4 flex items-center gap-3 pr-24">
-                    <StatusDot status={service.status} size={8} />
+                    <StatusDot status={statusDotForHealth(service.status)} size={8} />
                     <h3
                       data-testid="service-name"
                       className="flex-1 truncate font-display text-base font-semibold"
@@ -297,26 +409,62 @@ export function ServicesPage() {
                     </div>
                     <div className="flex items-center justify-between gap-3">
                       <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
-                        Datasource
+                        Health
                       </span>
                       <span
-                        data-testid="service-field"
+                        data-testid="service-health"
                         className="font-mono text-sm font-medium"
                         style={{ color: 'var(--color-on-surface)' }}
                       >
-                        {service.sourceTypeLabel}
+                        {healthLabel(service.status)}
                       </span>
                     </div>
                     <div className="flex items-center justify-between gap-3">
                       <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
-                        Health
+                        Latency p50
                       </span>
                       <span
-                        data-testid="service-field"
-                        className="font-mono text-sm font-medium"
+                        data-testid="service-latency-p50"
+                        className="font-mono text-sm font-medium tabular-nums"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        {formatLatencyMs(metrics.latencyP50Ms)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                        Latency p95
+                      </span>
+                      <span
+                        data-testid="service-latency-p95"
+                        className="font-mono text-sm font-medium tabular-nums"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        {formatLatencyMs(metrics.latencyP95Ms)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                        Error rate
+                      </span>
+                      <span
+                        data-testid="service-error-rate"
+                        className="font-mono text-sm font-medium tabular-nums"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        {formatErrorRate(metrics.errorRate)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                        Samples
+                      </span>
+                      <span
+                        data-testid="service-sample-count"
+                        className="font-mono text-sm font-medium tabular-nums"
                         style={{ color: 'var(--color-on-surface-variant)' }}
                       >
-                        Not evaluated
+                        {metrics.sampleCount}
                       </span>
                     </div>
                   </div>

--- a/frontend/src/pages/ServicesPage.tsx
+++ b/frontend/src/pages/ServicesPage.tsx
@@ -1,0 +1,331 @@
+import { Activity, AlertCircle, Star } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { fetchDataSourceTraceServices } from '@/api/datasources'
+import { EmptyState } from '@/components/EmptyState'
+import { StatusDot } from '@/components/StatusDot'
+import { useTracingDatasources } from '@/hooks/useTracingDatasources'
+import { useFavoritesStore } from '@/stores/favoritesStore'
+import { useOrgStore } from '@/stores/orgStore'
+import { dataSourceTypeLabels, type DataSource } from '@/types/datasource'
+
+interface ServiceInventoryItem {
+  id: string
+  name: string
+  sourceId: string
+  sourceName: string
+  sourceTypeLabel: string
+  status: 'info'
+}
+
+function labelForDataSource(source: DataSource): string {
+  return source.name || dataSourceTypeLabels[source.type]
+}
+
+export function ServicesPage() {
+  const currentOrgId = useOrgStore(state => state.currentOrgId)
+  const {
+    data: datasources = [],
+    tracingDatasources,
+    isLoading: datasourcesLoading,
+    error: datasourcesQueryError,
+  } = useTracingDatasources(currentOrgId)
+
+  const toggleFavorite = useFavoritesStore(state => state.toggleFavorite)
+  const isFavorite = useFavoritesStore(state => state.isFavorite)
+
+  const [services, setServices] = useState<ServiceInventoryItem[]>([])
+  const [loadingServices, setLoadingServices] = useState(false)
+  const [discoveryError, setDiscoveryError] = useState<string | null>(null)
+
+  const hasDataSources = datasources.length > 0
+  const hasTracingSources = tracingDatasources.length > 0
+  const datasourcesError =
+    datasourcesQueryError instanceof Error
+      ? datasourcesQueryError.message
+      : datasourcesQueryError
+        ? String(datasourcesQueryError)
+        : null
+
+  const tracingSourceKey = useMemo(
+    () => tracingDatasources.map(source => `${source.id}:${source.name}:${source.type}`).join('|'),
+    [tracingDatasources],
+  )
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed by tracingSourceKey to avoid array-identity refetches
+  useEffect(() => {
+    if (tracingDatasources.length === 0) {
+      setServices([])
+      setDiscoveryError(null)
+      setLoadingServices(false)
+      return
+    }
+
+    const controller = new AbortController()
+    let cancelled = false
+    const sources = tracingDatasources
+
+    async function loadDiscoveredServices() {
+      setLoadingServices(true)
+      setDiscoveryError(null)
+
+      try {
+        const results = await Promise.allSettled(
+          sources.map(async source => {
+            const names = await fetchDataSourceTraceServices(source.id, controller.signal)
+            return names
+              .map(name => name.trim())
+              .filter(Boolean)
+              .map<ServiceInventoryItem>(name => ({
+                id: `${source.id}:${name}`,
+                name,
+                sourceId: source.id,
+                sourceName: labelForDataSource(source),
+                sourceTypeLabel: dataSourceTypeLabels[source.type],
+                status: 'info',
+              }))
+          }),
+        )
+
+        if (cancelled || controller.signal.aborted) return
+
+        setServices(
+          results
+            .flatMap(result => (result.status === 'fulfilled' ? result.value : []))
+            .sort((left, right) => left.name.localeCompare(right.name)),
+        )
+
+        const failedSources = results.filter(result => result.status === 'rejected').length
+        setDiscoveryError(
+          failedSources
+            ? `Service discovery failed for ${failedSources} tracing datasource${failedSources === 1 ? '' : 's'}.`
+            : null,
+        )
+      } catch (error) {
+        if (cancelled || controller.signal.aborted) return
+        setServices([])
+        setDiscoveryError(error instanceof Error ? error.message : 'Failed to discover services')
+      } finally {
+        if (!cancelled && !controller.signal.aborted) {
+          setLoadingServices(false)
+        }
+      }
+    }
+
+    void loadDiscoveredServices()
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [tracingSourceKey])
+
+  const loading = datasourcesLoading || loadingServices
+
+  return (
+    <div className="mx-auto max-w-[1400px] px-6 py-6">
+      <div className="mb-6">
+        <h1 className="font-display text-2xl font-bold" style={{ color: 'var(--color-on-surface)' }}>
+          Services
+        </h1>
+        <p className="mt-1 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+          Service inventory discovered from tracing datasources. Ace does not show sample health
+          data here.
+        </p>
+      </div>
+
+      {loading ? (
+        <div
+          data-testid="services-loading"
+          className="flex min-h-[240px] flex-col items-center justify-center gap-3 rounded-lg p-6 text-sm"
+          style={{
+            backgroundColor: 'var(--color-surface-container-low)',
+            color: 'var(--color-on-surface-variant)',
+          }}
+        >
+          <Activity size={28} aria-hidden />
+          Discovering services from tracing datasources…
+        </div>
+      ) : datasourcesError ? (
+        <div
+          data-testid="services-error"
+          className="flex min-h-[240px] flex-col items-center justify-center gap-3 rounded-lg p-6 text-sm"
+          style={{
+            backgroundColor: 'var(--color-surface-container-low)',
+            color: 'var(--color-error)',
+          }}
+        >
+          <AlertCircle size={28} aria-hidden />
+          {datasourcesError}
+        </div>
+      ) : !hasDataSources ? (
+        <EmptyState
+          icon={Activity}
+          title="No service telemetry configured"
+          description="Connect a tracing datasource to discover services. Ace will not show hardcoded sample services here."
+          actionLabel="Add Data Source"
+          actionRoute="/app/settings/datasources"
+        />
+      ) : !hasTracingSources ? (
+        <EmptyState
+          icon={Activity}
+          title="No tracing datasource configured"
+          description="Services are discovered from Tempo, VictoriaTraces, or ClickHouse tracing data. Add one to populate this view."
+          actionLabel="Add Tracing Source"
+          actionRoute="/app/settings/datasources"
+        />
+      ) : discoveryError && services.length === 0 ? (
+        <div
+          data-testid="services-discovery-error"
+          className="flex min-h-[240px] flex-col items-center justify-center gap-3 rounded-lg p-6 text-center text-sm"
+          style={{
+            backgroundColor: 'var(--color-surface-container-low)',
+            color: 'var(--color-on-surface-variant)',
+          }}
+        >
+          <AlertCircle size={28} style={{ color: 'var(--color-tertiary)' }} aria-hidden />
+          <h2 className="m-0 font-display text-lg" style={{ color: 'var(--color-on-surface)' }}>
+            Service discovery unavailable
+          </h2>
+          <p className="m-0 max-w-md">{discoveryError}</p>
+          <p className="m-0 max-w-md">
+            Check the tracing datasource connection or use Explore to run a trace query directly.
+          </p>
+        </div>
+      ) : services.length === 0 ? (
+        <EmptyState
+          icon={Activity}
+          title="No services discovered yet"
+          description="Ace queried your tracing datasource but did not find service names in the current backend response. No sample services are shown."
+          actionLabel="Open Traces Explore"
+          actionRoute="/app/explore/traces"
+        />
+      ) : (
+        <div className="space-y-4">
+          {discoveryError ? (
+            <div
+              data-testid="services-partial-warning"
+              className="rounded-lg px-4 py-3 text-sm"
+              style={{
+                backgroundColor: 'rgba(249,115,22,0.08)',
+                border: '1px solid rgba(249,115,22,0.16)',
+                color: 'var(--color-on-surface-variant)',
+              }}
+            >
+              {discoveryError} Showing services from the datasources that responded.
+            </div>
+          ) : null}
+
+          <div
+            data-testid="services-data-notice"
+            className="rounded-lg px-4 py-3 text-sm"
+            style={{
+              backgroundColor: 'var(--color-surface-container-low)',
+              border: '1px solid var(--color-outline-variant)',
+              color: 'var(--color-on-surface-variant)',
+            }}
+          >
+            Inventory only: health, latency, error rate, and throughput are not inferred on this
+            page until they are backed by real telemetry queries.
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {services.map(service => {
+              const favoriteId = `svc::${service.name}`
+              const favorited = isFavorite(favoriteId)
+              return (
+                <div
+                  key={service.id}
+                  data-testid="service-card"
+                  className="relative rounded-lg p-5 transition hover:opacity-90"
+                  style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+                >
+                  <span
+                    data-testid="service-inventory-chip"
+                    className="absolute top-3 right-3 rounded-full px-2.5 py-1 text-[10px] font-medium"
+                    style={{
+                      backgroundColor: 'color-mix(in srgb, var(--color-primary) 15%, transparent)',
+                      color: 'var(--color-primary)',
+                    }}
+                  >
+                    Inventory only
+                  </span>
+
+                  <div className="mb-4 flex items-center gap-3 pr-24">
+                    <StatusDot status={service.status} size={8} />
+                    <h3
+                      data-testid="service-name"
+                      className="flex-1 truncate font-display text-base font-semibold"
+                      style={{ color: 'var(--color-on-surface)' }}
+                    >
+                      {service.name}
+                    </h3>
+                    <button
+                      type="button"
+                      className="shrink-0 cursor-pointer border-none bg-transparent p-1"
+                      data-testid={`favorite-svc-${service.name}`}
+                      title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+                      onClick={() =>
+                        toggleFavorite({
+                          id: favoriteId,
+                          title: service.name,
+                          type: 'service',
+                        })
+                      }
+                    >
+                      <Star
+                        size={14}
+                        fill={favorited ? 'currentColor' : 'none'}
+                        style={{
+                          color: favorited ? 'var(--color-primary)' : 'var(--color-outline)',
+                        }}
+                      />
+                    </button>
+                  </div>
+
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                        Source
+                      </span>
+                      <span
+                        data-testid="service-field"
+                        className="truncate text-right font-mono text-sm font-medium"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        {service.sourceName}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                        Datasource
+                      </span>
+                      <span
+                        data-testid="service-field"
+                        className="font-mono text-sm font-medium"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        {service.sourceTypeLabel}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                        Health
+                      </span>
+                      <span
+                        data-testid="service-field"
+                        className="font-mono text-sm font-medium"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      >
+                        Not evaluated
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ServicesPage.tsx
+++ b/frontend/src/pages/ServicesPage.tsx
@@ -104,7 +104,7 @@ export function ServicesPage() {
 
             const serviceItems = await Promise.all(
               uniqueNames.map(async name => {
-                let metrics = deriveServiceHealth([])
+                let metrics
                 try {
                   const summaries = await searchDataSourceTraces(source.id, {
                     service: name,
@@ -327,7 +327,7 @@ export function ServicesPage() {
 
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {services.map(service => {
-              const favoriteId = `svc::${service.name}`
+              const favoriteId = `svc::${service.sourceId}::${service.name}`
               const favorited = isFavorite(favoriteId)
               const { metrics } = service
               return (

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -19,6 +19,10 @@ const LoginPage = lazy(() => import('@/pages/LoginPage').then(m => ({ default: m
 const AuthCallbackPage = lazy(() =>
   import('@/pages/AuthCallbackPage').then(m => ({ default: m.AuthCallbackPage })),
 )
+const ServicesPage = lazy(() =>
+  import('@/pages/ServicesPage').then(m => ({ default: m.ServicesPage })),
+)
+const AlertsPage = lazy(() => import('@/pages/AlertsPage').then(m => ({ default: m.AlertsPage })))
 
 const DashboardAliasRedirect = createParamRedirect('/app/dashboards/:id')
 const DashboardSettingsAliasRedirect = createParamRedirect('/app/dashboards/:id/settings')
@@ -90,12 +94,12 @@ const appRoutes: RouteObject[] = [
   {
     path: '/app/services',
     handle: withMeta('Services — Ace'),
-    element: placeholder('Services'),
+    element: <ServicesPage />,
   },
   {
     path: '/app/alerts',
     handle: withMeta('Alerts | Ace'),
-    element: placeholder('Alerts'),
+    element: <AlertsPage />,
   },
   {
     path: '/app/explore',

--- a/frontend/src/stores/aiSidebarStore.ts
+++ b/frontend/src/stores/aiSidebarStore.ts
@@ -10,23 +10,48 @@ function readOpen(): boolean {
   }
 }
 
+export type AiSidebarContext = {
+  message: string
+  panelTitle?: string
+}
+
 type AiSidebarState = {
   isOpen: boolean
+  pendingContext: AiSidebarContext | null
+  open: (context?: AiSidebarContext) => void
   toggle: () => void
   close: () => void
+  consumePendingContext: () => AiSidebarContext | null
 }
 
 export const useAiSidebarStore = create<AiSidebarState>((set, get) => ({
   isOpen: readOpen(),
+  pendingContext: null,
+
+  open(context) {
+    localStorage.setItem(OPEN_KEY, 'true')
+    set({
+      isOpen: true,
+      ...(context ? { pendingContext: context } : {}),
+    })
+  },
 
   toggle() {
-    const next = !get().isOpen
-    localStorage.setItem(OPEN_KEY, String(next))
-    set({ isOpen: next })
+    if (get().isOpen) {
+      get().close()
+      return
+    }
+    get().open()
   },
 
   close() {
     localStorage.setItem(OPEN_KEY, 'false')
     set({ isOpen: false })
+  },
+
+  consumePendingContext() {
+    const ctx = get().pendingContext
+    set({ pendingContext: null })
+    return ctx
   },
 }))

--- a/frontend/src/types/datasource.ts
+++ b/frontend/src/types/datasource.ts
@@ -297,3 +297,28 @@ export interface AMSilenceCreate {
 export interface AMReceiver {
   name: string
 }
+
+export interface AMVersionInfo {
+  version: string
+  revision?: string
+  branch?: string
+  buildUser?: string
+  buildDate?: string
+  goVersion?: string
+}
+
+export interface AMClusterStatus {
+  status: string
+  name?: string
+}
+
+export interface AMConfig {
+  original: string
+}
+
+export interface AMStatus {
+  cluster: AMClusterStatus
+  versionInfo: AMVersionInfo
+  config: AMConfig
+  uptime: string
+}

--- a/website/api/routes.md
+++ b/website/api/routes.md
@@ -186,6 +186,7 @@ title: API Routes
 | POST | `/api/datasources/{id}/alertmanager/silences` | Yes | - | CreateSilence proxies POST /api/datasources/{id}/alertmanager/silences to AlertManager. |
 | DELETE | `/api/datasources/{id}/alertmanager/silences/{silenceId}` | Yes | - | ExpireSilence proxies DELETE /api/datasources/{id}/alertmanager/silences/{silenceId} to AlertManager. |
 | GET | `/api/datasources/{id}/alertmanager/receivers` | Yes | - | ListReceivers proxies GET /api/datasources/{id}/alertmanager/receivers to AlertManager. |
+| GET | `/api/datasources/{id}/alertmanager/status` | Yes | - | Status proxies GET /api/datasources/{id}/alertmanager/status to AlertManager. |
 | GET | `/api/datasources/{id}/alertmanager/health` | Yes | - | Health proxies GET /api/datasources/{id}/alertmanager/health to AlertManager. |
 
 ## GitHub Copilot auth routes


### PR DESCRIPTION
## Summary

Implements #307 services overview and alerts management for the React app, including fixes from a rejected adversarial review.

### Services (`/app/services`)
- Discover services from tracing datasources (no hardcoded sample data)
- Health, latency (p50/p95), and error rate views derived from the last hour of real trace summaries
- Summary counts + per-service cards with metrics

### Alerts (`/app/alerts`)
- VMAlert active alerts + rule groups with expand/detail UI
- **Rule editor panel** with structured fields + YAML export (VMAlert has no REST mutation API; documented in UI)
- Alertmanager alerts, silences CRUD, receivers
- **Configuration tab** via new `GET /api/datasources/{id}/alertmanager/status` proxy (includes `config.original`)
- Datasource integration for alert state
- **Org-switch fix**: clears stale datasource selection and cancels in-flight loads on org change

### Structure
- Split 1659-line `AlertsPage` into focused modules under `frontend/src/components/alerts/`
- Shared helpers in `frontend/src/lib/alerts.ts` and `frontend/src/lib/serviceHealth.ts`

## Validation
- `bun run test` — 388 passed
- `bun run lint` — clean
- `bunx tsc --noEmit` — clean
- `go test ./internal/datasource/ ./internal/handlers/` — ok
- Thermo-nuclear self-review: AlertsPage under 1k LOC after split; no spaghetti growth; real-telemetry services metrics; org-switch race fixed

## Test plan
- [ ] Open `/app/services` with a tracing datasource → cards show health/latency/error rate from traces
- [ ] Open `/app/alerts` with VMAlert → alerts table + rule groups; open rule editor + copy YAML
- [ ] Open `/app/alerts` with Alertmanager → silences create/expire; Configuration tab shows YAML
- [ ] Switch org while on Alerts → selection resets to new org's datasource (no stale id)

Closes #307