### PR TITLE
Document AI validateBaseURL vs ssrf client policy seams

### DIFF
--- a/backend/internal/handlers/ai_handler.go
+++ b/backend/internal/handlers/ai_handler.go
@@ -27,9 +27,13 @@ func jsonError(w http.ResponseWriter, msg string, code int) {
 	json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
-// validateBaseURL checks that a URL is safe to use as a provider base URL.
-// It requires http:// or https:// scheme, rejects userinfo (@) and fragments (#),
-// and blocks cloud metadata IPs (169.254.169.254).
+// validateBaseURL is the AI-provider config-time URL check (create/update).
+// It is not ssrf.ValidateURL or ssrf.ValidateDatasourceURL: localhost and
+// 127.0.0.1 are allowed for Ollama; other private/loopback addresses are
+// rejected; only 169.254.169.254 is treated as metadata. Enforcement is
+// save-time only — outbound HTTP in ai_provider.go uses the default
+// http.Client (no dial/redirect policy). See
+// docs/adr/0003-outbound-http-ssrf-policy-seams.md.
 func validateBaseURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -77,20 +81,19 @@ func validateBaseURL(raw string) error {
 	return nil
 }
 
-// checkDangerousIP returns an error if the given IP is a cloud metadata address,
-// loopback (other than 127.0.0.1 which is allowed for Ollama), or private RFC 1918 range.
+// checkDangerousIP rejects cloud metadata 169.254.169.254, loopback
+// (127.0.0.1 is allowed only via validateBaseURL's hostname early-return),
+// and RFC1918 / IPv6 ULA (ip.IsPrivate). It does not reject the rest of
+// 169.254.0.0/16 or fe80::/10 (unlike ssrf.SafeClient).
 func checkDangerousIP(ip net.IP) error {
-	// Block link-local / cloud metadata (169.254.x.x)
 	if ip.Equal(net.ParseIP("169.254.169.254")) {
 		return fmt.Errorf("base_url must not resolve to cloud metadata IP")
 	}
 
-	// Block loopback range (127.x.x.x) except 127.0.0.1 which is allowed above
 	if ip.IsLoopback() {
 		return fmt.Errorf("base_url must not resolve to loopback address")
 	}
 
-	// Block RFC 1918 private ranges: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
 	if ip.IsPrivate() {
 		return fmt.Errorf("base_url must not resolve to private network address")
 	}

--- a/backend/internal/handlers/ai_provider.go
+++ b/backend/internal/handlers/ai_provider.go
@@ -46,7 +46,11 @@ type ChatRequest struct {
 }
 
 // OpenAICompatibleProvider implements AIProvider for any OpenAI-compatible API
-// (OpenAI, Ollama, OpenRouter, vLLM, LiteLLM, etc.)
+// (OpenAI, Ollama, OpenRouter, vLLM, LiteLLM, etc.).
+//
+// Outbound HTTP uses Go's default http.Client (timeout only). Base URLs are
+// checked at save time by validateBaseURL, not by ssrf.SafeClient or
+// ssrf.DatasourceClient — see docs/adr/0003-outbound-http-ssrf-policy-seams.md.
 type OpenAICompatibleProvider struct {
 	BaseURL     string
 	APIKey      string // empty for local providers like Ollama
@@ -190,6 +194,10 @@ const defaultCopilotTokenEndpoint = "https://api.github.com/copilot_internal/v2/
 // It uses a two-step auth: first obtain a short-lived Copilot session token
 // from the GitHub API using the user's encrypted GitHub access token, then
 // use that session token to call the Copilot API.
+//
+// Token and chat HTTP use the default http.Client. endpoints.api from GitHub's
+// token JSON is used as-is (not validateBaseURL). See
+// docs/adr/0003-outbound-http-ssrf-policy-seams.md.
 type CopilotProvider struct {
 	EncryptedGHToken string // AES-GCM encrypted GitHub access token
 

--- a/backend/internal/ssrf/ssrf.go
+++ b/backend/internal/ssrf/ssrf.go
@@ -1,5 +1,12 @@
-// Package ssrf provides URL validation and a safe HTTP client that blocks
-// server-side request forgery by rejecting private/internal IP addresses.
+// Package ssrf provides URL validation and HTTP clients with request-forgery
+// policy. SafeClient is for untrusted user-supplied hosts (Grafana).
+// DatasourceClient is for configured observability backends (private networks
+// allowed; cloud metadata blocked at URL, dial, and redirect).
+//
+// AI provider base URLs are a third seam: handlers.validateBaseURL at save
+// time plus Go's default http.Client at request time. Do not silently reuse
+// SafeClient or DatasourceClient for AI — see
+// docs/adr/0003-outbound-http-ssrf-policy-seams.md.
 package ssrf
 
 import (

--- a/docs/adr/0003-outbound-http-ssrf-policy-seams.md
+++ b/docs/adr/0003-outbound-http-ssrf-policy-seams.md
@@ -1,0 +1,157 @@
+---
+status: accepted
+---
+
+# Outbound HTTP SSRF policy seams
+
+> **Implementation status:** Accepted description of *current* behaviour after
+> datasource query/stream wiring ([#377](https://github.com/aceobservability/ace/issues/377) /
+> [#374](https://github.com/aceobservability/ace/issues/374)). Folding AI
+> outbound onto `ssrf.SafeClient` / `ssrf.DatasourceClient` is **deferred**
+> ([#376](https://github.com/aceobservability/ace/issues/376)); do not treat
+> this ADR as permission to change AI HTTP semantics.
+
+Ace has **three** outbound HTTP policies. They are not interchangeable. Jan
+accepted a dedicated datasource client first; AI remains on a config-time URL
+check plus Go's default `http.Client`.
+
+## Why three seams
+
+| Seam | Trust model | Typical targets |
+|------|-------------|-----------------|
+| **Grafana / untrusted URL** | User-supplied URL in a request (import/connect). Must not reach the cluster or cloud metadata. | Public Grafana hosts |
+| **Configured datasource** | Operator-configured observability backends. Private/in-cluster URLs are required. | Prometheus, Loki, Victoria*, Tempo, ES, ClickHouse, Alertmanager, … |
+| **AI provider** | Org-admin configured OpenAI-compatible `base_url`. Local Ollama on loopback is required; RFC1918 cluster IPs are not the intended default. | `api.openai.com`, `localhost`/`127.0.0.1` Ollama, public gateways |
+
+A single client cannot satisfy all three: `SafeClient` would break in-cluster
+datasources **and** local Ollama; `DatasourceClient` would allow AI providers
+to target arbitrary private networks that `validateBaseURL` currently rejects
+at save time.
+
+## Inventory
+
+### 1. `ssrf.SafeClient` + `ValidateURL` / `IsValidRedirectURL`
+
+**Where:** `backend/internal/ssrf/ssrf.go`; call site `handlers.GrafanaDiscoveryHandler`.
+
+**Allows:** `http`/`https` URLs whose hostname (literal or DNS) is **not** in
+private/internal ranges.
+
+**Blocks (parse + DNS + dial):**
+
+- Non-http(s), missing host, userinfo
+- `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`
+- IPv6 `::1/128`, `fc00::/7`, `fe80::/10`
+
+**Client behaviour:**
+
+- Custom `DialContext`: fail-closed if **any** resolved IP is blocked; otherwise
+  try remaining addresses
+- `urlPolicyTransport` re-validates the request URL on every `RoundTrip`
+  (covers redirect hops that Go follows by default)
+- **No HTTP proxy** (`useProxy` false); destination hostnames are **not** pinned
+  (multi-A/AAAA fallback stays on the dialer)
+- Grafana **overrides** `CheckRedirect` to `ErrUseLastResponse` (does not follow)
+
+### 2. `ssrf.DatasourceClient` + `ValidateDatasourceURL` / `IsLocalURL`
+
+**Where:** `ssrf.go`; wired on query/stream clients in `backend/internal/datasource/*`
+and `handlers/prometheus.go`. Non-HTTP: Loki websocket uses `DatasourceDialContext`.
+
+**Allows:** `http`/`https` including private/loopback/link-local **except** the
+cloud metadata address.
+
+**Blocks:**
+
+- Non-http(s), missing host, userinfo
+- Literal or resolved `169.254.169.254` only (not the rest of `169.254.0.0/16`)
+
+**Client behaviour:**
+
+- Same dial-time reject, but `rejectCloudMetadata` instead of `isBlockedIP`
+- Explicit `CheckRedirect`: max 10 hops; each `Location` must pass
+  `ValidateDatasourceURL`
+- Honors `HTTP(S)_PROXY` / `NO_PROXY`. When a proxy hop is used, destination
+  hostnames are resolved and **pinned** to a policy-checked IP before the proxy
+  sees the request (closes proxy-side DNS rebinding). Direct dials stay unpinned.
+
+Config-time validation: `handlers/datasource.go` and `datasource/client.go`
+(`IsLocalURL` / `ValidateDatasourceURL`) — same policy as the client, not the
+Grafana CIDR list.
+
+### 3. `handlers.validateBaseURL` + vanilla `http.Client`
+
+**Where (check):** `backend/internal/handlers/ai_handler.go` —
+`validateBaseURL` / `checkDangerousIP`, called on AI provider **create** and
+**update** only.
+
+**Where (HTTP):** `backend/internal/handlers/ai_provider.go` —
+`OpenAICompatibleProvider` and `CopilotProvider` use `&http.Client{Timeout: …}`
+with the default transport (no dial policy, no redirect policy, proxy via
+environment as Go default). Copilot also follows `endpoints.api` from GitHub's
+token JSON without `validateBaseURL`. Device-flow / OAuth in
+`github_copilot.go` uses hardcoded `github.com` URLs and the same default
+client.
+
+**Allows:**
+
+- `http`/`https`
+- Hostname `localhost` or `127.0.0.1` (early return; DNS not consulted — so
+  `localhost` → `::1` is allowed)
+- Public addresses
+
+**Blocks (config-time only):**
+
+- Userinfo (`@` in the raw string), fragments (`#`)
+- Literal/resolved `169.254.169.254`
+- Other loopback (`ip.IsLoopback()`, e.g. `127.0.0.2`, `::1` as a literal)
+- RFC1918 / IPv6 ULA (`ip.IsPrivate()`)
+
+**Does not block (unlike `SafeClient`):** the rest of `169.254.0.0/16`, IPv6
+link-local `fe80::/10`. DNS lookup failures are ignored (`if err == nil`).
+
+**Does not enforce at request time:** after a provider is saved, outbound
+calls do not re-check IPs, do not fail closed on mixed A/AAAA records, and
+follow redirects with Go defaults. DNS rebinding after save is out of scope
+of `validateBaseURL`.
+
+## Gap statement
+
+| | Grafana | Datasource | AI OpenAI-compatible |
+|--|---------|------------|----------------------|
+| Policy function | `ValidateURL` | `ValidateDatasourceURL` | `validateBaseURL` |
+| HTTP client | `SafeClient` | `DatasourceClient` | default `http.Client` |
+| Private networks | blocked | **allowed** | **blocked** except `localhost`/`127.0.0.1` |
+| Cloud metadata `169.254.169.254` | blocked (whole `169.254/16`) | blocked (that IP) | blocked (that IP, save time) |
+| Dial-time enforcement | yes | yes | **no** |
+| Redirect policy | Grafana: don't follow; client RoundTrip would still validate | metadata check, 10-hop cap | Go default, **no** Ace policy |
+| Proxy / dest pin | no proxy | pin when proxied | Go default proxy, **no** pin |
+
+**AI outbound is not an instance of either SSRF client.** Mapping it onto
+`SafeClient` would reject local Ollama. Mapping it onto `DatasourceClient`
+would loosen AI toward any RFC1918 target and still would not match today's
+fragment/`localhost` special cases. A correct fold-in is a **fourth** client
+or a parameterized policy (dial + redirect + the AI allow-list), which is
+explicitly deferred.
+
+## Considered options (this pass)
+
+- **Fold AI onto `DatasourceClient` now** — rejected: changes allow-list
+  (private networks become reachable) and request-time behaviour.
+- **Fold AI onto `SafeClient` now** — rejected: breaks `localhost`/`127.0.0.1`
+  Ollama.
+- **Share `parseHTTPURL` into `validateBaseURL`** — skipped: would drop the
+  fragment check and add a required-host error; not a no-op.
+- **Document the seams and leave clients unchanged** — chosen.
+
+## Consequences
+
+- New observability HTTP clients continue to use `DatasourceClient`, not
+  `SafeClient` or `validateBaseURL`.
+- New Grafana-like untrusted fetches continue to use `SafeClient`.
+- AI provider HTTP stays on default clients until a dedicated follow-up
+  specifies dial/redirect semantics that preserve local Ollama and do not
+  open RFC1918.
+- SSO Copilot OAuth to `github.com` is hardcoded and out of this ticket;
+  Copilot `endpoints.api` remains an AI outbound URL without
+  `validateBaseURL`.


### PR DESCRIPTION
Closes #376.

<!-- ci-jedi-tn-round: 1 -->

Jan deferred folding AI outbound onto `ssrf.SafeClient` / `ssrf.DatasourceClient`. This PR **documents** the three policy seams and adds pointer comments. It does **not** change AI HTTP clients or datasource/Grafana wiring (#377 / #374).

## Inventory

### 1. Grafana / untrusted URL — `ssrf.SafeClient`

- **Validate:** `ssrf.ValidateURL` / `IsValidRedirectURL`
- **Client:** `backend/internal/ssrf/ssrf.go` `SafeClient`; call site `handlers.GrafanaDiscoveryHandler`
- **Allows:** http(s) to non-private hosts
- **Blocks:** private/internal CIDRs (`127.0.0.0/8`, RFC1918, `169.254.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`), userinfo, non-http(s)
- **Dial:** custom `DialContext`, fail-closed if any resolved IP is blocked
- **Redirect:** Grafana sets `CheckRedirect` to not follow; `urlPolicyTransport` would still validate each RoundTrip URL
- **Proxy:** none; destination hostnames not pinned (multi-A/AAAA fallback)

### 2. Configured datasource — `ssrf.DatasourceClient`

- **Validate:** `ssrf.ValidateDatasourceURL` / `IsLocalURL` (`handlers/datasource.go`, `datasource/client.go`)
- **Client:** query/stream in `backend/internal/datasource/*` and `handlers/prometheus.go`; Loki WS uses `DatasourceDialContext`
- **Allows:** http(s) including private/loopback (in-cluster Prometheus, local Victoria, etc.)
- **Blocks:** `169.254.169.254` only (not the rest of `169.254/16`), userinfo, non-http(s)
- **Dial + redirect:** metadata block at URL, dial, and `CheckRedirect` (10-hop cap)
- **Proxy:** `HTTP(S)_PROXY` honored; pin destination IP when a proxy hop is used

### 3. AI provider — `validateBaseURL` + default `http.Client`

- **Validate (save only):** `handlers.validateBaseURL` / `checkDangerousIP` on provider create/update in `ai_handler.go`
- **HTTP:** `ai_provider.go` `OpenAICompatibleProvider` and `CopilotProvider` use `&http.Client{Timeout: …}` (default transport). Copilot also uses GitHub `endpoints.api` without `validateBaseURL`. `github_copilot.go` OAuth hits hardcoded `github.com`.
- **Allows:** http(s); hostname `localhost` or `127.0.0.1` (Ollama; DNS skipped); public IPs
- **Blocks (config-time):** `@` userinfo, `#` fragments, `169.254.169.254`, other loopback (`IsLoopback`), RFC1918/ULA (`IsPrivate`)
- **Does not block:** rest of `169.254.0.0/16`, `fe80::/10` (unlike `SafeClient`)
- **Does not enforce at request time:** no dial policy, no Ace redirect policy, DNS rebinding after save is possible

## Gap

AI outbound is **not** either SSRF client:

| | Grafana | Datasource | AI |
|--|---------|------------|-----|
| Private nets | blocked | allowed | blocked except localhost/127.0.0.1 |
| Metadata | whole 169.254/16 | 169.254.169.254 | 169.254.169.254 at save |
| Dial-time | yes | yes | **no** |
| Redirect policy | don't follow / RoundTrip validate | metadata + 10 hops | Go default |

`SafeClient` would break local Ollama. `DatasourceClient` would allow AI to hit arbitrary RFC1918. Sharing `parseHTTPURL` would change fragment/host semantics. Fold-in needs a dedicated (or parameterized) client — deferred.

## What changed

- New [ADR-0003](docs/adr/0003-outbound-http-ssrf-policy-seams.md)
- Comments on `ssrf` package, `validateBaseURL`, and AI provider types pointing at the ADR
- No runtime behaviour change

## Test plan

- Comments/docs only; existing `ssrf` and datasource client tests still apply
- Confirm AI create/update still uses `validateBaseURL` (unchanged function body)
