### PR TITLE
Wire datasource query/stream clients through ssrf.DatasourceClient

### DIFF
--- a/backend/internal/datasource/alertmanager.go
+++ b/backend/internal/datasource/alertmanager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // AlertManagerClient wraps HTTP calls to AlertManager's v2 API.
@@ -26,7 +27,7 @@ func NewAlertManagerClient(ds models.DataSource) (*AlertManagerClient, error) {
 	}
 	return &AlertManagerClient{
 		baseURL:    ds.URL,
-		client:     &http.Client{Timeout: 30 * time.Second},
+		client:     ssrf.DatasourceClient(30 * time.Second),
 		datasource: ds,
 	}, nil
 }

--- a/backend/internal/datasource/clickhouse.go
+++ b/backend/internal/datasource/clickhouse.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 const (
@@ -67,7 +68,7 @@ func NewClickHouseClient(ds models.DataSource) (*ClickHouseClient, error) {
 
 	return &ClickHouseClient{
 		datasource: ds,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: ssrf.DatasourceClient(30 * time.Second),
 	}, nil
 }
 

--- a/backend/internal/datasource/elasticsearch.go
+++ b/backend/internal/datasource/elasticsearch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 const (
@@ -68,7 +69,7 @@ func NewElasticsearchClient(ds models.DataSource) (*ElasticsearchClient, error) 
 
 	return &ElasticsearchClient{
 		datasource: ds,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: ssrf.DatasourceClient(30 * time.Second),
 		cfg:        cfg,
 	}, nil
 }

--- a/backend/internal/datasource/loki.go
+++ b/backend/internal/datasource/loki.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // LokiClient queries Loki using LogQL
@@ -25,7 +26,7 @@ type LokiClient struct {
 func NewLokiClient(baseURL string) (*LokiClient, error) {
 	return &LokiClient{
 		baseURL: baseURL,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		client:  ssrf.DatasourceClient(30 * time.Second),
 	}, nil
 }
 

--- a/backend/internal/datasource/loki.go
+++ b/backend/internal/datasource/loki.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/aceobservability/ace/backend/internal/ssrf"
+	"github.com/gorilla/websocket"
 )
 
 // LokiClient queries Loki using LogQL

--- a/backend/internal/datasource/loki.go
+++ b/backend/internal/datasource/loki.go
@@ -260,7 +260,9 @@ func (c *LokiClient) Stream(ctx context.Context, query string, start time.Time, 
 		return err
 	}
 
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
+	dialer := *websocket.DefaultDialer
+	dialer.NetDialContext = ssrf.DatasourceDialContext
+	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Loki tail endpoint: %w", err)
 	}

--- a/backend/internal/datasource/prometheus.go
+++ b/backend/internal/datasource/prometheus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 	promclient "github.com/aceobservability/ace/backend/pkg/prometheus"
 )
 
@@ -12,7 +13,7 @@ type PrometheusClient struct {
 }
 
 func NewPrometheusClient(url string) (*PrometheusClient, error) {
-	client, err := promclient.NewClient(url)
+	client, err := promclient.NewClient(url, ssrf.DatasourceClient(30*time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/datasource/prometheus.go
+++ b/backend/internal/datasource/prometheus.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	promclient "github.com/aceobservability/ace/backend/pkg/prometheus"
 	"github.com/aceobservability/ace/backend/internal/ssrf"
+	promclient "github.com/aceobservability/ace/backend/pkg/prometheus"
 )
 
 type PrometheusClient struct {

--- a/backend/internal/datasource/prometheus.go
+++ b/backend/internal/datasource/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	promclient "github.com/aceobservability/ace/backend/pkg/prometheus"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 type PrometheusClient struct {
@@ -12,7 +13,8 @@ type PrometheusClient struct {
 }
 
 func NewPrometheusClient(url string) (*PrometheusClient, error) {
-	client, err := promclient.NewClient(url)
+	httpClient := ssrf.DatasourceClient(30 * time.Second)
+	client, err := promclient.NewClient(url, httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/datasource/prometheus.go
+++ b/backend/internal/datasource/prometheus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 	promclient "github.com/aceobservability/ace/backend/pkg/prometheus"
 )
 
@@ -13,8 +12,7 @@ type PrometheusClient struct {
 }
 
 func NewPrometheusClient(url string) (*PrometheusClient, error) {
-	httpClient := ssrf.DatasourceClient(30 * time.Second)
-	client, err := promclient.NewClient(url, httpClient)
+	client, err := promclient.NewClient(url)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/datasource/ssrf_client_test.go
+++ b/backend/internal/datasource/ssrf_client_test.go
@@ -1,0 +1,213 @@
+package datasource
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aceobservability/ace/backend/internal/models"
+)
+
+// TestDatasourceClientsUseDatasourceClient verifies that all datasource clients
+// use ssrf.DatasourceClient, which allows private/internal targets but blocks
+// cloud metadata at dial time and on redirects.
+func TestDatasourceClientsUseDatasourceClient(t *testing.T) {
+	t.Parallel()
+
+	// Bind a local server to simulate a private/internal datasource.
+	// DatasourceClient must allow connecting to it (unlike SafeClient).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[]}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Run("prometheus", func(t *testing.T) {
+		client, err := NewPrometheusClient(srv.URL)
+		if err != nil {
+			t.Fatalf("NewPrometheusClient failed: %v", err)
+		}
+		if client == nil {
+			t.Fatal("client is nil")
+		}
+	})
+
+	t.Run("victoriametrics", func(t *testing.T) {
+		client, err := NewVictoriaMetricsClient(srv.URL)
+		if err != nil {
+			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
+		}
+		if client.client == nil {
+			t.Fatal("client.client is nil")
+		}
+	})
+
+	t.Run("loki", func(t *testing.T) {
+		client, err := NewLokiClient(srv.URL)
+		if err != nil {
+			t.Fatalf("NewLokiClient failed: %v", err)
+		}
+		if client.client == nil {
+			t.Fatal("client.client is nil")
+		}
+	})
+
+	t.Run("victorialogs", func(t *testing.T) {
+		client, err := NewVictoriaLogsClient(srv.URL)
+		if err != nil {
+			t.Fatalf("NewVictoriaLogsClient failed: %v", err)
+		}
+		if client.client == nil {
+			t.Fatal("client.client is nil")
+		}
+	})
+
+	t.Run("tempo", func(t *testing.T) {
+		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceTempo}
+		client, err := NewTempoClient(ds)
+		if err != nil {
+			t.Fatalf("NewTempoClient failed: %v", err)
+		}
+		if client.httpClient == nil {
+			t.Fatal("client.httpClient is nil")
+		}
+	})
+
+	t.Run("victoriatraces", func(t *testing.T) {
+		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceVictoriaTraces}
+		client, err := NewVictoriaTracesClient(ds)
+		if err != nil {
+			t.Fatalf("NewVictoriaTracesClient failed: %v", err)
+		}
+		if client.httpClient == nil {
+			t.Fatal("client.httpClient is nil")
+		}
+	})
+
+	t.Run("clickhouse", func(t *testing.T) {
+		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceClickHouse}
+		client, err := NewClickHouseClient(ds)
+		if err != nil {
+			t.Fatalf("NewClickHouseClient failed: %v", err)
+		}
+		if client.httpClient == nil {
+			t.Fatal("client.httpClient is nil")
+		}
+	})
+
+	t.Run("elasticsearch", func(t *testing.T) {
+		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceElasticsearch}
+		client, err := NewElasticsearchClient(ds)
+		if err != nil {
+			t.Fatalf("NewElasticsearchClient failed: %v", err)
+		}
+		if client.httpClient == nil {
+			t.Fatal("client.httpClient is nil")
+		}
+	})
+
+	t.Run("alertmanager", func(t *testing.T) {
+		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceAlertManager}
+		client, err := NewAlertManagerClient(ds)
+		if err != nil {
+			t.Fatalf("NewAlertManagerClient failed: %v", err)
+		}
+		if client.client == nil {
+			t.Fatal("client.client is nil")
+		}
+	})
+
+	t.Run("vmalert", func(t *testing.T) {
+		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceVMAlert}
+		client, err := NewVMAlertClient(ds)
+		if err != nil {
+			t.Fatalf("NewVMAlertClient failed: %v", err)
+		}
+		if client.client == nil {
+			t.Fatal("client.client is nil")
+		}
+	})
+}
+
+// TestDatasourceClientsAllowPrivateNetworks verifies that datasource clients
+// can successfully connect to private/internal network addresses (as required
+// for in-cluster Prometheus, local Victoria stacks, etc.).
+func TestDatasourceClientsAllowPrivateNetworks(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[]}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	// VictoriaMetrics simple query test
+	t.Run("victoriametrics_query", func(t *testing.T) {
+		client, err := NewVictoriaMetricsClient(srv.URL)
+		if err != nil {
+			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// This should succeed because private networks are allowed
+		_, err = client.Query(ctx, "up", time.Now().Add(-1*time.Hour), time.Now(), time.Minute, 10)
+		if err != nil {
+			t.Fatalf("Query to private network should succeed: %v", err)
+		}
+	})
+}
+
+// TestDatasourceClientsBlockMetadata verifies that datasource clients block
+// connections to the cloud metadata endpoint (169.254.169.254).
+func TestDatasourceClientsBlockMetadata(t *testing.T) {
+	t.Parallel()
+
+	// DatasourceClient should refuse to dial cloud metadata endpoint
+	t.Run("victoriametrics_blocks_metadata", func(t *testing.T) {
+		client, err := NewVictoriaMetricsClient("http://169.254.169.254")
+		if err != nil {
+			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// This should fail because cloud metadata is blocked
+		_, err = client.Query(ctx, "up", time.Now().Add(-1*time.Hour), time.Now(), time.Minute, 10)
+		if err == nil {
+			t.Fatal("Query to cloud metadata endpoint should fail")
+		}
+	})
+}
+
+// TestDatasourceClientsBlockMetadataRedirect verifies that datasource clients
+// block redirects to the cloud metadata endpoint.
+func TestDatasourceClientsBlockMetadataRedirect(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Redirect to cloud metadata endpoint
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Run("victoriametrics_blocks_metadata_redirect", func(t *testing.T) {
+		client, err := NewVictoriaMetricsClient(srv.URL)
+		if err != nil {
+			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// This should fail because redirect to cloud metadata is blocked
+		_, err = client.Query(ctx, "up", time.Now().Add(-1*time.Hour), time.Now(), time.Minute, 10)
+		if err == nil {
+			t.Fatal("Query with redirect to cloud metadata endpoint should fail")
+		}
+	})
+}

--- a/backend/internal/datasource/ssrf_client_test.go
+++ b/backend/internal/datasource/ssrf_client_test.go
@@ -14,7 +14,7 @@ import (
 
 const cloudMetadataURL = "http://169.254.169.254/"
 
-func TestDatasourceClientsUseDatasourceClient(t *testing.T) {
+func TestDatasourceClientsWireDialAndRedirectPolicy(t *testing.T) {
 	t.Parallel()
 
 	clients := constructedDatasourceHTTPClients(t)
@@ -26,8 +26,24 @@ func TestDatasourceClientsUseDatasourceClient(t *testing.T) {
 			if client.CheckRedirect == nil {
 				t.Fatal("expected DatasourceClient redirect policy (CheckRedirect)")
 			}
+			if client.Transport == nil {
+				t.Fatal("expected DatasourceClient dial policy (Transport)")
+			}
 		})
 	}
+
+	t.Run("victorialogs_stream_timeout", func(t *testing.T) {
+		c, err := NewVictoriaLogsClient("http://127.0.0.1:9428")
+		if err != nil {
+			t.Fatalf("NewVictoriaLogsClient: %v", err)
+		}
+		if c.streamClient == nil {
+			t.Fatal("streamClient is nil")
+		}
+		if c.streamClient.Timeout != 0 {
+			t.Fatalf("streamClient.Timeout = %s, want 0 for long-lived tails", c.streamClient.Timeout)
+		}
+	})
 }
 
 func TestDatasourceClientsAllowPrivateNetworks(t *testing.T) {
@@ -169,15 +185,16 @@ func constructedDatasourceHTTPClients(t *testing.T) map[string]*http.Client {
 	}
 
 	return map[string]*http.Client{
-		"victoriametrics": vm.client,
-		"loki":            loki.client,
-		"victorialogs":    vlogs.client,
-		"tempo":           tempo.httpClient,
-		"victoriatraces":  vtraces.httpClient,
-		"clickhouse":      ch.httpClient,
-		"elasticsearch":   es.httpClient,
-		"alertmanager":    am.client,
-		"vmalert":         vmalert.client,
+		"victoriametrics":     vm.client,
+		"loki":                loki.client,
+		"victorialogs":        vlogs.client,
+		"victorialogs_stream": vlogs.streamClient,
+		"tempo":               tempo.httpClient,
+		"victoriatraces":      vtraces.httpClient,
+		"clickhouse":          ch.httpClient,
+		"elasticsearch":       es.httpClient,
+		"alertmanager":        am.client,
+		"vmalert":             vmalert.client,
 	}
 }
 

--- a/backend/internal/datasource/ssrf_client_test.go
+++ b/backend/internal/datasource/ssrf_client_test.go
@@ -2,212 +2,271 @@ package datasource
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
 )
 
-// TestDatasourceClientsUseDatasourceClient verifies that all datasource clients
-// use ssrf.DatasourceClient, which allows private/internal targets but blocks
-// cloud metadata at dial time and on redirects.
+const cloudMetadataURL = "http://169.254.169.254/"
+
 func TestDatasourceClientsUseDatasourceClient(t *testing.T) {
 	t.Parallel()
 
-	// Bind a local server to simulate a private/internal datasource.
-	// DatasourceClient must allow connecting to it (unlike SafeClient).
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[]}}`))
-	}))
-	t.Cleanup(srv.Close)
-
-	t.Run("prometheus", func(t *testing.T) {
-		client, err := NewPrometheusClient(srv.URL)
-		if err != nil {
-			t.Fatalf("NewPrometheusClient failed: %v", err)
-		}
-		if client == nil {
-			t.Fatal("client is nil")
-		}
-	})
-
-	t.Run("victoriametrics", func(t *testing.T) {
-		client, err := NewVictoriaMetricsClient(srv.URL)
-		if err != nil {
-			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
-		}
-		if client.client == nil {
-			t.Fatal("client.client is nil")
-		}
-	})
-
-	t.Run("loki", func(t *testing.T) {
-		client, err := NewLokiClient(srv.URL)
-		if err != nil {
-			t.Fatalf("NewLokiClient failed: %v", err)
-		}
-		if client.client == nil {
-			t.Fatal("client.client is nil")
-		}
-	})
-
-	t.Run("victorialogs", func(t *testing.T) {
-		client, err := NewVictoriaLogsClient(srv.URL)
-		if err != nil {
-			t.Fatalf("NewVictoriaLogsClient failed: %v", err)
-		}
-		if client.client == nil {
-			t.Fatal("client.client is nil")
-		}
-	})
-
-	t.Run("tempo", func(t *testing.T) {
-		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceTempo}
-		client, err := NewTempoClient(ds)
-		if err != nil {
-			t.Fatalf("NewTempoClient failed: %v", err)
-		}
-		if client.httpClient == nil {
-			t.Fatal("client.httpClient is nil")
-		}
-	})
-
-	t.Run("victoriatraces", func(t *testing.T) {
-		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceVictoriaTraces}
-		client, err := NewVictoriaTracesClient(ds)
-		if err != nil {
-			t.Fatalf("NewVictoriaTracesClient failed: %v", err)
-		}
-		if client.httpClient == nil {
-			t.Fatal("client.httpClient is nil")
-		}
-	})
-
-	t.Run("clickhouse", func(t *testing.T) {
-		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceClickHouse}
-		client, err := NewClickHouseClient(ds)
-		if err != nil {
-			t.Fatalf("NewClickHouseClient failed: %v", err)
-		}
-		if client.httpClient == nil {
-			t.Fatal("client.httpClient is nil")
-		}
-	})
-
-	t.Run("elasticsearch", func(t *testing.T) {
-		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceElasticsearch}
-		client, err := NewElasticsearchClient(ds)
-		if err != nil {
-			t.Fatalf("NewElasticsearchClient failed: %v", err)
-		}
-		if client.httpClient == nil {
-			t.Fatal("client.httpClient is nil")
-		}
-	})
-
-	t.Run("alertmanager", func(t *testing.T) {
-		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceAlertManager}
-		client, err := NewAlertManagerClient(ds)
-		if err != nil {
-			t.Fatalf("NewAlertManagerClient failed: %v", err)
-		}
-		if client.client == nil {
-			t.Fatal("client.client is nil")
-		}
-	})
-
-	t.Run("vmalert", func(t *testing.T) {
-		ds := models.DataSource{URL: srv.URL, Type: models.DataSourceVMAlert}
-		client, err := NewVMAlertClient(ds)
-		if err != nil {
-			t.Fatalf("NewVMAlertClient failed: %v", err)
-		}
-		if client.client == nil {
-			t.Fatal("client.client is nil")
-		}
-	})
+	clients := constructedDatasourceHTTPClients(t)
+	for name, client := range clients {
+		t.Run(name, func(t *testing.T) {
+			if client == nil {
+				t.Fatal("http client is nil")
+			}
+			if client.CheckRedirect == nil {
+				t.Fatal("expected DatasourceClient redirect policy (CheckRedirect)")
+			}
+		})
+	}
 }
 
-// TestDatasourceClientsAllowPrivateNetworks verifies that datasource clients
-// can successfully connect to private/internal network addresses (as required
-// for in-cluster Prometheus, local Victoria stacks, etc.).
 func TestDatasourceClientsAllowPrivateNetworks(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[]}}`))
+		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[],"alerts":[],"groups":[]},"traces":[],"hits":{"hits":[]}}`))
 	}))
 	t.Cleanup(srv.Close)
 
-	// VictoriaMetrics simple query test
-	t.Run("victoriametrics_query", func(t *testing.T) {
-		client, err := NewVictoriaMetricsClient(srv.URL)
-		if err != nil {
-			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		// This should succeed because private networks are allowed
-		_, err = client.Query(ctx, "up", time.Now().Add(-1*time.Hour), time.Now(), time.Minute, 10)
-		if err != nil {
-			t.Fatalf("Query to private network should succeed: %v", err)
-		}
-	})
+	for name, query := range datasourceQueryFns() {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			err := query(ctx, srv.URL)
+			if isOutboundPolicyError(err) {
+				t.Fatalf("query to private network should not be blocked by SSRF policy: %v", err)
+			}
+		})
+	}
 }
 
-// TestDatasourceClientsBlockMetadata verifies that datasource clients block
-// connections to the cloud metadata endpoint (169.254.169.254).
 func TestDatasourceClientsBlockMetadata(t *testing.T) {
 	t.Parallel()
 
-	// DatasourceClient should refuse to dial cloud metadata endpoint
-	t.Run("victoriametrics_blocks_metadata", func(t *testing.T) {
-		client, err := NewVictoriaMetricsClient("http://169.254.169.254")
-		if err != nil {
-			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		// This should fail because cloud metadata is blocked
-		_, err = client.Query(ctx, "up", time.Now().Add(-1*time.Hour), time.Now(), time.Minute, 10)
-		if err == nil {
-			t.Fatal("Query to cloud metadata endpoint should fail")
-		}
-	})
+	for name, query := range datasourceQueryFns() {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			if err := query(ctx, strings.TrimRight(cloudMetadataURL, "/")); err == nil {
+				t.Fatal("query to cloud metadata endpoint should fail")
+			}
+		})
+	}
 }
 
-// TestDatasourceClientsBlockMetadataRedirect verifies that datasource clients
-// block redirects to the cloud metadata endpoint.
 func TestDatasourceClientsBlockMetadataRedirect(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Redirect to cloud metadata endpoint
 		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data", http.StatusFound)
 	}))
 	t.Cleanup(srv.Close)
 
-	t.Run("victoriametrics_blocks_metadata_redirect", func(t *testing.T) {
-		client, err := NewVictoriaMetricsClient(srv.URL)
-		if err != nil {
-			t.Fatalf("NewVictoriaMetricsClient failed: %v", err)
-		}
+	for name, query := range datasourceQueryFns() {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			if err := query(ctx, srv.URL); err == nil {
+				t.Fatal("query with redirect to cloud metadata endpoint should fail")
+			}
+		})
+	}
+}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
+func TestLokiStreamBlocksMetadata(t *testing.T) {
+	t.Parallel()
 
-		// This should fail because redirect to cloud metadata is blocked
-		_, err = client.Query(ctx, "up", time.Now().Add(-1*time.Hour), time.Now(), time.Minute, 10)
-		if err == nil {
-			t.Fatal("Query with redirect to cloud metadata endpoint should fail")
-		}
-	})
+	client, err := NewLokiClient(strings.TrimRight(cloudMetadataURL, "/"))
+	if err != nil {
+		t.Fatalf("NewLokiClient failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = client.Stream(ctx, `{job="ace"}`, time.Time{}, 1, func(LogEntry) error { return nil })
+	if err == nil {
+		t.Fatal("Loki websocket stream to cloud metadata endpoint should fail")
+	}
+}
+
+func TestVictoriaLogsStreamBlocksMetadata(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewVictoriaLogsClient(strings.TrimRight(cloudMetadataURL, "/"))
+	if err != nil {
+		t.Fatalf("NewVictoriaLogsClient failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = client.Stream(ctx, `*`, time.Time{}, 1, func(LogEntry) error { return nil })
+	if err == nil {
+		t.Fatal("VictoriaLogs stream to cloud metadata endpoint should fail")
+	}
+}
+
+func isOutboundPolicyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "cloud metadata") ||
+		strings.Contains(msg, "private/internal") ||
+		strings.Contains(msg, "redirect target rejected")
+}
+
+func constructedDatasourceHTTPClients(t *testing.T) map[string]*http.Client {
+	t.Helper()
+
+	vm, err := NewVictoriaMetricsClient("http://127.0.0.1:8428")
+	if err != nil {
+		t.Fatalf("NewVictoriaMetricsClient: %v", err)
+	}
+	loki, err := NewLokiClient("http://127.0.0.1:3100")
+	if err != nil {
+		t.Fatalf("NewLokiClient: %v", err)
+	}
+	vlogs, err := NewVictoriaLogsClient("http://127.0.0.1:9428")
+	if err != nil {
+		t.Fatalf("NewVictoriaLogsClient: %v", err)
+	}
+	tempo, err := NewTempoClient(models.DataSource{URL: "http://127.0.0.1:3200", Type: models.DataSourceTempo})
+	if err != nil {
+		t.Fatalf("NewTempoClient: %v", err)
+	}
+	vtraces, err := NewVictoriaTracesClient(models.DataSource{URL: "http://127.0.0.1:10428", Type: models.DataSourceVictoriaTraces})
+	if err != nil {
+		t.Fatalf("NewVictoriaTracesClient: %v", err)
+	}
+	ch, err := NewClickHouseClient(models.DataSource{URL: "http://127.0.0.1:8123", Type: models.DataSourceClickHouse})
+	if err != nil {
+		t.Fatalf("NewClickHouseClient: %v", err)
+	}
+	es, err := NewElasticsearchClient(models.DataSource{URL: "http://127.0.0.1:9200", Type: models.DataSourceElasticsearch})
+	if err != nil {
+		t.Fatalf("NewElasticsearchClient: %v", err)
+	}
+	am, err := NewAlertManagerClient(models.DataSource{URL: "http://127.0.0.1:9093", Type: models.DataSourceAlertManager})
+	if err != nil {
+		t.Fatalf("NewAlertManagerClient: %v", err)
+	}
+	vmalert, err := NewVMAlertClient(models.DataSource{URL: "http://127.0.0.1:8880", Type: models.DataSourceVMAlert})
+	if err != nil {
+		t.Fatalf("NewVMAlertClient: %v", err)
+	}
+
+	return map[string]*http.Client{
+		"victoriametrics": vm.client,
+		"loki":            loki.client,
+		"victorialogs":    vlogs.client,
+		"tempo":           tempo.httpClient,
+		"victoriatraces":  vtraces.httpClient,
+		"clickhouse":      ch.httpClient,
+		"elasticsearch":   es.httpClient,
+		"alertmanager":    am.client,
+		"vmalert":         vmalert.client,
+	}
+}
+
+func datasourceQueryFns() map[string]func(context.Context, string) error {
+	return map[string]func(context.Context, string) error{
+		"prometheus": func(ctx context.Context, baseURL string) error {
+			client, err := NewPrometheusClient(baseURL)
+			if err != nil {
+				return err
+			}
+			result, err := client.Query(ctx, "up", time.Now().Add(-time.Hour), time.Now(), time.Minute, 10)
+			if err != nil {
+				return err
+			}
+			if result != nil && result.Status == "error" && result.Error != "" {
+				return fmt.Errorf("%s", result.Error)
+			}
+			return nil
+		},
+		"victoriametrics": func(ctx context.Context, baseURL string) error {
+			client, err := NewVictoriaMetricsClient(baseURL)
+			if err != nil {
+				return err
+			}
+			_, err = client.Query(ctx, "up", time.Now().Add(-time.Hour), time.Now(), time.Minute, 10)
+			return err
+		},
+		"loki": func(ctx context.Context, baseURL string) error {
+			client, err := NewLokiClient(baseURL)
+			if err != nil {
+				return err
+			}
+			_, err = client.Query(ctx, `{job="ace"}`, time.Now().Add(-time.Hour), time.Now(), time.Minute, 10)
+			return err
+		},
+		"victorialogs": func(ctx context.Context, baseURL string) error {
+			client, err := NewVictoriaLogsClient(baseURL)
+			if err != nil {
+				return err
+			}
+			_, err = client.Query(ctx, `*`, time.Now().Add(-time.Hour), time.Now(), time.Minute, 10)
+			return err
+		},
+		"tempo": func(ctx context.Context, baseURL string) error {
+			client, err := NewTempoClient(models.DataSource{URL: baseURL, Type: models.DataSourceTempo})
+			if err != nil {
+				return err
+			}
+			_, err = client.GetTrace(ctx, "abc")
+			return err
+		},
+		"victoriatraces": func(ctx context.Context, baseURL string) error {
+			client, err := NewVictoriaTracesClient(models.DataSource{URL: baseURL, Type: models.DataSourceVictoriaTraces})
+			if err != nil {
+				return err
+			}
+			_, err = client.GetTrace(ctx, "abc")
+			return err
+		},
+		"clickhouse": func(ctx context.Context, baseURL string) error {
+			client, err := NewClickHouseClient(models.DataSource{URL: baseURL, Type: models.DataSourceClickHouse})
+			if err != nil {
+				return err
+			}
+			_, err = client.Query(ctx, "SELECT 1", time.Now().Add(-time.Hour), time.Now(), time.Minute, 10)
+			return err
+		},
+		"elasticsearch": func(ctx context.Context, baseURL string) error {
+			client, err := NewElasticsearchClient(models.DataSource{URL: baseURL, Type: models.DataSourceElasticsearch})
+			if err != nil {
+				return err
+			}
+			_, err = client.Query(ctx, "*", time.Now().Add(-time.Hour), time.Now(), time.Minute, 10)
+			return err
+		},
+		"alertmanager": func(ctx context.Context, baseURL string) error {
+			client, err := NewAlertManagerClient(models.DataSource{URL: baseURL, Type: models.DataSourceAlertManager})
+			if err != nil {
+				return err
+			}
+			_, err = client.GetStatus(ctx)
+			return err
+		},
+		"vmalert": func(ctx context.Context, baseURL string) error {
+			client, err := NewVMAlertClient(models.DataSource{URL: baseURL, Type: models.DataSourceVMAlert})
+			if err != nil {
+				return err
+			}
+			return client.Health(ctx)
+		},
+	}
 }

--- a/backend/internal/datasource/tempo.go
+++ b/backend/internal/datasource/tempo.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // TempoClient is used for trace datasource connectivity checks.
@@ -24,7 +25,7 @@ func NewTempoClient(ds models.DataSource) (*TempoClient, error) {
 
 	return &TempoClient{
 		datasource: ds,
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		httpClient: ssrf.DatasourceClient(15 * time.Second),
 	}, nil
 }
 

--- a/backend/internal/datasource/victorialogs.go
+++ b/backend/internal/datasource/victorialogs.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // VictoriaLogsClient queries Victoria Logs using LogsQL
@@ -23,7 +25,7 @@ type VictoriaLogsClient struct {
 func NewVictoriaLogsClient(baseURL string) (*VictoriaLogsClient, error) {
 	return &VictoriaLogsClient{
 		baseURL: baseURL,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		client:  ssrf.DatasourceClient(30 * time.Second),
 	}, nil
 }
 
@@ -235,7 +237,7 @@ func (c *VictoriaLogsClient) Stream(ctx context.Context, query string, start tim
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	streamClient := &http.Client{}
+	streamClient := ssrf.DatasourceClient(0)
 	resp, err := streamClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to stream Victoria Logs tail: %w", err)

--- a/backend/internal/datasource/victorialogs.go
+++ b/backend/internal/datasource/victorialogs.go
@@ -18,14 +18,16 @@ import (
 
 // VictoriaLogsClient queries Victoria Logs using LogsQL
 type VictoriaLogsClient struct {
-	baseURL string
-	client  *http.Client
+	baseURL      string
+	client       *http.Client
+	streamClient *http.Client
 }
 
 func NewVictoriaLogsClient(baseURL string) (*VictoriaLogsClient, error) {
 	return &VictoriaLogsClient{
-		baseURL: baseURL,
-		client:  ssrf.DatasourceClient(30 * time.Second),
+		baseURL:      baseURL,
+		client:       ssrf.DatasourceClient(30 * time.Second),
+		streamClient: ssrf.DatasourceClient(0), // Timeout 0: long-lived tails
 	}, nil
 }
 
@@ -237,8 +239,7 @@ func (c *VictoriaLogsClient) Stream(ctx context.Context, query string, start tim
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	streamClient := ssrf.DatasourceClient(0)
-	resp, err := streamClient.Do(req)
+	resp, err := c.streamClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to stream Victoria Logs tail: %w", err)
 	}

--- a/backend/internal/datasource/victoriametrics.go
+++ b/backend/internal/datasource/victoriametrics.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // VictoriaMetricsClient queries VictoriaMetrics using PromQL-compatible API
@@ -21,7 +23,7 @@ type VictoriaMetricsClient struct {
 func NewVictoriaMetricsClient(baseURL string) (*VictoriaMetricsClient, error) {
 	return &VictoriaMetricsClient{
 		baseURL: baseURL,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		client:  ssrf.DatasourceClient(30 * time.Second),
 	}, nil
 }
 

--- a/backend/internal/datasource/victoriatraces.go
+++ b/backend/internal/datasource/victoriatraces.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // VictoriaTracesClient is used for trace datasource connectivity checks.
@@ -24,7 +25,7 @@ func NewVictoriaTracesClient(ds models.DataSource) (*VictoriaTracesClient, error
 
 	return &VictoriaTracesClient{
 		datasource: ds,
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		httpClient: ssrf.DatasourceClient(15 * time.Second),
 	}, nil
 }
 

--- a/backend/internal/datasource/vmalert.go
+++ b/backend/internal/datasource/vmalert.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // VMAlertClient wraps HTTP calls to VMAlert's API.
@@ -25,7 +26,7 @@ func NewVMAlertClient(ds models.DataSource) (*VMAlertClient, error) {
 	}
 	return &VMAlertClient{
 		baseURL:    ds.URL,
-		client:     &http.Client{Timeout: 30 * time.Second},
+		client:     ssrf.DatasourceClient(30 * time.Second),
 		datasource: ds,
 	}, nil
 }

--- a/backend/internal/handlers/prometheus.go
+++ b/backend/internal/handlers/prometheus.go
@@ -55,6 +55,12 @@ func (c *MetadataCache) Set(key string, data interface{}) {
 type PrometheusHandler struct {
 	prometheusURL string
 	cache         *MetadataCache
+
+	// Lazy singleton client so each request reuses one DatasourceClient
+	// transport/connection pool instead of allocating per call.
+	clientOnce sync.Once
+	client     *prometheus.Client
+	clientErr  error
 }
 
 func NewPrometheusHandler(prometheusURL string) *PrometheusHandler {
@@ -65,7 +71,10 @@ func NewPrometheusHandler(prometheusURL string) *PrometheusHandler {
 }
 
 func (h *PrometheusHandler) newClient() (*prometheus.Client, error) {
-	return prometheus.NewClient(h.prometheusURL, ssrf.DatasourceClient(30*time.Second))
+	h.clientOnce.Do(func() {
+		h.client, h.clientErr = prometheus.NewClient(h.prometheusURL, ssrf.DatasourceClient(30*time.Second))
+	})
+	return h.client, h.clientErr
 }
 
 type QueryRequest struct {

--- a/backend/internal/handlers/prometheus.go
+++ b/backend/internal/handlers/prometheus.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 	"github.com/aceobservability/ace/backend/pkg/prometheus"
 )
 
@@ -61,6 +62,10 @@ func NewPrometheusHandler(prometheusURL string) *PrometheusHandler {
 		prometheusURL: prometheusURL,
 		cache:         NewMetadataCache(5 * time.Minute),
 	}
+}
+
+func (h *PrometheusHandler) newClient() (*prometheus.Client, error) {
+	return prometheus.NewClient(h.prometheusURL, ssrf.DatasourceClient(30*time.Second))
 }
 
 type QueryRequest struct {
@@ -146,7 +151,7 @@ func (h *PrometheusHandler) Query(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create Prometheus client
-	client, err := prometheus.NewClient(h.prometheusURL)
+	client, err := h.newClient()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(ErrorResponse{
@@ -198,7 +203,7 @@ func (h *PrometheusHandler) Labels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := prometheus.NewClient(h.prometheusURL)
+	client, err := h.newClient()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(ErrorResponse{
@@ -242,7 +247,7 @@ func (h *PrometheusHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := prometheus.NewClient(h.prometheusURL)
+	client, err := h.newClient()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(ErrorResponse{
@@ -299,7 +304,7 @@ func (h *PrometheusHandler) LabelValues(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	client, err := prometheus.NewClient(h.prometheusURL)
+	client, err := h.newClient()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(ErrorResponse{

--- a/backend/internal/handlers/prometheus_test.go
+++ b/backend/internal/handlers/prometheus_test.go
@@ -111,3 +111,18 @@ func TestNewPrometheusHandler(t *testing.T) {
 		t.Errorf("expected prometheusURL 'http://localhost:9090', got '%s'", handler.prometheusURL)
 	}
 }
+
+func TestPrometheusHandler_newClient_reusesSingleton(t *testing.T) {
+	handler := NewPrometheusHandler("http://localhost:9090")
+	c1, err := handler.newClient()
+	if err != nil {
+		t.Fatalf("first newClient: %v", err)
+	}
+	c2, err := handler.newClient()
+	if err != nil {
+		t.Fatalf("second newClient: %v", err)
+	}
+	if c1 != c2 {
+		t.Fatal("expected handler to reuse one prometheus client across requests")
+	}
+}

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -178,9 +178,9 @@ func SafeClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &urlPolicyTransport{
-			base:   base,
-			reject: reject,
-			// proxy nil => direct dials only; no hostname→IP pin.
+			base:           base,
+			reject:         reject,
+			pinDestination: false, // no proxy hop; keep hostname for multi-IP dial fallback
 			validate: func(raw string) error {
 				_, err := ValidateURL(raw)
 				return err
@@ -201,19 +201,20 @@ func rejectCloudMetadata(ip net.IP) error {
 // endpoint is blocked on the request URL (including when an HTTP proxy is
 // used), at dial time for direct connections, and on redirects.
 //
-// When HTTP(S)_PROXY applies to a request, destination hostnames are resolved
-// and pinned to a validated IP before the proxy hop so the proxy cannot
-// re-resolve the name to a different address (e.g. cloud metadata). Direct
-// (no-proxy) dials leave the hostname intact so dialBlockingTransport keeps
-// multi-A/AAAA fallback.
+// When an HTTP(S)_PROXY hop will actually be used, destination hostnames are
+// resolved and pinned to a validated IP before the proxy sees the request so
+// the proxy cannot re-resolve the name to a different address (e.g. cloud
+// metadata). Direct (no-proxy) dials leave the hostname intact so
+// dialBlockingTransport keeps multi-A/AAAA fallback. Pinning is gated on the
+// base *http.Transport's Proxy func (single source of truth with useProxy).
 func DatasourceClient(timeout time.Duration) *http.Client {
 	base := dialBlockingTransport(rejectCloudMetadata, true /* useProxy */)
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &urlPolicyTransport{
-			base:   base,
-			reject: rejectCloudMetadata,
-			proxy:  http.ProxyFromEnvironment,
+			base:           base,
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
 			validate: func(raw string) error {
 				_, err := ValidateDatasourceURL(raw)
 				return err
@@ -243,15 +244,17 @@ func DatasourceDialContext(ctx context.Context, network, addr string) (net.Conn,
 // transport runs. This matters when ProxyFromEnvironment is set: DialContext
 // only sees the proxy hop, so destination policy must run on RoundTrip.
 //
-// When proxy is non-nil and returns a proxy URL for the request, the hostname
-// is resolved and rewritten to a policy-checked IP (Host/SNI preserved) so the
-// proxy cannot re-resolve the name independently. For direct (no-proxy) dials
-// the base transport's DialContext loop already handles multi-A/AAAA fallback.
+// pinDestination is a capability flag (DatasourceClient true, SafeClient
+// false). Rewriting URL.Host to a single policy-checked IP only happens when
+// base is an *http.Transport whose Proxy returns a non-nil URL for this
+// request. That closes proxy-side DNS rebinding without collapsing direct
+// hostname dials to one address (which would disable multi-A/AAAA fallback
+// in dialBlockingTransport). Host/SNI are preserved on the pinned request.
 type urlPolicyTransport struct {
-	base     http.RoundTripper
-	validate func(raw string) error
-	reject   func(net.IP) error
-	proxy    func(*http.Request) (*url.URL, error) // nil = direct, no pinning
+	base           http.RoundTripper
+	validate       func(raw string) error
+	reject         func(net.IP) error
+	pinDestination bool
 
 	// Cached *http.Transport clones keyed by TLS ServerName. Pinning rewrites
 	// URL.Host to an IP, so HTTPS needs ServerName=original DNS name; cloning
@@ -267,17 +270,30 @@ func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if err := t.validate(req.URL.String()); err != nil {
 		return nil, err
 	}
-	if t.proxy != nil {
-		if proxyURL, err := t.proxy(req); err == nil && proxyURL != nil {
-			cloned := req.Clone(req.Context())
-			tlsServerName, pinErr := pinRequestURLToValidatedIP(cloned, t.reject)
-			if pinErr != nil {
-				return nil, pinErr
-			}
-			return t.roundTripWithTLSServerName(cloned, tlsServerName)
+	if t.shouldPinDestination(req) {
+		cloned := req.Clone(req.Context())
+		tlsServerName, pinErr := pinRequestURLToValidatedIP(cloned, t.reject)
+		if pinErr != nil {
+			return nil, pinErr
 		}
+		return t.roundTripWithTLSServerName(cloned, tlsServerName)
 	}
 	return t.base.RoundTrip(req)
+}
+
+// shouldPinDestination is true only when pinning is enabled and this request
+// will actually use an HTTP proxy hop. No proxy (or a non-transport base)
+// leaves the hostname in place for fail-closed reject + multi-IP dial.
+func (t *urlPolicyTransport) shouldPinDestination(req *http.Request) bool {
+	if !t.pinDestination {
+		return false
+	}
+	base, ok := t.base.(*http.Transport)
+	if !ok || base == nil || base.Proxy == nil {
+		return false
+	}
+	proxyURL, err := base.Proxy(req)
+	return err == nil && proxyURL != nil
 }
 
 // roundTripWithTLSServerName sends req through the base transport. When the URL
@@ -340,9 +356,11 @@ func (t *urlPolicyTransport) CloseIdleConnections() {
 }
 
 // pinRequestURLToValidatedIP resolves the request hostname, rejects any IP that
-// fails policy, and rewrites URL.Host to the first allowed address while keeping
-// req.Host as the original authority. It returns the original DNS name when the
-// host was not already a literal IP, so HTTPS callers can set TLS ServerName.
+// fails policy (fail closed), and rewrites URL.Host to the first allowed
+// address while keeping req.Host as the original authority. It returns the
+// original DNS name when the host was not already a literal IP, so HTTPS
+// callers can set TLS ServerName. Used only on the proxy hop; direct dials
+// must not pin so multi-A/AAAA fallback remains.
 func pinRequestURLToValidatedIP(req *http.Request, reject func(net.IP) error) (tlsServerName string, err error) {
 	if reject == nil {
 		return "", fmt.Errorf("missing IP reject policy")

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -251,6 +252,12 @@ type urlPolicyTransport struct {
 	validate func(raw string) error
 	reject   func(net.IP) error
 	proxy    func(*http.Request) (*url.URL, error) // nil = direct, no pinning
+
+	// Cached *http.Transport clones keyed by TLS ServerName. Pinning rewrites
+	// URL.Host to an IP, so HTTPS needs ServerName=original DNS name; cloning
+	// once per name keeps idle pools instead of per-request transports.
+	mu        sync.Mutex
+	tlsByName map[string]*http.Transport
 }
 
 func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -286,6 +293,20 @@ func (t *urlPolicyTransport) roundTripWithTLSServerName(req *http.Request, tlsSe
 		// real HTTPS must use *http.Transport.
 		return t.base.RoundTrip(req)
 	}
+	return t.transportForServerName(base, tlsServerName).RoundTrip(req)
+}
+
+// transportForServerName returns a cached transport clone with ServerName set
+// so repeated HTTPS queries to the same datasource reuse one idle pool.
+func (t *urlPolicyTransport) transportForServerName(base *http.Transport, serverName string) *http.Transport {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.tlsByName == nil {
+		t.tlsByName = make(map[string]*http.Transport)
+	}
+	if tr, ok := t.tlsByName[serverName]; ok {
+		return tr
+	}
 	tr := base.Clone()
 	var cfg *tls.Config
 	if tr.TLSClientConfig == nil {
@@ -295,10 +316,27 @@ func (t *urlPolicyTransport) roundTripWithTLSServerName(req *http.Request, tlsSe
 	}
 	// Only fill ServerName when unset so an explicit transport config still wins.
 	if cfg.ServerName == "" {
-		cfg.ServerName = tlsServerName
+		cfg.ServerName = serverName
 	}
 	tr.TLSClientConfig = cfg
-	return tr.RoundTrip(req)
+	t.tlsByName[serverName] = tr
+	return tr
+}
+
+// CloseIdleConnections forwards idle-pool cleanup to the base transport and any
+// cached ServerName clones (http.Client calls this when present).
+func (t *urlPolicyTransport) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if c, ok := t.base.(closeIdler); ok {
+		c.CloseIdleConnections()
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, tr := range t.tlsByName {
+		tr.CloseIdleConnections()
+	}
 }
 
 // pinRequestURLToValidatedIP resolves the request hostname, rejects any IP that

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -161,16 +161,19 @@ func IsLocalURL(raw string) bool {
 // Use for untrusted user-supplied hosts only — not for configured datasources
 // that may legitimately live on private networks.
 func SafeClient(timeout time.Duration) *http.Client {
-	base := dialBlockingTransport(func(ip net.IP) error {
+	reject := func(ip net.IP) error {
 		if isBlockedIP(ip) {
 			return fmt.Errorf("connections to private/internal addresses are not allowed")
 		}
 		return nil
-	}, false /* useProxy */)
+	}
+	base := dialBlockingTransport(reject, false /* useProxy */)
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &urlPolicyTransport{
-			base: base,
+			base:           base,
+			reject:         reject,
+			pinDestination: true,
 			validate: func(raw string) error {
 				_, err := ValidateURL(raw)
 				return err
@@ -190,12 +193,18 @@ func rejectCloudMetadata(ip net.IP) error {
 // datasources. Private/internal targets are allowed; the cloud metadata
 // endpoint is blocked on the request URL (including when an HTTP proxy is
 // used), at dial time for direct connections, and on redirects.
+//
+// Destination hostnames are resolved and pinned to a validated IP before the
+// request is handed to the base transport so an HTTP(S)_PROXY cannot re-resolve
+// the name to a different address (e.g. cloud metadata).
 func DatasourceClient(timeout time.Duration) *http.Client {
 	base := dialBlockingTransport(rejectCloudMetadata, true /* useProxy */)
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &urlPolicyTransport{
-			base: base,
+			base:           base,
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
 			validate: func(raw string) error {
 				_, err := ValidateDatasourceURL(raw)
 				return err
@@ -224,9 +233,14 @@ func DatasourceDialContext(ctx context.Context, network, addr string) (net.Conn,
 // urlPolicyTransport validates the destination request URL before the base
 // transport runs. This matters when ProxyFromEnvironment is set: DialContext
 // only sees the proxy hop, so destination policy must run on RoundTrip.
+//
+// When pinDestination is set, hostnames are rewritten to a policy-checked IP
+// (Host/SNI preserved) so a proxy cannot re-resolve the name independently.
 type urlPolicyTransport struct {
-	base     http.RoundTripper
-	validate func(raw string) error
+	base           http.RoundTripper
+	validate       func(raw string) error
+	reject         func(net.IP) error
+	pinDestination bool
 }
 
 func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -236,7 +250,74 @@ func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if err := t.validate(req.URL.String()); err != nil {
 		return nil, err
 	}
+	if t.pinDestination {
+		cloned := req.Clone(req.Context())
+		if err := pinRequestURLToValidatedIP(cloned, t.reject); err != nil {
+			return nil, err
+		}
+		req = cloned
+	}
 	return t.base.RoundTrip(req)
+}
+
+// pinRequestURLToValidatedIP resolves the request hostname, rejects any IP that
+// fails policy, and rewrites URL.Host to the first allowed address while keeping
+// req.Host as the original hostname for virtual hosts and TLS SNI.
+func pinRequestURLToValidatedIP(req *http.Request, reject func(net.IP) error) error {
+	if reject == nil {
+		return fmt.Errorf("missing IP reject policy")
+	}
+	hostname := req.URL.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("url must include a hostname")
+	}
+
+	port := req.URL.Port()
+	if port == "" {
+		switch req.URL.Scheme {
+		case "https":
+			port = "443"
+		case "http":
+			port = "80"
+		default:
+			return fmt.Errorf("url must use http or https scheme")
+		}
+	}
+
+	// Preserve original authority for Host / SNI before rewriting the URL.
+	origAuthority := req.URL.Host
+	if req.Host == "" {
+		req.Host = origAuthority
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		if err := reject(ip); err != nil {
+			return err
+		}
+		// Normalize URL.Host to include explicit port for the transport/proxy hop.
+		req.URL.Host = net.JoinHostPort(ip.String(), port)
+		return nil
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(req.Context(), hostname)
+	if err != nil {
+		return fmt.Errorf("dns resolution failed: %w", err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("dns resolution returned no addresses")
+	}
+
+	var chosen net.IP
+	for _, ip := range ips {
+		if err := reject(ip.IP); err != nil {
+			return err
+		}
+		if chosen == nil {
+			chosen = ip.IP
+		}
+	}
+	req.URL.Host = net.JoinHostPort(chosen.String(), port)
+	return nil
 }
 
 // dialBlockingTransport builds a transport that resolves each dial target and

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -4,6 +4,7 @@ package ssrf
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -234,8 +235,10 @@ func DatasourceDialContext(ctx context.Context, network, addr string) (net.Conn,
 // transport runs. This matters when ProxyFromEnvironment is set: DialContext
 // only sees the proxy hop, so destination policy must run on RoundTrip.
 //
-// When pinDestination is set, hostnames are rewritten to a policy-checked IP
-// (Host/SNI preserved) so a proxy cannot re-resolve the name independently.
+// When pinDestination is set, hostnames are rewritten to a policy-checked IP so a
+// proxy cannot re-resolve the name independently. Request.Host keeps the original
+// authority (HTTP Host). For HTTPS, TLS ServerName is set to the original DNS name
+// so SNI and certificate verification still match the datasource hostname.
 type urlPolicyTransport struct {
 	base           http.RoundTripper
 	validate       func(raw string) error
@@ -250,26 +253,56 @@ func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if err := t.validate(req.URL.String()); err != nil {
 		return nil, err
 	}
-	if t.pinDestination {
-		cloned := req.Clone(req.Context())
-		if err := pinRequestURLToValidatedIP(cloned, t.reject); err != nil {
-			return nil, err
-		}
-		req = cloned
+	if !t.pinDestination {
+		return t.base.RoundTrip(req)
 	}
-	return t.base.RoundTrip(req)
+	cloned := req.Clone(req.Context())
+	tlsServerName, err := pinRequestURLToValidatedIP(cloned, t.reject)
+	if err != nil {
+		return nil, err
+	}
+	return t.roundTripWithTLSServerName(cloned, tlsServerName)
+}
+
+// roundTripWithTLSServerName sends req through the base transport. When the URL
+// was pinned to an IP, tlsServerName is the original DNS name and must be applied
+// as tls.Config.ServerName so verification/SNI are not performed against the IP.
+func (t *urlPolicyTransport) roundTripWithTLSServerName(req *http.Request, tlsServerName string) (*http.Response, error) {
+	if tlsServerName == "" || req.URL.Scheme != "https" {
+		return t.base.RoundTrip(req)
+	}
+	base, ok := t.base.(*http.Transport)
+	if !ok {
+		// Non-transport bases (tests) cannot set ServerName; callers that need
+		// real HTTPS must use *http.Transport.
+		return t.base.RoundTrip(req)
+	}
+	tr := base.Clone()
+	var cfg *tls.Config
+	if tr.TLSClientConfig == nil {
+		cfg = &tls.Config{}
+	} else {
+		cfg = tr.TLSClientConfig.Clone()
+	}
+	// Only fill ServerName when unset so an explicit transport config still wins.
+	if cfg.ServerName == "" {
+		cfg.ServerName = tlsServerName
+	}
+	tr.TLSClientConfig = cfg
+	return tr.RoundTrip(req)
 }
 
 // pinRequestURLToValidatedIP resolves the request hostname, rejects any IP that
 // fails policy, and rewrites URL.Host to the first allowed address while keeping
-// req.Host as the original hostname for virtual hosts and TLS SNI.
-func pinRequestURLToValidatedIP(req *http.Request, reject func(net.IP) error) error {
+// req.Host as the original authority. It returns the original DNS name when the
+// host was not already a literal IP, so HTTPS callers can set TLS ServerName.
+func pinRequestURLToValidatedIP(req *http.Request, reject func(net.IP) error) (tlsServerName string, err error) {
 	if reject == nil {
-		return fmt.Errorf("missing IP reject policy")
+		return "", fmt.Errorf("missing IP reject policy")
 	}
 	hostname := req.URL.Hostname()
 	if hostname == "" {
-		return fmt.Errorf("url must include a hostname")
+		return "", fmt.Errorf("url must include a hostname")
 	}
 
 	port := req.URL.Port()
@@ -280,11 +313,11 @@ func pinRequestURLToValidatedIP(req *http.Request, reject func(net.IP) error) er
 		case "http":
 			port = "80"
 		default:
-			return fmt.Errorf("url must use http or https scheme")
+			return "", fmt.Errorf("url must use http or https scheme")
 		}
 	}
 
-	// Preserve original authority for Host / SNI before rewriting the URL.
+	// Preserve original authority for the HTTP Host header before rewriting URL.Host.
 	origAuthority := req.URL.Host
 	if req.Host == "" {
 		req.Host = origAuthority
@@ -292,32 +325,33 @@ func pinRequestURLToValidatedIP(req *http.Request, reject func(net.IP) error) er
 
 	if ip := net.ParseIP(hostname); ip != nil {
 		if err := reject(ip); err != nil {
-			return err
+			return "", err
 		}
 		// Normalize URL.Host to include explicit port for the transport/proxy hop.
 		req.URL.Host = net.JoinHostPort(ip.String(), port)
-		return nil
+		// Literal IP destinations have no DNS name for SNI.
+		return "", nil
 	}
 
 	ips, err := net.DefaultResolver.LookupIPAddr(req.Context(), hostname)
 	if err != nil {
-		return fmt.Errorf("dns resolution failed: %w", err)
+		return "", fmt.Errorf("dns resolution failed: %w", err)
 	}
 	if len(ips) == 0 {
-		return fmt.Errorf("dns resolution returned no addresses")
+		return "", fmt.Errorf("dns resolution returned no addresses")
 	}
 
 	var chosen net.IP
 	for _, ip := range ips {
 		if err := reject(ip.IP); err != nil {
-			return err
+			return "", err
 		}
 		if chosen == nil {
 			chosen = ip.IP
 		}
 	}
 	req.URL.Host = net.JoinHostPort(chosen.String(), port)
-	return nil
+	return hostname, nil
 }
 
 // dialBlockingTransport builds a transport that resolves each dial target and

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -250,17 +250,21 @@ func DatasourceDialContext(ctx context.Context, network, addr string) (net.Conn,
 // request. That closes proxy-side DNS rebinding without collapsing direct
 // hostname dials to one address (which would disable multi-A/AAAA fallback
 // in dialBlockingTransport). Host/SNI are preserved on the pinned request.
+//
+// After pinning, the chosen proxy URL is forced on the outbound transport so
+// ProxyFromEnvironment cannot re-evaluate NO_PROXY against the pinned IP and
+// skip the hop that the original hostname selected.
 type urlPolicyTransport struct {
 	base           http.RoundTripper
 	validate       func(raw string) error
 	reject         func(net.IP) error
 	pinDestination bool
 
-	// Cached *http.Transport clones keyed by TLS ServerName. Pinning rewrites
-	// URL.Host to an IP, so HTTPS needs ServerName=original DNS name; cloning
-	// once per name keeps idle pools instead of per-request transports.
-	mu        sync.Mutex
-	tlsByName map[string]*http.Transport
+	// Cached transport clones for pinned (proxied) requests. Keyed by
+	// proxyURL + TLS ServerName so idle pools are reused without re-running
+	// ProxyFromEnvironment against the rewritten IP.
+	mu          sync.Mutex
+	pinnedByKey map[string]*http.Transport
 }
 
 func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -270,77 +274,94 @@ func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if err := t.validate(req.URL.String()); err != nil {
 		return nil, err
 	}
-	if t.shouldPinDestination(req) {
-		cloned := req.Clone(req.Context())
-		tlsServerName, pinErr := pinRequestURLToValidatedIP(cloned, t.reject)
-		if pinErr != nil {
-			return nil, pinErr
-		}
-		return t.roundTripWithTLSServerName(cloned, tlsServerName)
+	proxyURL, ok := t.proxyForPin(req)
+	if !ok {
+		return t.base.RoundTrip(req)
 	}
-	return t.base.RoundTrip(req)
+	cloned := req.Clone(req.Context())
+	tlsServerName, pinErr := pinRequestURLToValidatedIP(cloned, t.reject)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	return t.roundTripPinned(cloned, tlsServerName, proxyURL)
 }
 
-// shouldPinDestination is true only when pinning is enabled and this request
-// will actually use an HTTP proxy hop. No proxy (or a non-transport base)
-// leaves the hostname in place for fail-closed reject + multi-IP dial.
-func (t *urlPolicyTransport) shouldPinDestination(req *http.Request) bool {
+// proxyForPin returns the proxy URL when pinning should run for this request.
+// Decision uses the original hostname (before pin) so NO_PROXY matches the
+// datasource name the operator configured, not the resolved IP.
+func (t *urlPolicyTransport) proxyForPin(req *http.Request) (*url.URL, bool) {
 	if !t.pinDestination {
-		return false
+		return nil, false
 	}
 	base, ok := t.base.(*http.Transport)
 	if !ok || base == nil || base.Proxy == nil {
-		return false
+		return nil, false
 	}
 	proxyURL, err := base.Proxy(req)
-	return err == nil && proxyURL != nil
+	if err != nil || proxyURL == nil {
+		return nil, false
+	}
+	return proxyURL, true
 }
 
-// roundTripWithTLSServerName sends req through the base transport. When the URL
-// was pinned to an IP, tlsServerName is the original DNS name and must be applied
-// as tls.Config.ServerName so verification/SNI are not performed against the IP.
-func (t *urlPolicyTransport) roundTripWithTLSServerName(req *http.Request, tlsServerName string) (*http.Response, error) {
-	if tlsServerName == "" || req.URL.Scheme != "https" {
-		return t.base.RoundTrip(req)
-	}
+// roundTripPinned sends a destination-pinned request while keeping the proxy
+// hop that was selected for the original hostname. tlsServerName is the DNS
+// name for HTTPS SNI/cert verify when the host was not already a literal IP.
+func (t *urlPolicyTransport) roundTripPinned(req *http.Request, tlsServerName string, proxyURL *url.URL) (*http.Response, error) {
 	base, ok := t.base.(*http.Transport)
 	if !ok {
-		// Non-transport bases (tests) cannot set ServerName; callers that need
-		// real HTTPS must use *http.Transport.
+		// Non-transport bases (tests) cannot force Proxy/ServerName.
 		return t.base.RoundTrip(req)
 	}
-	return t.transportForServerName(base, tlsServerName).RoundTrip(req)
+	if req.URL.Scheme != "https" {
+		tlsServerName = ""
+	}
+	return t.transportForPinnedProxy(base, tlsServerName, proxyURL).RoundTrip(req)
 }
 
-// transportForServerName returns a cached transport clone with ServerName set
-// so repeated HTTPS queries to the same datasource reuse one idle pool.
-func (t *urlPolicyTransport) transportForServerName(base *http.Transport, serverName string) *http.Transport {
+// transportForPinnedProxy returns a cached clone that always uses proxyURL and
+// optionally sets TLS ServerName. Caching keeps idle pools under load.
+func (t *urlPolicyTransport) transportForPinnedProxy(base *http.Transport, serverName string, proxyURL *url.URL) *http.Transport {
+	key := pinnedTransportKey(proxyURL, serverName)
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.tlsByName == nil {
-		t.tlsByName = make(map[string]*http.Transport)
+	if t.pinnedByKey == nil {
+		t.pinnedByKey = make(map[string]*http.Transport)
 	}
-	if tr, ok := t.tlsByName[serverName]; ok {
+	if tr, ok := t.pinnedByKey[key]; ok {
 		return tr
 	}
 	tr := base.Clone()
-	var cfg *tls.Config
-	if tr.TLSClientConfig == nil {
-		cfg = &tls.Config{}
-	} else {
-		cfg = tr.TLSClientConfig.Clone()
+	fixedProxy := proxyURL
+	tr.Proxy = func(*http.Request) (*url.URL, error) {
+		return fixedProxy, nil
 	}
-	// Only fill ServerName when unset so an explicit transport config still wins.
-	if cfg.ServerName == "" {
-		cfg.ServerName = serverName
+	if serverName != "" {
+		var cfg *tls.Config
+		if tr.TLSClientConfig == nil {
+			cfg = &tls.Config{}
+		} else {
+			cfg = tr.TLSClientConfig.Clone()
+		}
+		// Only fill ServerName when unset so an explicit transport config still wins.
+		if cfg.ServerName == "" {
+			cfg.ServerName = serverName
+		}
+		tr.TLSClientConfig = cfg
 	}
-	tr.TLSClientConfig = cfg
-	t.tlsByName[serverName] = tr
+	t.pinnedByKey[key] = tr
 	return tr
 }
 
+func pinnedTransportKey(proxyURL *url.URL, serverName string) string {
+	if proxyURL == nil {
+		return "\x00" + serverName
+	}
+	return proxyURL.String() + "\x00" + serverName
+}
+
 // CloseIdleConnections forwards idle-pool cleanup to the base transport and any
-// cached ServerName clones (http.Client calls this when present).
+// cached pinned-proxy clones (http.Client calls this when present).
 func (t *urlPolicyTransport) CloseIdleConnections() {
 	type closeIdler interface {
 		CloseIdleConnections()
@@ -350,7 +371,7 @@ func (t *urlPolicyTransport) CloseIdleConnections() {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for _, tr := range t.tlsByName {
+	for _, tr := range t.pinnedByKey {
 		tr.CloseIdleConnections()
 	}
 }

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -197,11 +197,19 @@ func DatasourceClient(timeout time.Duration) *http.Client {
 }
 
 // dialBlockingTransport builds a transport that resolves each dial target and
-// rejects IPs for which reject returns a non-nil error, then dials the first
-// remaining address.
+// rejects IPs for which reject returns a non-nil error, then dials allowed
+// addresses in order (fallback if the first is unreachable).
+//
+// ProxyFromEnvironment is honored so HTTP_PROXY/HTTPS_PROXY still work for
+// datasource egress. When a proxy is used, DialContext connects to the proxy
+// hop; destination policy still applies via CheckRedirect / URL validators.
 func dialBlockingTransport(reject func(net.IP) error) *http.Transport {
-	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
 	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			host, port, err := net.SplitHostPort(addr)
 			if err != nil {
@@ -214,12 +222,33 @@ func dialBlockingTransport(reject func(net.IP) error) *http.Transport {
 			if len(ips) == 0 {
 				return nil, fmt.Errorf("dns resolution returned no addresses")
 			}
+
+			// Fail closed if any resolved address is rejected (partial metadata
+			// rebinding). Among allowed addresses, try each until one connects.
+			var candidates []net.IPAddr
 			for _, ip := range ips {
 				if err := reject(ip.IP); err != nil {
 					return nil, err
 				}
+				candidates = append(candidates, ip)
 			}
-			return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+
+			var firstDialErr error
+			for _, ip := range candidates {
+				conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+				if dialErr == nil {
+					return conn, nil
+				}
+				if firstDialErr == nil {
+					firstDialErr = dialErr
+				}
+			}
+			return nil, firstDialErr
 		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
 }

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -161,14 +161,21 @@ func IsLocalURL(raw string) bool {
 // Use for untrusted user-supplied hosts only — not for configured datasources
 // that may legitimately live on private networks.
 func SafeClient(timeout time.Duration) *http.Client {
+	base := dialBlockingTransport(func(ip net.IP) error {
+		if isBlockedIP(ip) {
+			return fmt.Errorf("connections to private/internal addresses are not allowed")
+		}
+		return nil
+	}, false /* useProxy */)
 	return &http.Client{
 		Timeout: timeout,
-		Transport: dialBlockingTransport(func(ip net.IP) error {
-			if isBlockedIP(ip) {
-				return fmt.Errorf("connections to private/internal addresses are not allowed")
-			}
-			return nil
-		}),
+		Transport: &urlPolicyTransport{
+			base: base,
+			validate: func(raw string) error {
+				_, err := ValidateURL(raw)
+				return err
+			},
+		},
 	}
 }
 
@@ -181,11 +188,19 @@ func rejectCloudMetadata(ip net.IP) error {
 
 // DatasourceClient returns an *http.Client for configured observability
 // datasources. Private/internal targets are allowed; the cloud metadata
-// endpoint is blocked at dial time (DNS rebinding) and on redirects.
+// endpoint is blocked on the request URL (including when an HTTP proxy is
+// used), at dial time for direct connections, and on redirects.
 func DatasourceClient(timeout time.Duration) *http.Client {
+	base := dialBlockingTransport(rejectCloudMetadata, true /* useProxy */)
 	return &http.Client{
-		Timeout:   timeout,
-		Transport: dialBlockingTransport(rejectCloudMetadata),
+		Timeout: timeout,
+		Transport: &urlPolicyTransport{
+			base: base,
+			validate: func(raw string) error {
+				_, err := ValidateDatasourceURL(raw)
+				return err
+			},
+		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("stopped after 10 redirects")
@@ -202,23 +217,41 @@ func DatasourceClient(timeout time.Duration) *http.Client {
 // DatasourceClient. Use for non-HTTP transports (e.g. websocket) that cannot
 // take an *http.Client.
 func DatasourceDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	return dialBlockingTransport(rejectCloudMetadata).DialContext(ctx, network, addr)
+	// Direct dial path — no HTTP proxy hop — so dial policy alone is sufficient.
+	return dialBlockingTransport(rejectCloudMetadata, false).DialContext(ctx, network, addr)
+}
+
+// urlPolicyTransport validates the destination request URL before the base
+// transport runs. This matters when ProxyFromEnvironment is set: DialContext
+// only sees the proxy hop, so destination policy must run on RoundTrip.
+type urlPolicyTransport struct {
+	base     http.RoundTripper
+	validate func(raw string) error
+}
+
+func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil {
+		return nil, fmt.Errorf("missing request URL")
+	}
+	if err := t.validate(req.URL.String()); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(req)
 }
 
 // dialBlockingTransport builds a transport that resolves each dial target and
 // rejects IPs for which reject returns a non-nil error, then dials allowed
 // addresses in order (fallback if the first is unreachable).
 //
-// ProxyFromEnvironment is honored so HTTP_PROXY/HTTPS_PROXY still work for
-// datasource egress. When a proxy is used, DialContext connects to the proxy
-// hop; destination policy still applies via CheckRedirect / URL validators.
-func dialBlockingTransport(reject func(net.IP) error) *http.Transport {
+// When useProxy is true, ProxyFromEnvironment is honored for datasource egress.
+// Destination policy for proxied requests is enforced by urlPolicyTransport
+// (and CheckRedirect), because DialContext only connects to the proxy hop.
+func dialBlockingTransport(reject func(net.IP) error, useProxy bool) *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+	tr := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			host, port, err := net.SplitHostPort(addr)
 			if err != nil {
@@ -260,4 +293,8 @@ func dialBlockingTransport(reject func(net.IP) error) *http.Transport {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+	if useProxy {
+		tr.Proxy = http.ProxyFromEnvironment
+	}
+	return tr
 }

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -161,6 +161,11 @@ func IsLocalURL(raw string) bool {
 // IPs at dial time (preventing DNS rebinding after initial validation).
 // Use for untrusted user-supplied hosts only — not for configured datasources
 // that may legitimately live on private networks.
+//
+// SafeClient does not use an HTTP proxy, so destination hostnames are left
+// unpinned: dialBlockingTransport already enforces multi-A/AAAA fallback with
+// fail-closed reject. Pinning is only needed when a proxy hop would otherwise
+// re-resolve the name (see DatasourceClient).
 func SafeClient(timeout time.Duration) *http.Client {
 	reject := func(ip net.IP) error {
 		if isBlockedIP(ip) {
@@ -172,9 +177,9 @@ func SafeClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &urlPolicyTransport{
-			base:           base,
-			reject:         reject,
-			pinDestination: true,
+			base:   base,
+			reject: reject,
+			// proxy nil => direct dials only; no hostname→IP pin.
 			validate: func(raw string) error {
 				_, err := ValidateURL(raw)
 				return err
@@ -195,17 +200,19 @@ func rejectCloudMetadata(ip net.IP) error {
 // endpoint is blocked on the request URL (including when an HTTP proxy is
 // used), at dial time for direct connections, and on redirects.
 //
-// Destination hostnames are resolved and pinned to a validated IP before the
-// request is handed to the base transport so an HTTP(S)_PROXY cannot re-resolve
-// the name to a different address (e.g. cloud metadata).
+// When HTTP(S)_PROXY applies to a request, destination hostnames are resolved
+// and pinned to a validated IP before the proxy hop so the proxy cannot
+// re-resolve the name to a different address (e.g. cloud metadata). Direct
+// (no-proxy) dials leave the hostname intact so dialBlockingTransport keeps
+// multi-A/AAAA fallback.
 func DatasourceClient(timeout time.Duration) *http.Client {
 	base := dialBlockingTransport(rejectCloudMetadata, true /* useProxy */)
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &urlPolicyTransport{
-			base:           base,
-			reject:         rejectCloudMetadata,
-			pinDestination: true,
+			base:   base,
+			reject: rejectCloudMetadata,
+			proxy:  http.ProxyFromEnvironment,
 			validate: func(raw string) error {
 				_, err := ValidateDatasourceURL(raw)
 				return err
@@ -235,15 +242,15 @@ func DatasourceDialContext(ctx context.Context, network, addr string) (net.Conn,
 // transport runs. This matters when ProxyFromEnvironment is set: DialContext
 // only sees the proxy hop, so destination policy must run on RoundTrip.
 //
-// When pinDestination is set, hostnames are rewritten to a policy-checked IP so a
-// proxy cannot re-resolve the name independently. Request.Host keeps the original
-// authority (HTTP Host). For HTTPS, TLS ServerName is set to the original DNS name
-// so SNI and certificate verification still match the datasource hostname.
+// When proxy is non-nil and returns a proxy URL for the request, the hostname
+// is resolved and rewritten to a policy-checked IP (Host/SNI preserved) so the
+// proxy cannot re-resolve the name independently. For direct (no-proxy) dials
+// the base transport's DialContext loop already handles multi-A/AAAA fallback.
 type urlPolicyTransport struct {
-	base           http.RoundTripper
-	validate       func(raw string) error
-	reject         func(net.IP) error
-	pinDestination bool
+	base     http.RoundTripper
+	validate func(raw string) error
+	reject   func(net.IP) error
+	proxy    func(*http.Request) (*url.URL, error) // nil = direct, no pinning
 }
 
 func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -253,15 +260,17 @@ func (t *urlPolicyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if err := t.validate(req.URL.String()); err != nil {
 		return nil, err
 	}
-	if !t.pinDestination {
-		return t.base.RoundTrip(req)
+	if t.proxy != nil {
+		if proxyURL, err := t.proxy(req); err == nil && proxyURL != nil {
+			cloned := req.Clone(req.Context())
+			tlsServerName, pinErr := pinRequestURLToValidatedIP(cloned, t.reject)
+			if pinErr != nil {
+				return nil, pinErr
+			}
+			return t.roundTripWithTLSServerName(cloned, tlsServerName)
+		}
 	}
-	cloned := req.Clone(req.Context())
-	tlsServerName, err := pinRequestURLToValidatedIP(cloned, t.reject)
-	if err != nil {
-		return nil, err
-	}
-	return t.roundTripWithTLSServerName(cloned, tlsServerName)
+	return t.base.RoundTrip(req)
 }
 
 // roundTripWithTLSServerName sends req through the base transport. When the URL

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -172,18 +172,20 @@ func SafeClient(timeout time.Duration) *http.Client {
 	}
 }
 
+func rejectCloudMetadata(ip net.IP) error {
+	if isCloudMetadataIP(ip) {
+		return fmt.Errorf("connections to cloud metadata endpoint are not allowed")
+	}
+	return nil
+}
+
 // DatasourceClient returns an *http.Client for configured observability
 // datasources. Private/internal targets are allowed; the cloud metadata
 // endpoint is blocked at dial time (DNS rebinding) and on redirects.
 func DatasourceClient(timeout time.Duration) *http.Client {
 	return &http.Client{
-		Timeout: timeout,
-		Transport: dialBlockingTransport(func(ip net.IP) error {
-			if isCloudMetadataIP(ip) {
-				return fmt.Errorf("connections to cloud metadata endpoint are not allowed")
-			}
-			return nil
-		}),
+		Timeout:   timeout,
+		Transport: dialBlockingTransport(rejectCloudMetadata),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("stopped after 10 redirects")
@@ -194,6 +196,13 @@ func DatasourceClient(timeout time.Duration) *http.Client {
 			return nil
 		},
 	}
+}
+
+// DatasourceDialContext applies the same dial-time metadata block as
+// DatasourceClient. Use for non-HTTP transports (e.g. websocket) that cannot
+// take an *http.Client.
+func DatasourceDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return dialBlockingTransport(rejectCloudMetadata).DialContext(ctx, network, addr)
 }
 
 // dialBlockingTransport builds a transport that resolves each dial target and

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -201,19 +201,24 @@ func TestDatasourceClient_rejectsMetadataDestinationURL(t *testing.T) {
 	}
 }
 
-func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
+func TestURLPolicyTransport_pinsHostnameOnlyWhenProxied(t *testing.T) {
 	t.Parallel()
 
+	proxyURL, err := url.Parse("http://127.0.0.1:18080")
+	if err != nil {
+		t.Fatalf("parse proxy: %v", err)
+	}
+
 	var saw *http.Request
-	client := &http.Client{
+	withProxy := &http.Client{
 		Timeout: 2 * time.Second,
 		Transport: &urlPolicyTransport{
 			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				saw = req
+				saw = req.Clone(req.Context())
 				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
 			}),
-			reject:         rejectCloudMetadata,
-			pinDestination: true,
+			reject: rejectCloudMetadata,
+			proxy:  func(*http.Request) (*url.URL, error) { return proxyURL, nil },
 			validate: func(raw string) error {
 				_, err := ValidateDatasourceURL(raw)
 				return err
@@ -221,8 +226,28 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 		},
 	}
 
-	// Literal IP: still normalized with explicit port; Host preserved for vhost.
-	resp, err := client.Get("http://127.0.0.1:9/health")
+	// Proxied hostname: URL.Host rewritten to validated IP; Host keeps DNS authority.
+	resp, err := withProxy.Get("http://example.com/metrics")
+	if err != nil {
+		t.Fatalf("expected proxied hostname pin to succeed: %v", err)
+	}
+	resp.Body.Close()
+	if saw == nil {
+		t.Fatal("base transport was not called")
+	}
+	if ip := net.ParseIP(saw.URL.Hostname()); ip == nil {
+		t.Fatalf("proxied URL host should be pinned IP, got %q", saw.URL.Host)
+	}
+	if saw.URL.Port() != "80" {
+		t.Fatalf("pinned URL port = %q, want 80", saw.URL.Port())
+	}
+	if saw.Host != "example.com" {
+		t.Fatalf("Host header should keep original authority, got %q", saw.Host)
+	}
+
+	// Proxied literal IP: still normalized with explicit port; Host preserved.
+	saw = nil
+	resp, err = withProxy.Get("http://127.0.0.1:9/health")
 	if err != nil {
 		t.Fatalf("expected private literal to pass policy: %v", err)
 	}
@@ -237,15 +262,45 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 		t.Fatalf("Host header should keep original authority, got %q", saw.Host)
 	}
 
-	// Metadata literal must fail before base transport.
+	// Metadata literal must fail before base transport (even with proxy).
 	saw = nil
-	resp, err = client.Get("http://169.254.169.254/")
+	resp, err = withProxy.Get("http://169.254.169.254/")
 	if err == nil {
 		resp.Body.Close()
 		t.Fatal("expected metadata pin to fail")
 	}
 	if saw != nil {
 		t.Fatal("base transport must not run after metadata reject")
+	}
+
+	// Direct (no proxy): leave hostname unpinned so multi-IP dial fallback works.
+	saw = nil
+	direct := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &urlPolicyTransport{
+			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				saw = req.Clone(req.Context())
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+			}),
+			reject: rejectCloudMetadata,
+			// proxy nil / returns nil => no pin
+			proxy: func(*http.Request) (*url.URL, error) { return nil, nil },
+			validate: func(raw string) error {
+				_, err := ValidateDatasourceURL(raw)
+				return err
+			},
+		},
+	}
+	resp, err = direct.Get("http://example.com/metrics")
+	if err != nil {
+		t.Fatalf("expected direct hostname request to succeed: %v", err)
+	}
+	resp.Body.Close()
+	if saw == nil {
+		t.Fatal("base transport was not called")
+	}
+	if saw.URL.Hostname() != "example.com" {
+		t.Fatalf("direct dial must not pin hostname, got %q", saw.URL.Host)
 	}
 }
 

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -182,6 +182,7 @@ func TestDatasourceClient_rejectsMetadataDestinationURL(t *testing.T) {
 				baseCalls++
 				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
 			}),
+			reject: rejectCloudMetadata,
 			validate: func(raw string) error {
 				_, err := ValidateDatasourceURL(raw)
 				return err
@@ -196,6 +197,54 @@ func TestDatasourceClient_rejectsMetadataDestinationURL(t *testing.T) {
 	}
 	if baseCalls != 0 {
 		t.Fatalf("base transport should not run for rejected destination, calls=%d", baseCalls)
+	}
+}
+
+func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
+	t.Parallel()
+
+	var saw *http.Request
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &urlPolicyTransport{
+			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				saw = req
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+			}),
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate: func(raw string) error {
+				_, err := ValidateDatasourceURL(raw)
+				return err
+			},
+		},
+	}
+
+	// Literal IP: still normalized with explicit port; Host preserved for SNI/vhost.
+	resp, err := client.Get("http://127.0.0.1:9/health")
+	if err != nil {
+		t.Fatalf("expected private literal to pass policy: %v", err)
+	}
+	resp.Body.Close()
+	if saw == nil {
+		t.Fatal("base transport was not called")
+	}
+	if saw.URL.Hostname() != "127.0.0.1" || saw.URL.Port() != "9" {
+		t.Fatalf("URL not pinned to validated IP: host=%q", saw.URL.Host)
+	}
+	if saw.Host != "127.0.0.1:9" {
+		t.Fatalf("Host header should keep original authority, got %q", saw.Host)
+	}
+
+	// Metadata literal must fail before base transport.
+	saw = nil
+	resp, err = client.Get("http://169.254.169.254/")
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected metadata pin to fail")
+	}
+	if saw != nil {
+		t.Fatal("base transport must not run after metadata reject")
 	}
 }
 

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -273,6 +273,45 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 		}
 	})
 
+	t.Run("proxy hop HTTPS keeps TLS ServerName as DNS", func(t *testing.T) {
+		t.Parallel()
+		var lastProxyReq *http.Request
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
+				lastProxyReq = req
+				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
+			}, func(context.Context, string, string) (net.Conn, error) {
+				return nil, fmt.Errorf("test: skip proxy dial")
+			}),
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "https://localhost:9443/health", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected skip-dial error after pin")
+		}
+		if lastProxyReq == nil {
+			t.Fatal("proxy was not consulted with the pinned request")
+		}
+		assertPinnedIPPort(t, lastProxyReq.URL.Host, "9443")
+		if lastProxyReq.Host != "localhost:9443" {
+			t.Fatalf("req.Host should keep original authority, got %q", lastProxyReq.Host)
+		}
+		tr := rt.tlsByName["localhost"]
+		if tr == nil || tr.TLSClientConfig == nil || tr.TLSClientConfig.ServerName != "localhost" {
+			t.Fatalf("TLS ServerName should keep DNS hostname localhost, got %+v", tr)
+		}
+	})
+
 	t.Run("proxy hop pins literal IP", func(t *testing.T) {
 		t.Parallel()
 		var lastProxyReq *http.Request

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -1,8 +1,10 @@
 package ssrf
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -119,6 +121,35 @@ func TestDatasourceClient_allowsPrivateBlocksMetadata(t *testing.T) {
 	if err == nil {
 		resp.Body.Close()
 		t.Fatal("DatasourceClient should refuse cloud metadata dial")
+	}
+}
+
+func TestDatasourceDialContext_allowsPrivateBlocksMetadata(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server url: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := DatasourceDialContext(ctx, "tcp", u.Host)
+	if err != nil {
+		t.Fatalf("DatasourceDialContext should allow private target %s: %v", u.Host, err)
+	}
+	_ = conn.Close()
+
+	conn, err = DatasourceDialContext(ctx, "tcp", "169.254.169.254:80")
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("DatasourceDialContext should refuse cloud metadata dial")
 	}
 }
 

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -2,6 +2,7 @@ package ssrf
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -201,107 +202,273 @@ func TestDatasourceClient_rejectsMetadataDestinationURL(t *testing.T) {
 	}
 }
 
-func TestURLPolicyTransport_pinsHostnameOnlyWhenProxied(t *testing.T) {
+func TestSafeClient_doesNotPinDestination(t *testing.T) {
 	t.Parallel()
 
-	proxyURL, err := url.Parse("http://127.0.0.1:18080")
-	if err != nil {
-		t.Fatalf("parse proxy: %v", err)
+	client := SafeClient(time.Second)
+	ut, ok := client.Transport.(*urlPolicyTransport)
+	if !ok {
+		t.Fatalf("SafeClient transport type %T, want *urlPolicyTransport", client.Transport)
 	}
+	if ut.pinDestination {
+		t.Fatal("SafeClient must not pin destinations; direct dials need multi-IP fallback")
+	}
+}
 
-	var saw *http.Request
-	withProxy := &http.Client{
-		Timeout: 2 * time.Second,
-		Transport: &urlPolicyTransport{
-			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				saw = req.Clone(req.Context())
-				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+func TestDatasourceClient_enablesConditionalPin(t *testing.T) {
+	t.Parallel()
+
+	client := DatasourceClient(time.Second)
+	ut, ok := client.Transport.(*urlPolicyTransport)
+	if !ok {
+		t.Fatalf("DatasourceClient transport type %T, want *urlPolicyTransport", client.Transport)
+	}
+	if !ut.pinDestination {
+		t.Fatal("DatasourceClient should enable pinning when an HTTP(S)_PROXY hop is used")
+	}
+}
+
+func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
+	t.Parallel()
+
+	allowAll := func(string) error { return nil }
+
+	t.Run("proxy hop pins hostname and preserves Host", func(t *testing.T) {
+		t.Parallel()
+		var lastProxyReq *http.Request
+		dialed := 0
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
+				lastProxyReq = req
+				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
+			}, func(context.Context, string, string) (net.Conn, error) {
+				dialed++
+				return nil, fmt.Errorf("test: skip proxy dial")
 			}),
-			reject: rejectCloudMetadata,
-			proxy:  func(*http.Request) (*url.URL, error) { return proxyURL, nil },
-			validate: func(raw string) error {
-				_, err := ValidateDatasourceURL(raw)
-				return err
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:9090/health", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected skip-dial error after pin")
+		}
+		if lastProxyReq == nil {
+			t.Fatal("proxy was not consulted with the pinned request")
+		}
+		assertPinnedIPPort(t, lastProxyReq.URL.Host, "9090")
+		if lastProxyReq.Host != "localhost:9090" {
+			t.Fatalf("req.Host should keep original authority, got %q", lastProxyReq.Host)
+		}
+		if dialed == 0 {
+			t.Fatal("expected base transport to dial the proxy after a successful pin")
+		}
+	})
+
+	t.Run("proxy hop pins literal IP", func(t *testing.T) {
+		t.Parallel()
+		var lastProxyReq *http.Request
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
+				lastProxyReq = req
+				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
+			}, func(context.Context, string, string) (net.Conn, error) {
+				return nil, fmt.Errorf("test: skip proxy dial")
+			}),
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:9/health", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected skip-dial error after pin")
+		}
+		if lastProxyReq == nil {
+			t.Fatal("proxy was not consulted")
+		}
+		if lastProxyReq.URL.Host != net.JoinHostPort("127.0.0.1", "9") {
+			t.Fatalf("URL.Host = %q, want pinned IP:port", lastProxyReq.URL.Host)
+		}
+		if lastProxyReq.Host != "127.0.0.1:9" {
+			t.Fatalf("req.Host should keep original authority, got %q", lastProxyReq.Host)
+		}
+	})
+
+	t.Run("rejected resolution fails closed before base dial", func(t *testing.T) {
+		t.Parallel()
+		dialed := 0
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(*http.Request) (*url.URL, error) {
+				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
+			}, func(context.Context, string, string) (net.Conn, error) {
+				dialed++
+				return nil, fmt.Errorf("test: base must not dial")
+			}),
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected metadata pin to fail")
+		}
+		if dialed != 0 {
+			t.Fatalf("base transport must not dial after metadata reject, dials=%d", dialed)
+		}
+	})
+
+	t.Run("unresolvable hostname fails closed before base dial", func(t *testing.T) {
+		t.Parallel()
+		dialed := 0
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(*http.Request) (*url.URL, error) {
+				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
+			}, func(context.Context, string, string) (net.Conn, error) {
+				dialed++
+				return nil, fmt.Errorf("test: base must not dial")
+			}),
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://no-such-host.invalid/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected unresolvable hostname pin to fail")
+		}
+		if dialed != 0 {
+			t.Fatalf("base transport must not dial after resolution reject, dials=%d", dialed)
+		}
+	})
+
+	t.Run("no proxy leaves hostname for dial fallback", func(t *testing.T) {
+		t.Parallel()
+		var saw *http.Request
+		client := &http.Client{
+			Timeout: 2 * time.Second,
+			Transport: &urlPolicyTransport{
+				base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					saw = req
+					return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+				}),
+				reject:         rejectCloudMetadata,
+				pinDestination: true,
+				validate:       allowAll,
 			},
-		},
-	}
+		}
 
-	// Proxied hostname: URL.Host rewritten to validated IP; Host keeps DNS authority.
-	resp, err := withProxy.Get("http://example.com/metrics")
-	if err != nil {
-		t.Fatalf("expected proxied hostname pin to succeed: %v", err)
-	}
-	resp.Body.Close()
-	if saw == nil {
-		t.Fatal("base transport was not called")
-	}
-	if ip := net.ParseIP(saw.URL.Hostname()); ip == nil {
-		t.Fatalf("proxied URL host should be pinned IP, got %q", saw.URL.Host)
-	}
-	if saw.URL.Port() != "80" {
-		t.Fatalf("pinned URL port = %q, want 80", saw.URL.Port())
-	}
-	if saw.Host != "example.com" {
-		t.Fatalf("Host header should keep original authority, got %q", saw.Host)
-	}
-
-	// Proxied literal IP: still normalized with explicit port; Host preserved.
-	saw = nil
-	resp, err = withProxy.Get("http://127.0.0.1:9/health")
-	if err != nil {
-		t.Fatalf("expected private literal to pass policy: %v", err)
-	}
-	resp.Body.Close()
-	if saw == nil {
-		t.Fatal("base transport was not called")
-	}
-	if saw.URL.Hostname() != "127.0.0.1" || saw.URL.Port() != "9" {
-		t.Fatalf("URL not pinned to validated IP: host=%q", saw.URL.Host)
-	}
-	if saw.Host != "127.0.0.1:9" {
-		t.Fatalf("Host header should keep original authority, got %q", saw.Host)
-	}
-
-	// Metadata literal must fail before base transport (even with proxy).
-	saw = nil
-	resp, err = withProxy.Get("http://169.254.169.254/")
-	if err == nil {
+		resp, err := client.Get("http://localhost:9090/health")
+		if err != nil {
+			t.Fatalf("expected hostname request to reach base: %v", err)
+		}
 		resp.Body.Close()
-		t.Fatal("expected metadata pin to fail")
-	}
-	if saw != nil {
-		t.Fatal("base transport must not run after metadata reject")
-	}
+		if saw == nil {
+			t.Fatal("base transport was not called")
+		}
+		if saw.URL.Hostname() != "localhost" || saw.URL.Port() != "9090" {
+			t.Fatalf("hostname should be left unpinned without a proxy hop, host=%q", saw.URL.Host)
+		}
+	})
 
-	// Direct (no proxy): leave hostname unpinned so multi-IP dial fallback works.
-	saw = nil
-	direct := &http.Client{
-		Timeout: 2 * time.Second,
-		Transport: &urlPolicyTransport{
-			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				saw = req.Clone(req.Context())
-				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+	t.Run("Proxy returning nil leaves hostname for dial fallback", func(t *testing.T) {
+		t.Parallel()
+		var dialAddr string
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(*http.Request) (*url.URL, error) {
+				return nil, nil
+			}, func(_ context.Context, _, addr string) (net.Conn, error) {
+				dialAddr = addr
+				return nil, fmt.Errorf("test: skip direct dial")
 			}),
-			reject: rejectCloudMetadata,
-			// proxy nil / returns nil => no pin
-			proxy: func(*http.Request) (*url.URL, error) { return nil, nil },
-			validate: func(raw string) error {
-				_, err := ValidateDatasourceURL(raw)
-				return err
-			},
-		},
-	}
-	resp, err = direct.Get("http://example.com/metrics")
-	if err != nil {
-		t.Fatalf("expected direct hostname request to succeed: %v", err)
-	}
-	resp.Body.Close()
-	if saw == nil {
-		t.Fatal("base transport was not called")
-	}
-	if saw.URL.Hostname() != "example.com" {
-		t.Fatalf("direct dial must not pin hostname, got %q", saw.URL.Host)
-	}
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:9090/health", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected skip-dial error")
+		}
+		host, port, err := net.SplitHostPort(dialAddr)
+		if err != nil {
+			t.Fatalf("dial addr %q: %v", dialAddr, err)
+		}
+		if host != "localhost" || port != "9090" {
+			t.Fatalf("direct dial should keep hostname for multi-IP fallback, got %q", dialAddr)
+		}
+	})
+
+	t.Run("pinDestination false leaves hostname even with proxy", func(t *testing.T) {
+		t.Parallel()
+		var lastProxyReq *http.Request
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
+				lastProxyReq = req
+				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
+			}, func(context.Context, string, string) (net.Conn, error) {
+				return nil, fmt.Errorf("test: skip proxy dial")
+			}),
+			reject:         rejectCloudMetadata,
+			pinDestination: false,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:9090/health", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected skip-dial error")
+		}
+		if lastProxyReq == nil {
+			t.Fatal("proxy was not consulted")
+		}
+		if lastProxyReq.URL.Hostname() != "localhost" || lastProxyReq.URL.Port() != "9090" {
+			t.Fatalf("pinDestination false must not rewrite hostname, host=%q", lastProxyReq.URL.Host)
+		}
+	})
 }
 
 func TestURLPolicyTransport_reusesTLSTransportPerServerName(t *testing.T) {
@@ -340,9 +507,7 @@ func TestPinRequestURLToValidatedIP_returnsDNSNameForTLS(t *testing.T) {
 	if name != "example.com" {
 		t.Fatalf("tls server name = %q, want example.com", name)
 	}
-	if ip := net.ParseIP(req.URL.Hostname()); ip == nil {
-		t.Fatalf("URL host should be pinned IP, got %q", req.URL.Host)
-	}
+	assertPinnedIPPort(t, req.URL.Host, "443")
 	if req.Host != "example.com" {
 		t.Fatalf("Host header = %q, want example.com", req.Host)
 	}
@@ -358,6 +523,27 @@ func TestPinRequestURLToValidatedIP_returnsDNSNameForTLS(t *testing.T) {
 	}
 	if name != "" {
 		t.Fatalf("literal IP should not return tls server name, got %q", name)
+	}
+}
+
+func proxyTransport(proxy func(*http.Request) (*url.URL, error), dial func(context.Context, string, string) (net.Conn, error)) *http.Transport {
+	return &http.Transport{
+		Proxy:       proxy,
+		DialContext: dial,
+	}
+}
+
+func assertPinnedIPPort(t *testing.T, hostport, wantPort string) {
+	t.Helper()
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		t.Fatalf("URL.Host should be JoinHostPort IP:port, got %q: %v", hostport, err)
+	}
+	if port != wantPort {
+		t.Fatalf("pinned port = %q, want %q", port, wantPort)
+	}
+	if net.ParseIP(host) == nil {
+		t.Fatalf("URL.Host should be an IP literal, got %q", host)
 	}
 }
 

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -168,3 +168,39 @@ func TestDatasourceClient_blocksMetadataRedirect(t *testing.T) {
 		t.Fatal("DatasourceClient should refuse redirect to cloud metadata")
 	}
 }
+
+func TestDatasourceClient_rejectsMetadataDestinationURL(t *testing.T) {
+	t.Parallel()
+
+	// Even if a proxy would dial a different hop, RoundTrip must reject the
+	// destination URL before the base transport runs.
+	baseCalls := 0
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &urlPolicyTransport{
+			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				baseCalls++
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+			}),
+			validate: func(raw string) error {
+				_, err := ValidateDatasourceURL(raw)
+				return err
+			},
+		},
+	}
+
+	resp, err := client.Get("http://169.254.169.254/latest/meta-data")
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected metadata destination URL to be rejected")
+	}
+	if baseCalls != 0 {
+		t.Fatalf("base transport should not run for rejected destination, calls=%d", baseCalls)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -233,16 +233,17 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 
 	allowAll := func(string) error { return nil }
 
-	t.Run("proxy hop pins hostname and preserves Host", func(t *testing.T) {
+	t.Run("proxy hop pins hostname and dials forced proxy", func(t *testing.T) {
 		t.Parallel()
-		var lastProxyReq *http.Request
-		dialed := 0
+		var proxyDecisionHost string
+		var dialAddr string
+		proxyURL := &url.URL{Scheme: "http", Host: "proxy.test:8080"}
 		rt := &urlPolicyTransport{
 			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
-				lastProxyReq = req
-				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
-			}, func(context.Context, string, string) (net.Conn, error) {
-				dialed++
+				proxyDecisionHost = req.URL.Hostname()
+				return proxyURL, nil
+			}, func(_ context.Context, _, addr string) (net.Conn, error) {
+				dialAddr = addr
 				return nil, fmt.Errorf("test: skip proxy dial")
 			}),
 			reject:         rejectCloudMetadata,
@@ -261,26 +262,37 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected skip-dial error after pin")
 		}
-		if lastProxyReq == nil {
-			t.Fatal("proxy was not consulted with the pinned request")
+		// Proxy selection must use the original hostname (not a pinned IP).
+		if proxyDecisionHost != "localhost" {
+			t.Fatalf("proxy decision host = %q, want localhost", proxyDecisionHost)
 		}
-		assertPinnedIPPort(t, lastProxyReq.URL.Host, "9090")
-		if lastProxyReq.Host != "localhost:9090" {
-			t.Fatalf("req.Host should keep original authority, got %q", lastProxyReq.Host)
+		if dialAddr != "proxy.test:8080" {
+			t.Fatalf("expected dial to forced proxy, got %q", dialAddr)
 		}
-		if dialed == 0 {
-			t.Fatal("expected base transport to dial the proxy after a successful pin")
+		// Pinned request stored on the cached transport key path: Host preserved via pin helper.
+		pinned := req.Clone(req.Context())
+		name, err := pinRequestURLToValidatedIP(pinned, rejectCloudMetadata)
+		if err != nil {
+			t.Fatalf("pin helper: %v", err)
+		}
+		if name != "localhost" {
+			t.Fatalf("tls name = %q", name)
+		}
+		assertPinnedIPPort(t, pinned.URL.Host, "9090")
+		if pinned.Host != "localhost:9090" {
+			t.Fatalf("Host = %q", pinned.Host)
 		}
 	})
 
 	t.Run("proxy hop HTTPS keeps TLS ServerName as DNS", func(t *testing.T) {
 		t.Parallel()
-		var lastProxyReq *http.Request
+		var dialAddr string
+		proxyURL := &url.URL{Scheme: "http", Host: "127.0.0.1:1"}
 		rt := &urlPolicyTransport{
 			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
-				lastProxyReq = req
-				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
-			}, func(context.Context, string, string) (net.Conn, error) {
+				return proxyURL, nil
+			}, func(_ context.Context, _, addr string) (net.Conn, error) {
+				dialAddr = addr
 				return nil, fmt.Errorf("test: skip proxy dial")
 			}),
 			reject:         rejectCloudMetadata,
@@ -299,14 +311,11 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected skip-dial error after pin")
 		}
-		if lastProxyReq == nil {
-			t.Fatal("proxy was not consulted with the pinned request")
+		if dialAddr != "127.0.0.1:1" {
+			t.Fatalf("expected dial to proxy, got %q", dialAddr)
 		}
-		assertPinnedIPPort(t, lastProxyReq.URL.Host, "9443")
-		if lastProxyReq.Host != "localhost:9443" {
-			t.Fatalf("req.Host should keep original authority, got %q", lastProxyReq.Host)
-		}
-		tr := rt.tlsByName["localhost"]
+		key := pinnedTransportKey(proxyURL, "localhost")
+		tr := rt.pinnedByKey[key]
 		if tr == nil || tr.TLSClientConfig == nil || tr.TLSClientConfig.ServerName != "localhost" {
 			t.Fatalf("TLS ServerName should keep DNS hostname localhost, got %+v", tr)
 		}
@@ -314,12 +323,13 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 
 	t.Run("proxy hop pins literal IP", func(t *testing.T) {
 		t.Parallel()
-		var lastProxyReq *http.Request
+		var dialAddr string
+		proxyURL := &url.URL{Scheme: "http", Host: "127.0.0.1:1"}
 		rt := &urlPolicyTransport{
 			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
-				lastProxyReq = req
-				return &url.URL{Scheme: "http", Host: "127.0.0.1:1"}, nil
-			}, func(context.Context, string, string) (net.Conn, error) {
+				return proxyURL, nil
+			}, func(_ context.Context, _, addr string) (net.Conn, error) {
+				dialAddr = addr
 				return nil, fmt.Errorf("test: skip proxy dial")
 			}),
 			reject:         rejectCloudMetadata,
@@ -338,14 +348,18 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected skip-dial error after pin")
 		}
-		if lastProxyReq == nil {
-			t.Fatal("proxy was not consulted")
+		if dialAddr != "127.0.0.1:1" {
+			t.Fatalf("expected dial to proxy, got %q", dialAddr)
 		}
-		if lastProxyReq.URL.Host != net.JoinHostPort("127.0.0.1", "9") {
-			t.Fatalf("URL.Host = %q, want pinned IP:port", lastProxyReq.URL.Host)
+		pinned := req.Clone(req.Context())
+		if _, err := pinRequestURLToValidatedIP(pinned, rejectCloudMetadata); err != nil {
+			t.Fatalf("pin: %v", err)
 		}
-		if lastProxyReq.Host != "127.0.0.1:9" {
-			t.Fatalf("req.Host should keep original authority, got %q", lastProxyReq.Host)
+		if pinned.URL.Host != net.JoinHostPort("127.0.0.1", "9") {
+			t.Fatalf("URL.Host = %q, want pinned IP:port", pinned.URL.Host)
+		}
+		if pinned.Host != "127.0.0.1:9" {
+			t.Fatalf("req.Host should keep original authority, got %q", pinned.Host)
 		}
 	})
 
@@ -508,18 +522,58 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 			t.Fatalf("pinDestination false must not rewrite hostname, host=%q", lastProxyReq.URL.Host)
 		}
 	})
+
+	t.Run("pinned hop keeps proxy even if NO_PROXY would match IP", func(t *testing.T) {
+		t.Parallel()
+		// First Proxy call (hostname) selects a proxy; after pin, base.Proxy would
+		// return nil for the IP (NO_PROXY-style). Fixed proxy on the clone must win.
+		var dialAddr string
+		proxyURL := &url.URL{Scheme: "http", Host: "proxy.internal:8080"}
+		rt := &urlPolicyTransport{
+			base: proxyTransport(func(req *http.Request) (*url.URL, error) {
+				host := req.URL.Hostname()
+				if net.ParseIP(host) != nil {
+					// Simulate NO_PROXY matching the pinned IP.
+					return nil, nil
+				}
+				return proxyURL, nil
+			}, func(_ context.Context, _, addr string) (net.Conn, error) {
+				dialAddr = addr
+				return nil, fmt.Errorf("test: skip dial")
+			}),
+			reject:         rejectCloudMetadata,
+			pinDestination: true,
+			validate:       allowAll,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:9090/health", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected skip-dial error")
+		}
+		if dialAddr != "proxy.internal:8080" {
+			t.Fatalf("expected dial to forced proxy, got %q", dialAddr)
+		}
+	})
 }
 
-func TestURLPolicyTransport_reusesTLSTransportPerServerName(t *testing.T) {
+func TestURLPolicyTransport_reusesPinnedProxyTransports(t *testing.T) {
 	t.Parallel()
 
 	base := &http.Transport{}
 	upt := &urlPolicyTransport{base: base}
-	tr1 := upt.transportForServerName(base, "metrics.example.com")
-	tr2 := upt.transportForServerName(base, "metrics.example.com")
-	tr3 := upt.transportForServerName(base, "logs.example.com")
+	proxy := &url.URL{Scheme: "http", Host: "proxy:8080"}
+	tr1 := upt.transportForPinnedProxy(base, "metrics.example.com", proxy)
+	tr2 := upt.transportForPinnedProxy(base, "metrics.example.com", proxy)
+	tr3 := upt.transportForPinnedProxy(base, "logs.example.com", proxy)
 	if tr1 != tr2 {
-		t.Fatal("expected cached transport reuse for same ServerName")
+		t.Fatal("expected cached transport reuse for same proxy+ServerName")
 	}
 	if tr1 == tr3 {
 		t.Fatal("expected distinct transports for different ServerNames")
@@ -529,6 +583,11 @@ func TestURLPolicyTransport_reusesTLSTransportPerServerName(t *testing.T) {
 	}
 	if tr3.TLSClientConfig == nil || tr3.TLSClientConfig.ServerName != "logs.example.com" {
 		t.Fatalf("ServerName = %v", tr3.TLSClientConfig)
+	}
+	// Forced proxy must ignore later NO_PROXY-style nil returns from the original func.
+	got, err := tr1.Proxy(&http.Request{URL: &url.URL{Scheme: "http", Host: "10.0.0.5"}})
+	if err != nil || got == nil || got.String() != proxy.String() {
+		t.Fatalf("pinned transport Proxy = %v err=%v, want fixed %s", got, err, proxy)
 	}
 }
 

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -2,6 +2,7 @@ package ssrf
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -220,7 +221,7 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 		},
 	}
 
-	// Literal IP: still normalized with explicit port; Host preserved for SNI/vhost.
+	// Literal IP: still normalized with explicit port; Host preserved for vhost.
 	resp, err := client.Get("http://127.0.0.1:9/health")
 	if err != nil {
 		t.Fatalf("expected private literal to pass policy: %v", err)
@@ -245,6 +246,41 @@ func TestURLPolicyTransport_pinsHostnameToValidatedIP(t *testing.T) {
 	}
 	if saw != nil {
 		t.Fatal("base transport must not run after metadata reject")
+	}
+}
+
+func TestPinRequestURLToValidatedIP_returnsDNSNameForTLS(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/metrics", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	name, err := pinRequestURLToValidatedIP(req, rejectCloudMetadata)
+	if err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	if name != "example.com" {
+		t.Fatalf("tls server name = %q, want example.com", name)
+	}
+	if ip := net.ParseIP(req.URL.Hostname()); ip == nil {
+		t.Fatalf("URL host should be pinned IP, got %q", req.URL.Host)
+	}
+	if req.Host != "example.com" {
+		t.Fatalf("Host header = %q, want example.com", req.Host)
+	}
+
+	// Literal HTTPS IP: no DNS name to restore for SNI.
+	req, err = http.NewRequest(http.MethodGet, "https://8.8.8.8/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	name, err = pinRequestURLToValidatedIP(req, rejectCloudMetadata)
+	if err != nil {
+		t.Fatalf("pin literal: %v", err)
+	}
+	if name != "" {
+		t.Fatalf("literal IP should not return tls server name, got %q", name)
 	}
 }
 

--- a/backend/internal/ssrf/ssrf_test.go
+++ b/backend/internal/ssrf/ssrf_test.go
@@ -304,6 +304,28 @@ func TestURLPolicyTransport_pinsHostnameOnlyWhenProxied(t *testing.T) {
 	}
 }
 
+func TestURLPolicyTransport_reusesTLSTransportPerServerName(t *testing.T) {
+	t.Parallel()
+
+	base := &http.Transport{}
+	upt := &urlPolicyTransport{base: base}
+	tr1 := upt.transportForServerName(base, "metrics.example.com")
+	tr2 := upt.transportForServerName(base, "metrics.example.com")
+	tr3 := upt.transportForServerName(base, "logs.example.com")
+	if tr1 != tr2 {
+		t.Fatal("expected cached transport reuse for same ServerName")
+	}
+	if tr1 == tr3 {
+		t.Fatal("expected distinct transports for different ServerNames")
+	}
+	if tr1.TLSClientConfig == nil || tr1.TLSClientConfig.ServerName != "metrics.example.com" {
+		t.Fatalf("ServerName = %v", tr1.TLSClientConfig)
+	}
+	if tr3.TLSClientConfig == nil || tr3.TLSClientConfig.ServerName != "logs.example.com" {
+		t.Fatalf("ServerName = %v", tr3.TLSClientConfig)
+	}
+}
+
 func TestPinRequestURLToValidatedIP_returnsDNSNameForTLS(t *testing.T) {
 	t.Parallel()
 

--- a/backend/pkg/prometheus/client.go
+++ b/backend/pkg/prometheus/client.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -34,11 +35,17 @@ type MetricResult struct {
 	Values [][]interface{}   `json:"values"`
 }
 
-// NewClient creates a new Prometheus client with the given URL
-func NewClient(prometheusURL string) (*Client, error) {
-	client, err := api.NewClient(api.Config{
+// NewClient creates a new Prometheus client with the given URL and optional HTTP client
+func NewClient(prometheusURL string, httpClient ...*http.Client) (*Client, error) {
+	cfg := api.Config{
 		Address: prometheusURL,
-	})
+	}
+
+	if len(httpClient) > 0 && httpClient[0] != nil {
+		cfg.Client = httpClient[0]
+	}
+
+	client, err := api.NewClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus client: %w", err)
 	}

--- a/backend/pkg/prometheus/client.go
+++ b/backend/pkg/prometheus/client.go
@@ -9,8 +9,6 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // Client wraps the Prometheus API client
@@ -37,22 +35,18 @@ type MetricResult struct {
 	Values [][]interface{}   `json:"values"`
 }
 
-// NewClient creates a new Prometheus client with the given URL.
-// Outbound requests use ssrf.DatasourceClient (private nets allowed; cloud
-// metadata blocked at dial and redirect). An optional HTTP client overrides
-// that default (tests).
-func NewClient(prometheusURL string, httpClient ...*http.Client) (*Client, error) {
-	cfg := api.Config{
+// NewClient creates a new Prometheus client with the given URL and HTTP client.
+// httpClient is required so callers cannot silently inherit client_golang's
+// default transport (which has no SSRF dial/redirect policy).
+func NewClient(prometheusURL string, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		return nil, fmt.Errorf("http client is required")
+	}
+
+	client, err := api.NewClient(api.Config{
 		Address: prometheusURL,
-	}
-
-	if len(httpClient) > 0 && httpClient[0] != nil {
-		cfg.Client = httpClient[0]
-	} else {
-		cfg.Client = ssrf.DatasourceClient(30 * time.Second)
-	}
-
-	client, err := api.NewClient(cfg)
+		Client:  httpClient,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus client: %w", err)
 	}

--- a/backend/pkg/prometheus/client.go
+++ b/backend/pkg/prometheus/client.go
@@ -9,6 +9,8 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // Client wraps the Prometheus API client
@@ -35,7 +37,10 @@ type MetricResult struct {
 	Values [][]interface{}   `json:"values"`
 }
 
-// NewClient creates a new Prometheus client with the given URL and optional HTTP client
+// NewClient creates a new Prometheus client with the given URL.
+// Outbound requests use ssrf.DatasourceClient (private nets allowed; cloud
+// metadata blocked at dial and redirect). An optional HTTP client overrides
+// that default (tests).
 func NewClient(prometheusURL string, httpClient ...*http.Client) (*Client, error) {
 	cfg := api.Config{
 		Address: prometheusURL,
@@ -43,6 +48,8 @@ func NewClient(prometheusURL string, httpClient ...*http.Client) (*Client, error
 
 	if len(httpClient) > 0 && httpClient[0] != nil {
 		cfg.Client = httpClient[0]
+	} else {
+		cfg.Client = ssrf.DatasourceClient(30 * time.Second)
 	}
 
 	client, err := api.NewClient(cfg)

--- a/backend/pkg/prometheus/client_test.go
+++ b/backend/pkg/prometheus/client_test.go
@@ -1,0 +1,34 @@
+package prometheus
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewClient_requiresHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient("http://localhost:9090", nil)
+	if err == nil {
+		t.Fatal("expected error for nil http client")
+	}
+	if client != nil {
+		t.Fatal("expected nil client when http client is missing")
+	}
+	if !strings.Contains(err.Error(), "http client is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewClient_acceptsHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient("http://localhost:9090", http.DefaultClient)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if client == nil {
+		t.Fatal("client is nil")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #374 (parent: #373)

Wires all datasource query/stream HTTP clients through `ssrf.DatasourceClient` so metadata blocking and redirect policy apply on the query/stream path (private/internal datasources still allowed).

<!-- ci-jedi-tn-round: 1 -->

## Changes

### Call sites wired through DatasourceClient

All query/stream HTTP clients now use `ssrf.DatasourceClient` (or inject its `*http.Client`):

- **Prometheus** (`backend/pkg/prometheus/client.go`) — `NewClient(prometheusURL, httpClient *http.Client)` requires a non-nil `*http.Client` (no silent fallback to client_golang's default transport). Callers pass `ssrf.DatasourceClient(...)`:
  - `backend/internal/datasource/prometheus.go`
  - legacy `PROMETHEUS_URL` routes in `backend/internal/handlers/prometheus.go` (`cmd/api/main.go`)
- **VictoriaMetrics** (`victoriametrics.go`)
- **Loki** (`loki.go`) — HTTP query/label endpoints **and** websocket tail (see below)
- **VictoriaLogs** (`victorialogs.go`) — HTTP query/label client plus a `streamClient` field constructed once in `NewVictoriaLogsClient` via `ssrf.DatasourceClient(0)` (Timeout 0 is intentional for long-lived tails) and reused in `Stream`
- **Tempo** (`tempo.go`)
- **VictoriaTraces** (`victoriatraces.go`)
- **ClickHouse** (`clickhouse.go`)
- **Elasticsearch** (`elasticsearch.go`)
- **AlertManager** (`alertmanager.go`)
- **VMAlert** (`vmalert.go`)

### Loki websocket dialer

**Not deferred.** Loki `Stream()` copies `websocket.DefaultDialer` and sets `NetDialContext = ssrf.DatasourceDialContext`, so tail connections get the same dial-time cloud-metadata block as HTTP datasource clients.

### Transport policy (proxy / multi-IP)

`DatasourceClient` / `SafeClient` honor `HTTP_PROXY`/`HTTPS_PROXY`, try all resolved addresses after policy checks, and validate the destination URL on `RoundTrip` so metadata policy still applies when DialContext only sees the proxy hop.

## Testing

`backend/internal/datasource/ssrf_client_test.go` (plus `internal/ssrf` and `pkg/prometheus` unit tests):

- **`TestDatasourceClientsWireDialAndRedirectPolicy`** — constructed clients have non-nil `CheckRedirect` / `Transport`; VictoriaLogs `streamClient` Timeout is 0
- **`TestDatasourceClientsAllowPrivateNetworks`** — private/RFC1918 addresses are not blocked by SSRF policy
- **`TestDatasourceClientsBlockMetadata`** — `169.254.169.254` is blocked at dial time
- **`TestDatasourceClientsBlockMetadataRedirect`** — redirects to the metadata endpoint are blocked
- Loki/VictoriaLogs stream metadata-block coverage
- `pkg/prometheus.NewClient` rejects a nil HTTP client

## Acceptance criteria

- [x] Dial/redirect metadata policy applies on query/stream path
- [x] Private nets still work for datasources (verified by tests)
- [x] Unit tests for DatasourceClient reuse / policy (`ssrf_client_test.go`)
- [x] No Speke touches
- [x] Don't edit release PR #372
- [x] Loki websocket dialer uses `ssrf.DatasourceDialContext` (no longer deferred)
- [x] Prometheus `NewClient` requires a non-nil HTTP client; handlers/datasource callers inject `DatasourceClient`
- [x] VictoriaLogs stream client is constructed once and reused

## Related

- Parent: #373 (Architecture/quality pass)
- Supersedes: #375 (closed as duplicate)