### PR TITLE
feat(frontend): datasource creation and audit log (#309)

### DIFF
--- a/frontend/src/components/settings/DataSourceSettingsPanel.tsx
+++ b/frontend/src/components/settings/DataSourceSettingsPanel.tsx
@@ -8,6 +8,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router'
 import {
   deleteDataSource,
   listDataSources,
@@ -103,14 +104,15 @@ export function DataSourceSettingsPanel({ orgId, isAdmin }: DataSourceSettingsPa
         <p className="m-0 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
           Add a data source to start visualising your metrics, logs, and traces.
         </p>
-        {/* Creation is owned by #309; avoid broken circular /new redirect. */}
-        <p
-          className="m-0 text-xs"
-          style={{ color: 'var(--color-outline)' }}
-          data-testid="ds-panel-create-deferred"
-        >
-          Data source creation will be available in a follow-up release.
-        </p>
+        {isAdmin ? (
+          <Link
+            to={`/app/datasources/new?orgId=${orgId}`}
+            data-testid="ds-panel-add-empty-btn"
+            className="inline-flex items-center gap-1.5 rounded-sm border-none bg-[var(--color-primary)] px-3.5 py-2 text-sm font-medium text-white no-underline transition hover:opacity-90"
+          >
+            Add data source
+          </Link>
+        ) : null}
       </div>
     )
   }
@@ -124,14 +126,15 @@ export function DataSourceSettingsPanel({ orgId, isAdmin }: DataSourceSettingsPa
         >
           {datasources.length} data source{datasources.length !== 1 ? 's' : ''}
         </span>
-        {/* Creation is owned by #309; list + edit links ship here. */}
-        <span
-          className="text-xs"
-          style={{ color: 'var(--color-outline)' }}
-          data-testid="ds-panel-create-deferred"
-        >
-          Creation coming soon
-        </span>
+        {isAdmin ? (
+          <Link
+            to={`/app/datasources/new?orgId=${orgId}`}
+            data-testid="ds-panel-add-btn"
+            className="inline-flex items-center gap-1.5 rounded-sm border-none bg-[var(--color-primary)] px-3.5 py-2 text-sm font-medium text-white no-underline transition hover:opacity-90"
+          >
+            Add data source
+          </Link>
+        ) : null}
       </div>
 
       {actionError ? (
@@ -230,16 +233,15 @@ export function DataSourceSettingsPanel({ orgId, isAdmin }: DataSourceSettingsPa
               >
                 <Zap size={14} />
               </button>
-              {/* Edit UI ships in #309; avoid linking to the placeholder route. */}
-              <span
+              <Link
+                to={`/app/datasources/${ds.id}/edit`}
                 data-testid={`ds-panel-edit-${ds.id}`}
-                className="inline-flex h-[30px] w-[30px] items-center justify-center rounded-sm border border-transparent bg-transparent p-0 opacity-40"
+                className="inline-flex h-[30px] w-[30px] items-center justify-center rounded-sm border border-transparent bg-transparent p-0 no-underline transition-all"
                 style={{ color: 'var(--color-on-surface-variant)' }}
-                title="Edit coming soon"
-                aria-disabled="true"
+                title="Edit"
               >
                 <Edit2 size={14} />
-              </span>
+              </Link>
               {isAdmin ? (
                 <button
                   type="button"

--- a/frontend/src/pages/AuditLogPage.spec.tsx
+++ b/frontend/src/pages/AuditLogPage.spec.tsx
@@ -1,0 +1,133 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter } from 'react-router'
+import { RouterProvider } from 'react-router/dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuditLogPage } from '@/pages/AuditLogPage'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+
+const mockListAuditLog = vi.hoisted(() => vi.fn())
+const mockExportAuditLog = vi.hoisted(() => vi.fn())
+
+vi.mock('@/api/audit', () => ({
+  listAuditLog: (...args: unknown[]) => mockListAuditLog(...args),
+  exportAuditLog: (...args: unknown[]) => mockExportAuditLog(...args),
+}))
+
+vi.mock('@/hooks/useOrganization', () => ({
+  useOrganization: () => ({
+    currentOrgId: 'org-1',
+    currentOrg: {
+      id: 'org-1',
+      name: 'Test Org',
+      slug: 'test',
+      role: 'admin' as const,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    },
+    organizations: [],
+    selectOrganization: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+const MOCK_ENTRIES = [
+  {
+    id: 'entry-1',
+    organization_id: 'org-1',
+    actor_email: 'admin@example.com',
+    action: 'login',
+    outcome: 'success',
+    ip_address: '192.168.1.1',
+    created_at: '2026-03-23T10:00:00Z',
+  },
+  {
+    id: 'entry-2',
+    organization_id: 'org-1',
+    actor_email: 'user@example.com',
+    action: 'delete',
+    resource_type: 'dashboard',
+    resource_name: 'My Dashboard',
+    outcome: 'denied',
+    ip_address: '10.0.0.5',
+    created_at: '2026-03-23T09:30:00Z',
+  },
+]
+
+function renderPage() {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter([{ path: '/app/audit-log', element: <AuditLogPage /> }], {
+    initialEntries: ['/app/audit-log'],
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AuditLogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListAuditLog.mockResolvedValue({
+      entries: MOCK_ENTRIES,
+      total: 2,
+      page: 1,
+      limit: 50,
+    })
+    mockExportAuditLog.mockResolvedValue(new Blob(['csv,data'], { type: 'text/csv' }))
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    global.URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders audit log heading', async () => {
+    renderPage()
+    expect((await screen.findByTestId('audit-log-heading')).textContent).toContain('Audit Log')
+  })
+
+  it('renders table when entries are returned', async () => {
+    renderPage()
+    expect(await screen.findByTestId('audit-log-table')).toBeTruthy()
+    expect(screen.getAllByTestId('audit-log-row')).toHaveLength(2)
+    expect(screen.getByText('admin@example.com')).toBeTruthy()
+    expect(screen.getByText('login')).toBeTruthy()
+    expect(screen.getByText('success')).toBeTruthy()
+  })
+
+  it('shows empty state when no entries are returned', async () => {
+    mockListAuditLog.mockResolvedValueOnce({
+      entries: [],
+      total: 0,
+      page: 1,
+      limit: 50,
+    })
+    renderPage()
+    expect((await screen.findByTestId('empty-state')).textContent).toContain('No audit log entries found')
+  })
+
+  it('renders export buttons and triggers CSV export', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('audit-log-table')
+
+    expect(screen.getByTestId('export-csv-btn')).toBeTruthy()
+    expect(screen.getByTestId('export-json-btn')).toBeTruthy()
+
+    await user.click(screen.getByTestId('export-csv-btn'))
+    await waitFor(() => {
+      expect(mockExportAuditLog).toHaveBeenCalledWith('org-1', 'csv', undefined, undefined)
+    })
+  })
+
+  it('shows error banner when list fails', async () => {
+    mockListAuditLog.mockRejectedValueOnce(new Error('Admin or auditor access required'))
+    renderPage()
+    expect((await screen.findByTestId('error-banner')).textContent).toContain('Admin or auditor access required')
+  })
+})

--- a/frontend/src/pages/AuditLogPage.spec.tsx
+++ b/frontend/src/pages/AuditLogPage.spec.tsx
@@ -78,8 +78,14 @@ describe('AuditLogPage', () => {
       limit: 50,
     })
     mockExportAuditLog.mockResolvedValue(new Blob(['csv,data'], { type: 'text/csv' }))
-    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
-    global.URL.revokeObjectURL = vi.fn()
+    Object.defineProperty(globalThis.URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:mock-url'),
+      configurable: true,
+    })
+    Object.defineProperty(globalThis.URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      configurable: true,
+    })
   })
 
   afterEach(() => {

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -1,0 +1,507 @@
+import { ChevronLeft, ChevronRight, Download, Filter, Search } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  exportAuditLog,
+  listAuditLog,
+  type AuditLogEntry,
+  type AuditLogParams,
+} from '@/api/audit'
+import { useOrganization } from '@/hooks/useOrganization'
+
+const ACTION_OPTIONS = [
+  { value: '', label: 'All Actions' },
+  { value: 'login', label: 'Login' },
+  { value: 'logout', label: 'Logout' },
+  { value: 'create', label: 'Create' },
+  { value: 'update', label: 'Update' },
+  { value: 'delete', label: 'Delete' },
+  { value: 'permission.change', label: 'Permission Change' },
+  { value: 'export', label: 'Export' },
+  { value: 'invite', label: 'Invite' },
+]
+
+function formatTimestamp(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
+function resourceLabel(entry: AuditLogEntry): string {
+  const parts: string[] = []
+  if (entry.resource_type) parts.push(entry.resource_type)
+  if (entry.resource_name) parts.push(entry.resource_name)
+  else if (entry.resource_id) parts.push(entry.resource_id)
+  return parts.join(': ')
+}
+
+export function AuditLogPage() {
+  const { currentOrg } = useOrganization()
+
+  const [entries, setEntries] = useState<AuditLogEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [limit] = useState(50)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [exportError, setExportError] = useState<string | null>(null)
+
+  const [actorFilter, setActorFilter] = useState('')
+  const [actionFilter, setActionFilter] = useState('')
+  const [resourceTypeFilter, setResourceTypeFilter] = useState('')
+  const [fromFilter, setFromFilter] = useState('')
+  const [toFilter, setToFilter] = useState('')
+
+  const totalPages = Math.max(1, Math.ceil(total / limit))
+
+  const fetchEntries = useCallback(
+    async (pageOverride?: number) => {
+      const orgId = currentOrg?.id
+      if (!orgId) return
+
+      const nextPage = pageOverride ?? page
+      setLoading(true)
+      setError(null)
+
+      const params: AuditLogParams = {
+        page: nextPage,
+        limit,
+      }
+      if (actorFilter) params.actor = actorFilter
+      if (actionFilter) params.action = actionFilter
+      if (resourceTypeFilter) params.resource_type = resourceTypeFilter
+      if (fromFilter) params.from = `${fromFilter}:00Z`
+      if (toFilter) params.to = `${toFilter}:00Z`
+
+      try {
+        const result = await listAuditLog(orgId, params)
+        setEntries(result.entries)
+        setTotal(result.total)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch audit log')
+        setEntries([])
+        setTotal(0)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [
+      actionFilter,
+      actorFilter,
+      currentOrg?.id,
+      fromFilter,
+      limit,
+      page,
+      resourceTypeFilter,
+      toFilter,
+    ],
+  )
+
+  useEffect(() => {
+    void fetchEntries()
+  }, [fetchEntries])
+
+  async function handleExport(format: 'csv' | 'json') {
+    const orgId = currentOrg?.id
+    if (!orgId) return
+
+    setExportError(null)
+    try {
+      const blob = await exportAuditLog(
+        orgId,
+        format,
+        fromFilter ? `${fromFilter}:00Z` : undefined,
+        toFilter ? `${toFilter}:00Z` : undefined,
+      )
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `audit-log.${format}`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : 'Export failed')
+    }
+  }
+
+  function handleFilterChange() {
+    setPage(1)
+    void fetchEntries(1)
+  }
+
+  function prevPage() {
+    if (page > 1) {
+      const next = page - 1
+      setPage(next)
+      void fetchEntries(next)
+    }
+  }
+
+  function nextPage() {
+    if (page < totalPages) {
+      const next = page + 1
+      setPage(next)
+      void fetchEntries(next)
+    }
+  }
+
+  return (
+    <div
+      className="flex min-h-screen flex-col"
+      style={{ backgroundColor: 'var(--color-surface)', color: 'var(--color-on-surface)' }}
+    >
+      <div
+        className="flex shrink-0 items-center justify-between px-5 py-4"
+        style={{
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+          backgroundColor: 'var(--color-surface-container-low)',
+        }}
+      >
+        <h1
+          data-testid="audit-log-heading"
+          className="font-display text-xl font-semibold"
+          style={{ color: 'var(--color-on-surface)', letterSpacing: '-0.02em' }}
+        >
+          Audit Log
+        </h1>
+
+        <div className="flex items-center gap-2">
+          {exportError ? (
+            <span className="text-xs" style={{ color: 'var(--color-error)' }} data-testid="export-error">
+              {exportError}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            data-testid="export-csv-btn"
+            className="flex cursor-pointer items-center gap-1.5 border px-3 py-1.5 text-sm transition-colors"
+            style={{
+              backgroundColor: 'transparent',
+              color: 'var(--color-on-surface-variant)',
+              borderColor: 'rgba(255,255,255,0.12)',
+              borderRadius: '4px',
+            }}
+            onClick={() => void handleExport('csv')}
+          >
+            <Download size={14} />
+            CSV
+          </button>
+          <button
+            type="button"
+            data-testid="export-json-btn"
+            className="flex cursor-pointer items-center gap-1.5 border px-3 py-1.5 text-sm transition-colors"
+            style={{
+              backgroundColor: 'transparent',
+              color: 'var(--color-on-surface-variant)',
+              borderColor: 'rgba(255,255,255,0.12)',
+              borderRadius: '4px',
+            }}
+            onClick={() => void handleExport('json')}
+          >
+            <Download size={14} />
+            JSON
+          </button>
+        </div>
+      </div>
+
+      <div
+        data-testid="filter-bar"
+        className="flex shrink-0 flex-wrap items-center gap-3 px-5 py-3"
+        style={{
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+          backgroundColor: 'var(--color-surface-container-low)',
+        }}
+      >
+        <div className="relative flex items-center gap-1.5">
+          <Search
+            size={14}
+            className="pointer-events-none absolute left-2.5"
+            style={{ color: 'var(--color-outline)' }}
+          />
+          <input
+            value={actorFilter}
+            onChange={e => setActorFilter(e.target.value)}
+            onBlur={handleFilterChange}
+            onKeyDown={e => {
+              if (e.key === 'Enter') handleFilterChange()
+            }}
+            data-testid="filter-actor"
+            type="text"
+            placeholder="Filter by actor email"
+            className="py-1.5 pr-3 pl-8 text-sm"
+            style={{
+              width: '220px',
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface)',
+              border: '1px solid rgba(255,255,255,0.12)',
+              borderRadius: '4px',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <Filter size={14} style={{ color: 'var(--color-outline)' }} />
+          <select
+            value={actionFilter}
+            onChange={e => {
+              setActionFilter(e.target.value)
+              setPage(1)
+            }}
+            data-testid="filter-action"
+            className="cursor-pointer px-2.5 py-1.5 text-sm"
+            style={{
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface)',
+              border: '1px solid rgba(255,255,255,0.12)',
+              borderRadius: '4px',
+              outline: 'none',
+            }}
+          >
+            {ACTION_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <input
+          value={resourceTypeFilter}
+          onChange={e => setResourceTypeFilter(e.target.value)}
+          onBlur={handleFilterChange}
+          onKeyDown={e => {
+            if (e.key === 'Enter') handleFilterChange()
+          }}
+          data-testid="filter-resource-type"
+          type="text"
+          placeholder="Resource type"
+          className="px-3 py-1.5 text-sm"
+          style={{
+            width: '160px',
+            backgroundColor: 'var(--color-surface-container-high)',
+            color: 'var(--color-on-surface)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: '4px',
+            outline: 'none',
+          }}
+        />
+
+        <input
+          value={fromFilter}
+          onChange={e => {
+            setFromFilter(e.target.value)
+            setPage(1)
+          }}
+          data-testid="filter-from"
+          type="datetime-local"
+          className="px-3 py-1.5 text-sm"
+          style={{
+            backgroundColor: 'var(--color-surface-container-high)',
+            color: 'var(--color-on-surface)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: '4px',
+            outline: 'none',
+            colorScheme: 'dark',
+          }}
+        />
+        <span className="text-sm" style={{ color: 'var(--color-outline)' }}>
+          —
+        </span>
+        <input
+          value={toFilter}
+          onChange={e => {
+            setToFilter(e.target.value)
+            setPage(1)
+          }}
+          data-testid="filter-to"
+          type="datetime-local"
+          className="px-3 py-1.5 text-sm"
+          style={{
+            backgroundColor: 'var(--color-surface-container-high)',
+            color: 'var(--color-on-surface)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: '4px',
+            outline: 'none',
+            colorScheme: 'dark',
+          }}
+        />
+      </div>
+
+      {error ? (
+        <div
+          data-testid="error-banner"
+          className="mx-5 mt-4 rounded px-4 py-3 text-sm"
+          style={{
+            backgroundColor: 'rgba(239,68,68,0.10)',
+            color: 'var(--color-error)',
+            border: '1px solid rgba(239,68,68,0.24)',
+            borderRadius: '4px',
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div
+          data-testid="loading-state"
+          className="flex flex-1 items-center justify-center"
+          style={{ color: 'var(--color-on-surface-variant)' }}
+        >
+          <span className="text-sm">Loading...</span>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto px-5 pt-4">
+          {entries.length === 0 ? (
+            <div
+              data-testid="empty-state"
+              className="flex flex-col items-center justify-center gap-2 py-16"
+            >
+              <p className="text-sm font-medium" style={{ color: 'var(--color-on-surface)' }}>
+                No audit log entries found
+              </p>
+              <p className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+                Try adjusting your filters or date range
+              </p>
+            </div>
+          ) : (
+            <table data-testid="audit-log-table" className="w-full border-collapse text-sm">
+              <thead>
+                <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+                  {['Timestamp', 'Actor', 'Action', 'Resource', 'Outcome', 'IP Address'].map(
+                    (label, idx) => (
+                      <th
+                        key={label}
+                        className={`py-2 text-left text-xs font-medium ${idx < 5 ? 'pr-4' : ''}`}
+                        style={{
+                          color: 'var(--color-on-surface-variant)',
+                          letterSpacing: '0.04em',
+                          textTransform: 'uppercase',
+                        }}
+                      >
+                        {label}
+                      </th>
+                    ),
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map(entry => (
+                  <tr
+                    key={entry.id}
+                    data-testid="audit-log-row"
+                    className="transition-colors"
+                    style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}
+                  >
+                    <td
+                      className="py-2.5 pr-4 font-mono text-xs"
+                      style={{ color: 'var(--color-on-surface-variant)' }}
+                    >
+                      {formatTimestamp(entry.created_at)}
+                    </td>
+                    <td className="py-2.5 pr-4 text-sm" style={{ color: 'var(--color-on-surface)' }}>
+                      {entry.actor_email}
+                    </td>
+                    <td
+                      className="py-2.5 pr-4 font-mono text-sm"
+                      style={{ color: 'var(--color-on-surface)' }}
+                    >
+                      {entry.action}
+                    </td>
+                    <td
+                      className="py-2.5 pr-4 text-sm"
+                      style={{ color: 'var(--color-on-surface-variant)' }}
+                    >
+                      {resourceLabel(entry)}
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <span
+                        className="rounded px-2 py-0.5 text-xs font-medium"
+                        style={{
+                          backgroundColor:
+                            entry.outcome === 'success'
+                              ? 'rgba(52,211,153,0.12)'
+                              : 'rgba(239,68,68,0.12)',
+                          color:
+                            entry.outcome === 'success'
+                              ? 'var(--color-secondary)'
+                              : 'var(--color-error)',
+                          borderRadius: '4px',
+                        }}
+                      >
+                        {entry.outcome}
+                      </span>
+                    </td>
+                    <td
+                      className="py-2.5 font-mono text-xs"
+                      style={{ color: 'var(--color-on-surface-variant)' }}
+                    >
+                      {entry.ip_address ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {!loading && total > 0 ? (
+        <div
+          data-testid="pagination"
+          className="flex shrink-0 items-center justify-between px-5 py-3"
+          style={{
+            borderTop: '1px solid rgba(255,255,255,0.06)',
+            backgroundColor: 'var(--color-surface-container-low)',
+          }}
+        >
+          <span className="text-xs" style={{ color: 'var(--color-on-surface-variant)' }}>
+            {total} total entries
+          </span>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              data-testid="prev-page-btn"
+              className="flex cursor-pointer items-center gap-1 border px-3 py-1.5 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={page <= 1}
+              style={{
+                backgroundColor: 'transparent',
+                color: 'var(--color-on-surface-variant)',
+                borderColor: 'rgba(255,255,255,0.12)',
+                borderRadius: '4px',
+              }}
+              onClick={prevPage}
+            >
+              <ChevronLeft size={14} />
+              Previous
+            </button>
+
+            <span className="text-sm" style={{ color: 'var(--color-on-surface)' }}>
+              Page {page} of {totalPages}
+            </span>
+
+            <button
+              type="button"
+              data-testid="next-page-btn"
+              className="flex cursor-pointer items-center gap-1 border px-3 py-1.5 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={page >= totalPages}
+              style={{
+                backgroundColor: 'transparent',
+                color: 'var(--color-on-surface-variant)',
+                borderColor: 'rgba(255,255,255,0.12)',
+                borderRadius: '4px',
+              }}
+              onClick={nextPage}
+            >
+              Next
+              <ChevronRight size={14} />
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/DataSourceCreatePage.spec.tsx
+++ b/frontend/src/pages/DataSourceCreatePage.spec.tsx
@@ -1,0 +1,163 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter } from 'react-router'
+import { RouterProvider } from 'react-router/dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DataSourceCreatePage } from '@/pages/DataSourceCreatePage'
+import { createTestQueryClient } from '@/test/renderWithProviders'
+
+const mockNavigate = vi.fn()
+const mockCreateDataSource = vi.hoisted(() => vi.fn())
+const mockUpdateDataSource = vi.hoisted(() => vi.fn())
+const mockGetDataSource = vi.hoisted(() => vi.fn())
+const mockTestDraft = vi.hoisted(() => vi.fn())
+const mockFetchTraceDatasources = vi.hoisted(() => vi.fn())
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@/hooks/useOrganization', () => ({
+  useOrganization: () => ({
+    currentOrgId: 'org-1',
+    currentOrg: {
+      id: 'org-1',
+      name: 'Acme',
+      slug: 'acme',
+      role: 'admin' as const,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    },
+    organizations: [],
+    selectOrganization: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/api/datasources', () => ({
+  createDataSource: (...args: unknown[]) => mockCreateDataSource(...args),
+  updateDataSource: (...args: unknown[]) => mockUpdateDataSource(...args),
+  getDataSource: (...args: unknown[]) => mockGetDataSource(...args),
+  testDataSourceDraftConnection: (...args: unknown[]) => mockTestDraft(...args),
+  fetchTraceDatasources: (...args: unknown[]) => mockFetchTraceDatasources(...args),
+}))
+
+function renderAt(path: string) {
+  const queryClient = createTestQueryClient()
+  const router = createMemoryRouter(
+    [
+      { path: '/app/datasources/new', element: <DataSourceCreatePage /> },
+      { path: '/app/datasources/:id/edit', element: <DataSourceCreatePage /> },
+    ],
+    { initialEntries: [path] },
+  )
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('DataSourceCreatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateDataSource.mockResolvedValue({ id: 'ds-new' })
+    mockUpdateDataSource.mockResolvedValue({ id: 'ds-1' })
+    mockTestDraft.mockResolvedValue(undefined)
+    mockFetchTraceDatasources.mockResolvedValue([])
+    mockGetDataSource.mockResolvedValue(undefined)
+  })
+
+  it('creates a datasource in create mode', async () => {
+    const user = userEvent.setup()
+    renderAt('/app/datasources/new')
+
+    expect(screen.getByRole('heading', { name: 'Add Data Source' })).toBeTruthy()
+
+    await user.type(screen.getByTestId('ds-name-input'), 'Primary Prometheus')
+    await user.clear(screen.getByTestId('ds-url-input'))
+    await user.type(screen.getByTestId('ds-url-input'), 'http://localhost:9090')
+    await user.click(screen.getByTestId('ds-save-btn'))
+
+    await waitFor(() => {
+      expect(mockCreateDataSource).toHaveBeenCalledWith(
+        'org-1',
+        expect.objectContaining({
+          name: 'Primary Prometheus',
+          type: 'prometheus',
+          url: 'http://localhost:9090',
+        }),
+      )
+    })
+    expect(mockUpdateDataSource).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/app/settings/datasources')
+  })
+
+  it('edits a datasource when route includes id', async () => {
+    const user = userEvent.setup()
+    mockGetDataSource.mockResolvedValue({
+      id: 'ds-1',
+      organization_id: 'org-1',
+      name: 'Tempo Source',
+      type: 'tempo',
+      url: 'http://tempo:3200',
+      is_default: false,
+      auth_type: 'none',
+      auth_config: {},
+      trace_id_field: 'trace_id',
+      created_at: '2026-02-08T00:00:00Z',
+      updated_at: '2026-02-08T00:00:00Z',
+    })
+
+    renderAt('/app/datasources/ds-1/edit')
+
+    await waitFor(() => {
+      expect(mockGetDataSource).toHaveBeenCalledWith('ds-1')
+    })
+    expect(await screen.findByRole('heading', { name: 'Edit Data Source' })).toBeTruthy()
+
+    const nameInput = screen.getByTestId('ds-name-input')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Tempo Source Updated')
+    await user.click(screen.getByTestId('ds-save-btn'))
+
+    await waitFor(() => {
+      expect(mockUpdateDataSource).toHaveBeenCalledWith(
+        'ds-1',
+        expect.objectContaining({
+          name: 'Tempo Source Updated',
+          type: 'tempo',
+          url: 'http://tempo:3200',
+        }),
+      )
+    })
+    expect(mockCreateDataSource).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/app/settings/datasources')
+  })
+
+  it('tests draft connection before save', async () => {
+    const user = userEvent.setup()
+    renderAt('/app/datasources/new')
+
+    await user.type(screen.getByTestId('ds-name-input'), 'Prom')
+    await user.type(screen.getByTestId('ds-url-input'), 'http://localhost:9090')
+    await user.click(screen.getByTestId('ds-test-btn'))
+
+    await waitFor(() => {
+      expect(mockTestDraft).toHaveBeenCalledWith(
+        'org-1',
+        expect.objectContaining({
+          type: 'prometheus',
+          url: 'http://localhost:9090',
+        }),
+      )
+    })
+    expect(await screen.findByText('Connection test succeeded')).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/DataSourceCreatePage.tsx
+++ b/frontend/src/pages/DataSourceCreatePage.tsx
@@ -1,0 +1,1051 @@
+import {
+  ArrowLeft,
+  CheckCircle2,
+  CircleAlert,
+  Database,
+  HeartPulse,
+  Loader2,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router'
+import {
+  createDataSource,
+  fetchTraceDatasources,
+  getDataSource,
+  testDataSourceDraftConnection,
+  updateDataSource,
+} from '@/api/datasources'
+import { useOrganization } from '@/hooks/useOrganization'
+import {
+  dataSourceTypeLabels,
+  isAlertingType,
+  isLogsType,
+  isTracingType,
+  type CreateDataSourceRequest,
+  type DataSource,
+  type DataSourceType,
+  type TraceDatasource,
+} from '@/types/datasource'
+
+type AuthType = 'none' | 'basic' | 'bearer' | 'api_key'
+
+const TYPE_OPTIONS: Array<{ value: DataSourceType; label: string }> = [
+  { value: 'prometheus', label: 'Prometheus (PromQL)' },
+  { value: 'victoriametrics', label: 'VictoriaMetrics (PromQL)' },
+  { value: 'loki', label: 'Loki (LogQL)' },
+  { value: 'victorialogs', label: 'Victoria Logs (LogsQL)' },
+  { value: 'tempo', label: 'Tempo (Tracing)' },
+  { value: 'victoriatraces', label: 'VictoriaTraces (Tracing)' },
+  { value: 'clickhouse', label: 'ClickHouse (SQL)' },
+  { value: 'cloudwatch', label: 'CloudWatch (Metrics + Logs)' },
+  { value: 'elasticsearch', label: 'Elasticsearch (ELK)' },
+  { value: 'vmalert', label: 'VMAlert (Alerting)' },
+  { value: 'alertmanager', label: 'AlertManager (Alerting)' },
+]
+
+const inputClass =
+  'w-full rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] placeholder:text-[var(--color-outline)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none transition border-none'
+const labelClass = 'block text-sm font-medium text-[var(--color-on-surface-variant)] mb-1.5'
+const sectionClass = 'rounded-lg bg-[var(--color-surface-container-low)] p-6'
+const selectClass =
+  "w-full rounded-sm bg-[var(--color-surface-container-high)] px-3 py-2.5 text-sm text-[var(--color-on-surface)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none transition border-none appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%2712%27%20height=%2712%27%20viewBox=%270%200%2024%2024%27%20fill=%27none%27%20stroke=%27%2394a3b8%27%20stroke-width=%272%27%20stroke-linecap=%27round%27%20stroke-linejoin=%27round%27%3E%3Cpath%20d=%27m6%209%206%206%206-6%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.75rem_center] pr-9"
+
+function emptyAuthFields() {
+  return {
+    authType: 'none' as AuthType,
+    basicUsername: '',
+    basicPassword: '',
+    bearerToken: '',
+    apiKeyHeader: 'X-API-Key',
+    apiKeyValue: '',
+    database: '',
+    cloudWatchRegion: '',
+    cloudWatchMetricNamespace: '',
+    cloudWatchLogGroup: '',
+    cloudWatchAccessKeyId: '',
+    cloudWatchSecretAccessKey: '',
+    cloudWatchSessionToken: '',
+    elasticsearchIndex: '',
+    elasticsearchTimestampField: '',
+    elasticsearchMessageField: '',
+    elasticsearchLevelField: '',
+    traceIdField: 'trace_id',
+    linkedTraceDatasourceId: null as string | null,
+  }
+}
+
+export function DataSourceCreatePage() {
+  const { id: routeId } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const { currentOrg } = useOrganization()
+
+  const datasourceId = routeId && routeId.trim() !== '' ? routeId : null
+  const isEditing = datasourceId !== null
+
+  const [formName, setFormName] = useState('')
+  const [formType, setFormType] = useState<DataSourceType>('prometheus')
+  const [formUrl, setFormUrl] = useState('')
+  const [formIsDefault, setFormIsDefault] = useState(false)
+  const [authFields, setAuthFields] = useState(emptyAuthFields)
+  const [traceDatasources, setTraceDatasources] = useState<TraceDatasource[]>([])
+  const [saveLoading, setSaveLoading] = useState(false)
+  const [testLoading, setTestLoading] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [testError, setTestError] = useState<string | null>(null)
+  const [testSuccess, setTestSuccess] = useState<string | null>(null)
+  const [lastTestedSignature, setLastTestedSignature] = useState<string | null>(null)
+  const [pageLoading, setPageLoading] = useState(isEditing)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [loadedDatasourceOrgId, setLoadedDatasourceOrgId] = useState<string | null>(null)
+
+  const isClickHouseType = formType === 'clickhouse'
+  const isCloudWatchType = formType === 'cloudwatch'
+  const isElasticsearchType = formType === 'elasticsearch'
+  const showLogCorrelation = isLogsType(formType) && !isClickHouseType
+  const showAuthSettings =
+    (isTracingType(formType) ||
+      isClickHouseType ||
+      isElasticsearchType ||
+      isAlertingType(formType)) &&
+    !isCloudWatchType
+
+  const formSignature = useMemo(
+    () =>
+      JSON.stringify({
+        name: formName.trim(),
+        type: formType,
+        url: formUrl.trim(),
+        isDefault: formIsDefault,
+        ...authFields,
+      }),
+    [formName, formType, formUrl, formIsDefault, authFields],
+  )
+
+  const isTestStale =
+    lastTestedSignature !== null && lastTestedSignature !== formSignature
+
+  const pageTitle = isEditing ? 'Edit Data Source' : 'Add Data Source'
+  const pageDescription = isEditing
+    ? 'Update connection details, test connectivity, then save your changes.'
+    : 'Configure connection details, test connectivity, then save.'
+  const saveButtonText = saveLoading
+    ? 'Saving...'
+    : isEditing
+      ? 'Save Changes'
+      : 'Save Data Source'
+
+  const activeOrgId = currentOrg?.id || loadedDatasourceOrgId || null
+
+  const patchAuth = useCallback((patch: Partial<ReturnType<typeof emptyAuthFields>>) => {
+    setAuthFields(prev => ({ ...prev, ...patch }))
+  }, [])
+
+  const hydrateForm = useCallback((ds: DataSource) => {
+    setFormName(ds.name)
+    setFormType(ds.type)
+    setFormUrl(ds.url)
+    setFormIsDefault(ds.is_default)
+    setLoadedDatasourceOrgId(ds.organization_id)
+
+    const authType = (ds.auth_type || 'none') as AuthType
+    const cfg = ds.auth_config || {}
+    setAuthFields({
+      authType,
+      basicUsername: typeof cfg.username === 'string' ? cfg.username : '',
+      basicPassword: typeof cfg.password === 'string' ? cfg.password : '',
+      bearerToken: typeof cfg.token === 'string' ? cfg.token : '',
+      apiKeyHeader:
+        typeof cfg.header === 'string' && cfg.header.trim() !== '' ? cfg.header : 'X-API-Key',
+      apiKeyValue: typeof cfg.value === 'string' ? cfg.value : '',
+      database: typeof cfg.database === 'string' ? cfg.database : '',
+      cloudWatchRegion: typeof cfg.region === 'string' ? cfg.region : '',
+      cloudWatchMetricNamespace:
+        typeof cfg.metric_namespace === 'string' ? cfg.metric_namespace : '',
+      cloudWatchLogGroup: typeof cfg.log_group === 'string' ? cfg.log_group : '',
+      cloudWatchAccessKeyId: typeof cfg.access_key_id === 'string' ? cfg.access_key_id : '',
+      cloudWatchSecretAccessKey:
+        typeof cfg.secret_access_key === 'string' ? cfg.secret_access_key : '',
+      cloudWatchSessionToken: typeof cfg.session_token === 'string' ? cfg.session_token : '',
+      elasticsearchIndex: typeof cfg.index === 'string' ? cfg.index : '',
+      elasticsearchTimestampField: typeof cfg.time_field === 'string' ? cfg.time_field : '',
+      elasticsearchMessageField: typeof cfg.message_field === 'string' ? cfg.message_field : '',
+      elasticsearchLevelField: typeof cfg.level_field === 'string' ? cfg.level_field : '',
+      traceIdField: ds.trace_id_field || 'trace_id',
+      linkedTraceDatasourceId: ds.linked_trace_datasource_id || null,
+    })
+    setFormError(null)
+    setLoadError(null)
+    setTestError(null)
+    setTestSuccess(null)
+    setLastTestedSignature(null)
+  }, [])
+
+  const loadDatasourceForEdit = useCallback(async () => {
+    if (!isEditing || !datasourceId) {
+      setFormName('')
+      setFormType('prometheus')
+      setFormUrl('')
+      setFormIsDefault(false)
+      setAuthFields(emptyAuthFields())
+      setLoadedDatasourceOrgId(null)
+      setPageLoading(false)
+      setLoadError(null)
+      return
+    }
+
+    setPageLoading(true)
+    setLoadError(null)
+    try {
+      const ds = await getDataSource(datasourceId)
+      hydrateForm(ds)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Failed to load datasource')
+    } finally {
+      setPageLoading(false)
+    }
+  }, [datasourceId, hydrateForm, isEditing])
+
+  useEffect(() => {
+    void loadDatasourceForEdit()
+  }, [loadDatasourceForEdit])
+
+  useEffect(() => {
+    if (formType !== 'clickhouse') {
+      patchAuth({ database: '' })
+    }
+    if (formType !== 'elasticsearch') {
+      patchAuth({
+        elasticsearchIndex: '',
+        elasticsearchTimestampField: '',
+        elasticsearchMessageField: '',
+        elasticsearchLevelField: '',
+      })
+    }
+    if (formType === 'cloudwatch') {
+      setAuthFields(prev => {
+        const region = prev.cloudWatchRegion.trim() || 'us-east-1'
+        return {
+          ...prev,
+          authType: 'none',
+          cloudWatchRegion: region,
+        }
+      })
+      setFormUrl(prev => {
+        if (prev.trim()) return prev
+        return 'https://monitoring.us-east-1.amazonaws.com'
+      })
+      return
+    }
+    patchAuth({
+      cloudWatchRegion: '',
+      cloudWatchMetricNamespace: '',
+      cloudWatchLogGroup: '',
+      cloudWatchAccessKeyId: '',
+      cloudWatchSecretAccessKey: '',
+      cloudWatchSessionToken: '',
+    })
+  }, [formType, patchAuth])
+
+  useEffect(() => {
+    if (!showAuthSettings) {
+      patchAuth({
+        authType: 'none',
+        basicUsername: '',
+        basicPassword: '',
+        bearerToken: '',
+        apiKeyHeader: 'X-API-Key',
+        apiKeyValue: '',
+      })
+    }
+  }, [showAuthSettings, patchAuth])
+
+  useEffect(() => {
+    if (formType !== 'cloudwatch') return
+    const region = authFields.cloudWatchRegion.trim() || 'us-east-1'
+    setFormUrl(prev => {
+      let hostname = ''
+      try {
+        hostname = new URL(prev.trim()).hostname
+      } catch {
+        /* invalid URL */
+      }
+      if (!prev.trim() || hostname.endsWith('.amazonaws.com')) {
+        return `https://monitoring.${region}.amazonaws.com`
+      }
+      return prev
+    })
+  }, [authFields.cloudWatchRegion, formType])
+
+  useEffect(() => {
+    if (!showLogCorrelation || !activeOrgId) {
+      setTraceDatasources([])
+      if (!showLogCorrelation) {
+        patchAuth({
+          traceIdField: 'trace_id',
+          linkedTraceDatasourceId: null,
+        })
+      }
+      return
+    }
+
+    let cancelled = false
+    void fetchTraceDatasources(activeOrgId, datasourceId || 'new')
+      .then(list => {
+        if (!cancelled) setTraceDatasources(list)
+      })
+      .catch(() => {
+        if (!cancelled) setTraceDatasources([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeOrgId, datasourceId, patchAuth, showLogCorrelation])
+
+  function buildAuthPayload() {
+    if (isCloudWatchType) {
+      if (!authFields.cloudWatchRegion.trim()) {
+        throw new Error('CloudWatch region is required')
+      }
+
+      const cloudWatchConfig: Record<string, unknown> = {
+        region: authFields.cloudWatchRegion.trim(),
+      }
+
+      const metricNamespace = authFields.cloudWatchMetricNamespace.trim()
+      if (metricNamespace) cloudWatchConfig.metric_namespace = metricNamespace
+
+      const logGroup = authFields.cloudWatchLogGroup.trim()
+      if (logGroup) cloudWatchConfig.log_group = logGroup
+
+      const accessKeyId = authFields.cloudWatchAccessKeyId.trim()
+      const secretAccessKey = authFields.cloudWatchSecretAccessKey.trim()
+      if (accessKeyId || secretAccessKey) {
+        if (!accessKeyId || !secretAccessKey) {
+          throw new Error('CloudWatch access key ID and secret access key must both be provided')
+        }
+        cloudWatchConfig.access_key_id = accessKeyId
+        cloudWatchConfig.secret_access_key = secretAccessKey
+      }
+
+      const sessionToken = authFields.cloudWatchSessionToken.trim()
+      if (sessionToken) cloudWatchConfig.session_token = sessionToken
+
+      return {
+        auth_type: 'none' as const,
+        auth_config: cloudWatchConfig,
+      }
+    }
+
+    if (!showAuthSettings || authFields.authType === 'none') {
+      return {
+        auth_type: 'none' as const,
+        auth_config: undefined as Record<string, unknown> | undefined,
+      }
+    }
+
+    if (authFields.authType === 'basic') {
+      if (!authFields.basicUsername.trim()) {
+        throw new Error('Basic auth username is required')
+      }
+      return {
+        auth_type: 'basic' as const,
+        auth_config: {
+          username: authFields.basicUsername.trim(),
+          password: authFields.basicPassword,
+        },
+      }
+    }
+
+    if (authFields.authType === 'bearer') {
+      if (!authFields.bearerToken.trim()) {
+        throw new Error('Bearer token is required')
+      }
+      return {
+        auth_type: 'bearer' as const,
+        auth_config: {
+          token: authFields.bearerToken.trim(),
+        },
+      }
+    }
+
+    if (!authFields.apiKeyValue.trim()) {
+      throw new Error('API key value is required')
+    }
+
+    return {
+      auth_type: 'api_key' as const,
+      auth_config: {
+        header: authFields.apiKeyHeader.trim() || 'X-API-Key',
+        value: authFields.apiKeyValue.trim(),
+      },
+    }
+  }
+
+  function buildCreatePayload(requireName: boolean): CreateDataSourceRequest {
+    const trimmedName = formName.trim()
+    if (requireName && !trimmedName) {
+      throw new Error('Name is required')
+    }
+
+    let submitURL = formUrl.trim()
+    if (isCloudWatchType && !submitURL && authFields.cloudWatchRegion.trim()) {
+      submitURL = `https://monitoring.${authFields.cloudWatchRegion.trim()}.amazonaws.com`
+      setFormUrl(submitURL)
+    }
+
+    if (!submitURL) {
+      throw new Error('URL is required')
+    }
+
+    const authPayload = buildAuthPayload()
+    const authConfig: Record<string, unknown> = authPayload.auth_config
+      ? { ...authPayload.auth_config }
+      : {}
+
+    if (isClickHouseType) {
+      const database = authFields.database.trim()
+      if (database) authConfig.database = database
+    }
+
+    if (isElasticsearchType) {
+      const index = authFields.elasticsearchIndex.trim()
+      if (index) authConfig.index = index
+
+      const timeField = authFields.elasticsearchTimestampField.trim()
+      if (timeField) authConfig.time_field = timeField
+
+      const messageField = authFields.elasticsearchMessageField.trim()
+      if (messageField) authConfig.message_field = messageField
+
+      const levelField = authFields.elasticsearchLevelField.trim()
+      if (levelField) authConfig.level_field = levelField
+    }
+
+    const finalAuthConfig = Object.keys(authConfig).length > 0 ? authConfig : undefined
+
+    const payload: CreateDataSourceRequest = {
+      name: trimmedName || `Untitled ${dataSourceTypeLabels[formType]}`,
+      type: formType,
+      url: submitURL,
+      is_default: formIsDefault,
+      auth_type: authPayload.auth_type,
+      auth_config: finalAuthConfig,
+    }
+
+    if (showLogCorrelation) {
+      payload.trace_id_field = authFields.traceIdField.trim() || 'trace_id'
+      payload.linked_trace_datasource_id = authFields.linkedTraceDatasourceId || null
+    }
+
+    return payload
+  }
+
+  async function handleTestConnection() {
+    if (!activeOrgId) {
+      setTestError('Select an organization before testing this datasource')
+      setTestSuccess(null)
+      return
+    }
+
+    setTestLoading(true)
+    setTestError(null)
+    setTestSuccess(null)
+
+    try {
+      const payload = buildCreatePayload(false)
+      await testDataSourceDraftConnection(activeOrgId, payload)
+      setLastTestedSignature(formSignature)
+      setTestSuccess('Connection test succeeded')
+    } catch (e) {
+      setTestError(e instanceof Error ? e.message : 'Connection test failed')
+      setLastTestedSignature(null)
+    } finally {
+      setTestLoading(false)
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    setSaveLoading(true)
+    setFormError(null)
+
+    try {
+      const payload = buildCreatePayload(true)
+      if (isEditing) {
+        if (!datasourceId) throw new Error('Datasource id is required')
+        await updateDataSource(datasourceId, payload)
+      } else {
+        if (!activeOrgId) {
+          throw new Error('Select an organization before creating a datasource')
+        }
+        await createDataSource(activeOrgId, payload)
+      }
+      navigate('/app/settings/datasources')
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to save datasource')
+    } finally {
+      setSaveLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-8 py-6">
+      <header className="mb-6 flex flex-col gap-3">
+        <Link
+          to="/app/settings/datasources"
+          className="flex w-fit cursor-pointer items-center gap-1 border-none bg-transparent text-sm text-[var(--color-outline)] transition hover:text-[var(--color-on-surface)] no-underline"
+        >
+          <ArrowLeft size={16} />
+          Back to Data Sources
+        </Link>
+        <div>
+          <h1 className="m-0 font-display text-2xl font-bold text-[var(--color-on-surface)]">
+            {pageTitle}
+          </h1>
+          <p className="m-0 mt-1 text-sm text-[var(--color-outline)]">{pageDescription}</p>
+        </div>
+      </header>
+
+      {pageLoading ? (
+        <div className="mb-4 inline-flex items-center gap-2 rounded-sm bg-[var(--color-surface-container-low)] px-3.5 py-3 text-sm text-[var(--color-outline)]">
+          <Loader2 size={18} className="animate-spin" />
+          <span>Loading datasource details...</span>
+        </div>
+      ) : null}
+
+      {!pageLoading && loadError ? (
+        <div className="mb-4 rounded-sm bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
+          {loadError}
+        </div>
+      ) : null}
+
+      {!pageLoading && !loadError ? (
+        <form
+          className="flex flex-col gap-4"
+          data-testid="ds-create-form"
+          onSubmit={e => void handleSave(e)}
+        >
+          <section className={sectionClass}>
+            <h2 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">Basics</h2>
+            <div className="grid grid-cols-2 gap-3 max-md:grid-cols-1">
+              <div className="mb-4">
+                <label htmlFor="ds-name" className={labelClass}>
+                  Name <span className="text-[var(--color-error)]">*</span>
+                </label>
+                <input
+                  id="ds-name"
+                  data-testid="ds-name-input"
+                  value={formName}
+                  onChange={e => setFormName(e.target.value)}
+                  type="text"
+                  placeholder="My Prometheus"
+                  disabled={saveLoading}
+                  autoComplete="off"
+                  className={inputClass}
+                />
+              </div>
+              <div className="mb-4">
+                <label htmlFor="ds-type" className={labelClass}>
+                  Type
+                </label>
+                <select
+                  id="ds-type"
+                  data-testid="ds-type-select"
+                  value={formType}
+                  onChange={e => setFormType(e.target.value as DataSourceType)}
+                  disabled={saveLoading}
+                  className={selectClass}
+                >
+                  {TYPE_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="mb-0">
+              <label htmlFor="ds-url" className={labelClass}>
+                URL <span className="text-[var(--color-error)]">*</span>
+              </label>
+              <input
+                id="ds-url"
+                data-testid="ds-url-input"
+                value={formUrl}
+                onChange={e => setFormUrl(e.target.value)}
+                type="text"
+                placeholder="http://localhost:9090"
+                disabled={saveLoading}
+                autoComplete="off"
+                className={inputClass}
+              />
+            </div>
+          </section>
+
+          {isCloudWatchType ? (
+            <section className={sectionClass}>
+              <h2 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">
+                CloudWatch Settings
+              </h2>
+              <div className="grid grid-cols-2 gap-3 max-md:grid-cols-1">
+                <div className="mb-4">
+                  <label htmlFor="ds-cloudwatch-region" className={labelClass}>
+                    AWS Region <span className="text-[var(--color-error)]">*</span>
+                  </label>
+                  <input
+                    id="ds-cloudwatch-region"
+                    data-testid="ds-cloudwatch-region-input"
+                    value={authFields.cloudWatchRegion}
+                    onChange={e => patchAuth({ cloudWatchRegion: e.target.value })}
+                    type="text"
+                    placeholder="us-east-1"
+                    disabled={saveLoading}
+                    autoComplete="off"
+                    className={inputClass}
+                  />
+                </div>
+                <div className="mb-4">
+                  <label htmlFor="ds-cloudwatch-namespace" className={labelClass}>
+                    Metric Namespace (optional)
+                  </label>
+                  <input
+                    id="ds-cloudwatch-namespace"
+                    value={authFields.cloudWatchMetricNamespace}
+                    onChange={e => patchAuth({ cloudWatchMetricNamespace: e.target.value })}
+                    type="text"
+                    placeholder="AWS/ECS"
+                    disabled={saveLoading}
+                    autoComplete="off"
+                    className={inputClass}
+                  />
+                </div>
+              </div>
+              <div className="mb-4">
+                <label htmlFor="ds-cloudwatch-log-group" className={labelClass}>
+                  Default Log Group (optional)
+                </label>
+                <input
+                  id="ds-cloudwatch-log-group"
+                  value={authFields.cloudWatchLogGroup}
+                  onChange={e => patchAuth({ cloudWatchLogGroup: e.target.value })}
+                  type="text"
+                  placeholder="/aws/lambda/my-function"
+                  disabled={saveLoading}
+                  autoComplete="off"
+                  className={inputClass}
+                />
+              </div>
+              <div className="mt-4 rounded-lg bg-[var(--color-surface-container-high)] p-4">
+                <h3 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">
+                  AWS Credentials (optional)
+                </h3>
+                <div className="grid grid-cols-2 gap-3 max-md:grid-cols-1">
+                  <div className="mb-4">
+                    <label htmlFor="ds-cloudwatch-access-key" className={labelClass}>
+                      Access Key ID
+                    </label>
+                    <input
+                      id="ds-cloudwatch-access-key"
+                      value={authFields.cloudWatchAccessKeyId}
+                      onChange={e => patchAuth({ cloudWatchAccessKeyId: e.target.value })}
+                      type="text"
+                      disabled={saveLoading}
+                      autoComplete="off"
+                      className={inputClass}
+                    />
+                  </div>
+                  <div className="mb-4">
+                    <label htmlFor="ds-cloudwatch-secret-key" className={labelClass}>
+                      Secret Access Key
+                    </label>
+                    <input
+                      id="ds-cloudwatch-secret-key"
+                      value={authFields.cloudWatchSecretAccessKey}
+                      onChange={e => patchAuth({ cloudWatchSecretAccessKey: e.target.value })}
+                      type="password"
+                      disabled={saveLoading}
+                      autoComplete="new-password"
+                      className={inputClass}
+                    />
+                  </div>
+                </div>
+                <div className="mb-0">
+                  <label htmlFor="ds-cloudwatch-session-token" className={labelClass}>
+                    Session Token
+                  </label>
+                  <input
+                    id="ds-cloudwatch-session-token"
+                    value={authFields.cloudWatchSessionToken}
+                    onChange={e => patchAuth({ cloudWatchSessionToken: e.target.value })}
+                    type="password"
+                    disabled={saveLoading}
+                    autoComplete="new-password"
+                    className={inputClass}
+                  />
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          {isClickHouseType ? (
+            <section className={sectionClass}>
+              <h2 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">
+                ClickHouse Settings
+              </h2>
+              <div className="mb-0">
+                <label htmlFor="ds-database" className={labelClass}>
+                  Database (optional)
+                </label>
+                <input
+                  id="ds-database"
+                  data-testid="ds-database-input"
+                  value={authFields.database}
+                  onChange={e => patchAuth({ database: e.target.value })}
+                  type="text"
+                  placeholder="default"
+                  disabled={saveLoading}
+                  autoComplete="off"
+                  className={inputClass}
+                />
+              </div>
+            </section>
+          ) : null}
+
+          {isElasticsearchType ? (
+            <section className={sectionClass}>
+              <h2 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">
+                Elasticsearch Settings
+              </h2>
+              <div className="mb-4">
+                <label htmlFor="ds-elasticsearch-index" className={labelClass}>
+                  Default Index Pattern (optional)
+                </label>
+                <input
+                  id="ds-elasticsearch-index"
+                  data-testid="ds-elasticsearch-index-input"
+                  value={authFields.elasticsearchIndex}
+                  onChange={e => patchAuth({ elasticsearchIndex: e.target.value })}
+                  type="text"
+                  placeholder="logs-*"
+                  disabled={saveLoading}
+                  autoComplete="off"
+                  className={inputClass}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3 max-md:grid-cols-1">
+                <div className="mb-4">
+                  <label htmlFor="ds-elasticsearch-time-field" className={labelClass}>
+                    Timestamp Field (optional)
+                  </label>
+                  <input
+                    id="ds-elasticsearch-time-field"
+                    value={authFields.elasticsearchTimestampField}
+                    onChange={e => patchAuth({ elasticsearchTimestampField: e.target.value })}
+                    type="text"
+                    placeholder="@timestamp"
+                    disabled={saveLoading}
+                    autoComplete="off"
+                    className={inputClass}
+                  />
+                </div>
+                <div className="mb-4">
+                  <label htmlFor="ds-elasticsearch-message-field" className={labelClass}>
+                    Message Field (optional)
+                  </label>
+                  <input
+                    id="ds-elasticsearch-message-field"
+                    value={authFields.elasticsearchMessageField}
+                    onChange={e => patchAuth({ elasticsearchMessageField: e.target.value })}
+                    type="text"
+                    placeholder="message"
+                    disabled={saveLoading}
+                    autoComplete="off"
+                    className={inputClass}
+                  />
+                </div>
+              </div>
+              <div className="mb-0">
+                <label htmlFor="ds-elasticsearch-level-field" className={labelClass}>
+                  Level Field (optional)
+                </label>
+                <input
+                  id="ds-elasticsearch-level-field"
+                  value={authFields.elasticsearchLevelField}
+                  onChange={e => patchAuth({ elasticsearchLevelField: e.target.value })}
+                  type="text"
+                  placeholder="level"
+                  disabled={saveLoading}
+                  autoComplete="off"
+                  className={inputClass}
+                />
+              </div>
+            </section>
+          ) : null}
+
+          {showLogCorrelation ? (
+            <section className={sectionClass}>
+              <h2 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">
+                Log Correlation
+              </h2>
+              <div className="mb-4">
+                <label htmlFor="ds-trace-id-field" className={labelClass}>
+                  Trace ID Field
+                </label>
+                <input
+                  id="ds-trace-id-field"
+                  value={authFields.traceIdField}
+                  onChange={e => patchAuth({ traceIdField: e.target.value })}
+                  type="text"
+                  placeholder="trace_id"
+                  disabled={saveLoading}
+                  autoComplete="off"
+                  className={inputClass}
+                />
+                <p className="m-0 mt-1 text-xs text-[var(--color-outline)]">
+                  The log field name that contains distributed trace IDs. Default: trace_id
+                </p>
+              </div>
+              <div className="mb-0">
+                <label htmlFor="ds-linked-trace-ds" className={labelClass}>
+                  Linked Tracing Datasource (optional)
+                </label>
+                <select
+                  id="ds-linked-trace-ds"
+                  value={authFields.linkedTraceDatasourceId || ''}
+                  disabled={saveLoading}
+                  className={selectClass}
+                  onChange={e =>
+                    patchAuth({ linkedTraceDatasourceId: e.target.value || null })
+                  }
+                >
+                  <option value="">None — disable trace linking</option>
+                  {traceDatasources.map(td => (
+                    <option key={td.id} value={td.id}>
+                      {td.name} ({td.type})
+                    </option>
+                  ))}
+                </select>
+                <p className="m-0 mt-1 text-xs text-[var(--color-outline)]">
+                  When a user clicks a trace ID in logs, they&apos;ll be taken to this tracing
+                  datasource.
+                </p>
+              </div>
+            </section>
+          ) : null}
+
+          {showAuthSettings ? (
+            <section className={sectionClass}>
+              <h2 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">
+                Authentication
+              </h2>
+              <div className="mb-4">
+                <label htmlFor="ds-auth-type" className={labelClass}>
+                  Authentication
+                </label>
+                <select
+                  id="ds-auth-type"
+                  data-testid="ds-auth-type-select"
+                  value={authFields.authType}
+                  onChange={e => patchAuth({ authType: e.target.value as AuthType })}
+                  disabled={saveLoading}
+                  className={selectClass}
+                >
+                  <option value="none">None</option>
+                  <option value="basic">Basic auth</option>
+                  <option value="bearer">Bearer token</option>
+                  <option value="api_key">API key</option>
+                </select>
+              </div>
+
+              {authFields.authType === 'basic' ? (
+                <div className="mt-4 rounded-lg bg-[var(--color-surface-container-high)] p-4">
+                  <div className="grid grid-cols-2 gap-3 max-md:grid-cols-1">
+                    <div className="mb-0">
+                      <label htmlFor="ds-basic-username" className={labelClass}>
+                        Username <span className="text-[var(--color-error)]">*</span>
+                      </label>
+                      <input
+                        id="ds-basic-username"
+                        data-testid="ds-basic-username-input"
+                        value={authFields.basicUsername}
+                        onChange={e => patchAuth({ basicUsername: e.target.value })}
+                        type="text"
+                        disabled={saveLoading}
+                        autoComplete="off"
+                        className={inputClass}
+                      />
+                    </div>
+                    <div className="mb-0">
+                      <label htmlFor="ds-basic-password" className={labelClass}>
+                        Password
+                      </label>
+                      <input
+                        id="ds-basic-password"
+                        data-testid="ds-basic-password-input"
+                        value={authFields.basicPassword}
+                        onChange={e => patchAuth({ basicPassword: e.target.value })}
+                        type="password"
+                        disabled={saveLoading}
+                        autoComplete="new-password"
+                        className={inputClass}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {authFields.authType === 'bearer' ? (
+                <div className="mt-4 rounded-lg bg-[var(--color-surface-container-high)] p-4">
+                  <div className="mb-0">
+                    <label htmlFor="ds-bearer-token" className={labelClass}>
+                      Bearer token <span className="text-[var(--color-error)]">*</span>
+                    </label>
+                    <input
+                      id="ds-bearer-token"
+                      data-testid="ds-bearer-token-input"
+                      value={authFields.bearerToken}
+                      onChange={e => patchAuth({ bearerToken: e.target.value })}
+                      type="password"
+                      disabled={saveLoading}
+                      autoComplete="new-password"
+                      className={inputClass}
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              {authFields.authType === 'api_key' ? (
+                <div className="mt-4 rounded-lg bg-[var(--color-surface-container-high)] p-4">
+                  <div className="grid grid-cols-2 gap-3 max-md:grid-cols-1">
+                    <div className="mb-0">
+                      <label htmlFor="ds-api-header" className={labelClass}>
+                        Header name
+                      </label>
+                      <input
+                        id="ds-api-header"
+                        data-testid="ds-api-header-input"
+                        value={authFields.apiKeyHeader}
+                        onChange={e => patchAuth({ apiKeyHeader: e.target.value })}
+                        type="text"
+                        disabled={saveLoading}
+                        autoComplete="off"
+                        className={inputClass}
+                      />
+                    </div>
+                    <div className="mb-0">
+                      <label htmlFor="ds-api-value" className={labelClass}>
+                        API key <span className="text-[var(--color-error)]">*</span>
+                      </label>
+                      <input
+                        id="ds-api-value"
+                        data-testid="ds-api-value-input"
+                        value={authFields.apiKeyValue}
+                        onChange={e => patchAuth({ apiKeyValue: e.target.value })}
+                        type="password"
+                        disabled={saveLoading}
+                        autoComplete="new-password"
+                        className={inputClass}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+
+          <section className={sectionClass}>
+            <h2 className="mb-3 mt-0 text-sm font-semibold text-[var(--color-on-surface)]">
+              Connection Test
+            </h2>
+            <p className="-mt-1 mb-3 text-xs text-[var(--color-outline)]">
+              Run a connection test before saving to verify URL, auth, and datasource availability.
+            </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                className="inline-flex items-center justify-center gap-2 rounded-sm border-none bg-[var(--color-surface-container-high)] px-4 py-2 text-sm font-semibold text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-bright)] disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="ds-test-btn"
+                disabled={testLoading || saveLoading}
+                onClick={() => void handleTestConnection()}
+              >
+                {testLoading ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  <HeartPulse size={16} />
+                )}
+                {testLoading ? 'Testing...' : 'Test Connection'}
+              </button>
+              {testSuccess && !isTestStale ? (
+                <span className="inline-flex items-center gap-1.5 rounded-sm bg-[var(--color-secondary)]/10 px-3 py-2 text-sm text-[var(--color-secondary)]">
+                  <CheckCircle2 size={16} />
+                  {testSuccess}
+                </span>
+              ) : null}
+              {isTestStale ? (
+                <span className="inline-flex items-center gap-1.5 text-sm text-[var(--color-tertiary)]">
+                  <CircleAlert size={16} />
+                  Configuration changed since last successful test
+                </span>
+              ) : null}
+              {!testSuccess && !isTestStale && testError ? (
+                <span className="inline-flex items-center gap-1.5 rounded-sm bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
+                  <CircleAlert size={16} />
+                  {testError}
+                </span>
+              ) : null}
+            </div>
+          </section>
+
+          <section className="rounded-lg bg-[var(--color-surface-container-low)] px-6 py-4">
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-[var(--color-on-surface)]">
+              <input
+                type="checkbox"
+                checked={formIsDefault}
+                onChange={e => setFormIsDefault(e.target.checked)}
+                data-testid="ds-default-checkbox"
+                disabled={saveLoading}
+                className="h-4 w-4"
+              />
+              Set as default data source
+            </label>
+          </section>
+
+          {formError ? (
+            <div className="rounded-sm bg-[var(--color-error)]/10 px-3 py-2 text-sm text-[var(--color-error)]">
+              {formError}
+            </div>
+          ) : null}
+
+          <footer className="flex justify-end gap-2.5 max-md:flex-col-reverse">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 rounded-sm border-none bg-[var(--color-surface-container-high)] px-4 py-2 text-sm font-semibold text-[var(--color-on-surface)] transition hover:bg-[var(--color-surface-bright)] disabled:cursor-not-allowed disabled:opacity-50 max-md:w-full"
+              data-testid="ds-cancel-btn"
+              disabled={saveLoading}
+              onClick={() => navigate('/app/settings/datasources')}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              data-testid="ds-save-btn"
+              className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2.5 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 max-md:w-full"
+              style={{
+                background: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dim) 100%)',
+              }}
+              disabled={saveLoading}
+            >
+              {saveLoading ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Database size={16} />
+              )}
+              {saveButtonText}
+            </button>
+          </footer>
+        </form>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -4,9 +4,6 @@ import { AuthGuard } from '@/layouts/AuthGuard'
 import { AppLayout } from '@/layouts/AppLayout'
 import { createParamRedirect } from '@/lib/redirects'
 
-const PlaceholderPage = lazy(() =>
-  import('@/pages/PlaceholderPage').then(m => ({ default: m.PlaceholderPage })),
-)
 const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })))
 const ExplorePage = lazy(() => import('@/pages/ExplorePage').then(m => ({ default: m.ExplorePage })))
 const DashboardsPage = lazy(() =>
@@ -32,6 +29,12 @@ const AlertsPage = lazy(() => import('@/pages/AlertsPage').then(m => ({ default:
 const SettingsPage = lazy(() =>
   import('@/pages/SettingsPage').then(m => ({ default: m.SettingsPage })),
 )
+const DataSourceCreatePage = lazy(() =>
+  import('@/pages/DataSourceCreatePage').then(m => ({ default: m.DataSourceCreatePage })),
+)
+const AuditLogPage = lazy(() =>
+  import('@/pages/AuditLogPage').then(m => ({ default: m.AuditLogPage })),
+)
 
 const DashboardAliasRedirect = createParamRedirect('/app/dashboards/:id')
 const DashboardSettingsAliasRedirect = createParamRedirect('/app/dashboards/:id/settings')
@@ -51,10 +54,6 @@ export type RouteMeta = {
 
 function withMeta(title: string, description = defaultDescription, extra: Partial<RouteMeta> = {}): RouteMeta {
   return { title, description, ...extra }
-}
-
-function placeholder(title: string, description?: string) {
-  return <PlaceholderPage title={title} description={description} />
 }
 
 function SettingsOrgSectionRedirect() {
@@ -142,17 +141,18 @@ const appRoutes: RouteObject[] = [
   },
   {
     path: '/app/datasources/new',
-    element: <Navigate to="/app/settings/datasources" replace />,
+    handle: withMeta('Add Data Source | Ace'),
+    element: <DataSourceCreatePage />,
   },
   {
     path: '/app/datasources/:id/edit',
     handle: withMeta('Edit Data Source | Ace'),
-    element: placeholder('Edit Data Source'),
+    element: <DataSourceCreatePage />,
   },
   {
     path: '/app/audit-log',
     handle: withMeta('Audit Log — Ace'),
-    element: placeholder('Audit Log'),
+    element: <AuditLogPage />,
   },
 ]
 

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -28,9 +28,7 @@
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [
     "src/**/*.spec.ts",
-    "src/**/*.spec.tsx",
     "src/**/*.test.ts",
-    "src/**/*.test.tsx",
     "src/**/*.vue",
     "src/components/**/*.vue",
     "src/components/panels/**",

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -28,7 +28,9 @@
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [
     "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
     "src/**/*.test.ts",
+    "src/**/*.test.tsx",
     "src/**/*.vue",
     "src/components/**/*.vue",
     "src/components/panels/**",


### PR DESCRIPTION
## Summary

- Port Vue `DataSourceCreateView` → React `DataSourceCreatePage` (create + edit, per-type forms, draft connection test)
- Port Vue `AuditLogView` → React `AuditLogPage` (filters, pagination, CSV/JSON export)
- Wire `/app/datasources/new`, `/app/datasources/:id/edit`, `/app/audit-log` to real pages
- Re-enable Add/Edit links in settings datasource panel

Closes #309

## Test plan

- [x] `bun run test src/pages/DataSourceCreatePage.spec.tsx src/pages/AuditLogPage.spec.tsx` (8 pass)
- [x] `bun run test src/pages/SettingsPage.spec.tsx src/router` (17 pass)
- [x] `bun run type-check`
- [x] `bun run lint`
- [ ] Manual: create Prometheus DS from Settings → Data Sources → appears in list
- [ ] Manual: edit existing DS, test connection, save
- [ ] Manual: open `/app/audit-log`, filter and export