### PR TITLE
Deepen datasource.Client: auth RoundTripper + vendor dispatch

### DIFF
--- a/backend/internal/datasource/alertmanager.go
+++ b/backend/internal/datasource/alertmanager.go
@@ -10,14 +10,12 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // AlertManagerClient wraps HTTP calls to AlertManager's v2 API.
 type AlertManagerClient struct {
-	baseURL    string
-	client     *http.Client
-	datasource models.DataSource
+	baseURL string
+	client  *http.Client
 }
 
 // NewAlertManagerClient creates a new AlertManager client from a datasource record.
@@ -26,9 +24,8 @@ func NewAlertManagerClient(ds models.DataSource) (*AlertManagerClient, error) {
 		return nil, fmt.Errorf("alertmanager datasource URL is required")
 	}
 	return &AlertManagerClient{
-		baseURL:    ds.URL,
-		client:     ssrf.DatasourceClient(30 * time.Second),
-		datasource: ds,
+		baseURL: ds.URL,
+		client:  newDatasourceHTTPClient(ds, 30*time.Second),
 	}, nil
 }
 
@@ -158,10 +155,6 @@ func (c *AlertManagerClient) ExpireSilence(ctx context.Context, id string) error
 	if err != nil {
 		return fmt.Errorf("failed to create expire silence request: %w", err)
 	}
-	if err := applyDataSourceAuth(req, c.datasource); err != nil {
-		return err
-	}
-
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("expire silence request failed: %w", err)
@@ -205,10 +198,6 @@ func doAlertManagerRequest[T any](ctx context.Context, c *AlertManagerClient, me
 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
-	}
-
-	if err := applyDataSourceAuth(req, c.datasource); err != nil {
-		return zero, err
 	}
 
 	resp, err := c.client.Do(req)

--- a/backend/internal/datasource/auth.go
+++ b/backend/internal/datasource/auth.go
@@ -120,11 +120,12 @@ func newDatasourceHTTPClient(ds models.DataSource, timeout time.Duration) *http.
 }
 
 func wrapDatasourceAuth(client *http.Client, ds models.DataSource) *http.Client {
-	base := client.Transport
-	if base == nil {
-		base = http.DefaultTransport
+	if client.Transport == nil {
+		panic("datasource: wrapDatasourceAuth requires a non-nil Transport (DatasourceClient policy)")
 	}
-	client.Transport = &dataSourceAuthRoundTripper{base: base, ds: ds}
+	// Mutate in place: DatasourceClient returns a fresh *http.Client per call.
+	// Do not share that client across datasources.
+	client.Transport = &dataSourceAuthRoundTripper{base: client.Transport, ds: ds}
 	return client
 }
 

--- a/backend/internal/datasource/auth.go
+++ b/backend/internal/datasource/auth.go
@@ -3,7 +3,9 @@ package datasource
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -11,9 +13,11 @@ import (
 	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
-// dataSourceAuthRoundTripper stamps stored datasource credentials onto every
-// outbound request while leaving the inner DatasourceClient dial/pin/proxy/TLS
-// policy untouched.
+// dataSourceAuthRoundTripper stamps stored datasource credentials onto outbound
+// requests bound for the configured datasource origin only. Cross-origin
+// redirect hops must not regain secrets (net/http reuses the transport, and
+// custom API-key headers are not stripped by the default redirect policy).
+// Inner DatasourceClient dial/pin/proxy/TLS policy is left untouched.
 type dataSourceAuthRoundTripper struct {
 	base http.RoundTripper
 	ds   models.DataSource
@@ -21,10 +25,91 @@ type dataSourceAuthRoundTripper struct {
 
 func (t *dataSourceAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	cloned := req.Clone(req.Context())
-	if err := applyDataSourceAuth(cloned, t.ds); err != nil {
-		return nil, err
+	if sameDatasourceOrigin(cloned, t.ds.URL) {
+		if err := applyDataSourceAuth(cloned, t.ds); err != nil {
+			return nil, err
+		}
+	} else {
+		// Drop credentials that may have been copied onto a cross-origin hop
+		// (especially custom API-key headers Go does not strip on redirect).
+		stripDataSourceAuth(cloned, t.ds)
 	}
 	return t.base.RoundTrip(cloned)
+}
+
+// sameDatasourceOrigin reports whether req targets the same host:port as the
+// configured datasource URL. req.Host is preferred over URL.Host so IP pinning
+// in the SSRF transport (which rewrites URL.Host but keeps the Host header)
+// still matches the configured origin.
+func sameDatasourceOrigin(req *http.Request, rawURL string) bool {
+	configured, err := url.Parse(rawURL)
+	if err != nil || strings.TrimSpace(configured.Host) == "" {
+		return false
+	}
+	want := canonicalHostPort(configured.Scheme, configured.Host)
+
+	if host := strings.TrimSpace(req.Host); host != "" {
+		scheme := ""
+		if req.URL != nil {
+			scheme = req.URL.Scheme
+		}
+		if scheme == "" {
+			scheme = configured.Scheme
+		}
+		if canonicalHostPort(scheme, host) == want {
+			return true
+		}
+	}
+	if req.URL != nil && strings.TrimSpace(req.URL.Host) != "" {
+		return canonicalHostPort(req.URL.Scheme, req.URL.Host) == want
+	}
+	return false
+}
+
+func canonicalHostPort(scheme, host string) string {
+	hostname := host
+	port := ""
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+		port = p
+	} else if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		// Bracketed IPv6 without an explicit port.
+		hostname = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+	if port == "" {
+		port = defaultPortForScheme(scheme)
+	}
+	return strings.ToLower(hostname) + ":" + port
+}
+
+func defaultPortForScheme(scheme string) string {
+	switch strings.ToLower(strings.TrimSpace(scheme)) {
+	case "https", "wss":
+		return "443"
+	default:
+		return "80"
+	}
+}
+
+// stripDataSourceAuth removes credentials applyDataSourceAuth would have set,
+// so redirect targets cannot inherit stored secrets via header copy.
+func stripDataSourceAuth(req *http.Request, ds models.DataSource) {
+	req.Header.Del("Authorization")
+
+	authType := normalizeAuthType(ds.AuthType)
+	if authType != "api_key" {
+		return
+	}
+	headerName := "X-API-Key"
+	if len(ds.AuthConfig) > 0 {
+		var cfg datasourceAuthConfig
+		if err := json.Unmarshal(ds.AuthConfig, &cfg); err == nil {
+			if name := strings.TrimSpace(cfg.Header); name != "" {
+				headerName = name
+			}
+		}
+	}
+	req.Header.Del(headerName)
 }
 
 // newDatasourceHTTPClient builds ssrf.DatasourceClient(timeout) then wraps it

--- a/backend/internal/datasource/auth.go
+++ b/backend/internal/datasource/auth.go
@@ -5,9 +5,56 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
+
+// dataSourceAuthRoundTripper stamps stored datasource credentials onto every
+// outbound request while leaving the inner DatasourceClient dial/pin/proxy/TLS
+// policy untouched.
+type dataSourceAuthRoundTripper struct {
+	base http.RoundTripper
+	ds   models.DataSource
+}
+
+func (t *dataSourceAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	if err := applyDataSourceAuth(cloned, t.ds); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(cloned)
+}
+
+// newDatasourceHTTPClient builds ssrf.DatasourceClient(timeout) then wraps it
+// with stored-credential auth. Per-type timeouts stay at the call site
+// (15s / 30s / stream 0).
+func newDatasourceHTTPClient(ds models.DataSource, timeout time.Duration) *http.Client {
+	return wrapDatasourceAuth(ssrf.DatasourceClient(timeout), ds)
+}
+
+func wrapDatasourceAuth(client *http.Client, ds models.DataSource) *http.Client {
+	base := client.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	client.Transport = &dataSourceAuthRoundTripper{base: base, ds: ds}
+	return client
+}
+
+// dataSourceAuthHeader is the websocket call site for the same credential
+// helper used by dataSourceAuthRoundTripper.
+func dataSourceAuthHeader(ds models.DataSource) (http.Header, error) {
+	req, err := http.NewRequest(http.MethodGet, "http://datasource.invalid", nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyDataSourceAuth(req, ds); err != nil {
+		return nil, err
+	}
+	return req.Header, nil
+}
 
 type datasourceAuthConfig struct {
 	Username string `json:"username"`

--- a/backend/internal/datasource/auth.go
+++ b/backend/internal/datasource/auth.go
@@ -37,16 +37,17 @@ func (t *dataSourceAuthRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	return t.base.RoundTrip(cloned)
 }
 
-// sameDatasourceOrigin reports whether req targets the same host:port as the
-// configured datasource URL. req.Host is preferred over URL.Host so IP pinning
-// in the SSRF transport (which rewrites URL.Host but keeps the Host header)
-// still matches the configured origin.
+// sameDatasourceOrigin reports whether req targets the same scheme+host+port
+// as the configured datasource URL. Scheme is part of the origin so an
+// HTTPS→HTTP redirect on the same host:port does not keep credentials.
+// req.Host is preferred over URL.Host so IP pinning in the SSRF transport
+// (which rewrites URL.Host but keeps the Host header) still matches.
 func sameDatasourceOrigin(req *http.Request, rawURL string) bool {
 	configured, err := url.Parse(rawURL)
 	if err != nil || strings.TrimSpace(configured.Host) == "" {
 		return false
 	}
-	want := canonicalHostPort(configured.Scheme, configured.Host)
+	want := canonicalOrigin(configured.Scheme, configured.Host)
 
 	if host := strings.TrimSpace(req.Host); host != "" {
 		scheme := ""
@@ -56,17 +57,20 @@ func sameDatasourceOrigin(req *http.Request, rawURL string) bool {
 		if scheme == "" {
 			scheme = configured.Scheme
 		}
-		if canonicalHostPort(scheme, host) == want {
+		if canonicalOrigin(scheme, host) == want {
 			return true
 		}
 	}
 	if req.URL != nil && strings.TrimSpace(req.URL.Host) != "" {
-		return canonicalHostPort(req.URL.Scheme, req.URL.Host) == want
+		return canonicalOrigin(req.URL.Scheme, req.URL.Host) == want
 	}
 	return false
 }
 
-func canonicalHostPort(scheme, host string) string {
+// canonicalOrigin returns scheme://host:port for origin comparison.
+// Scheme is required so HTTPS and HTTP are never treated as the same origin,
+// including when both use an explicit non-default port.
+func canonicalOrigin(scheme, host string) string {
 	hostname := host
 	port := ""
 	if h, p, err := net.SplitHostPort(host); err == nil {
@@ -79,7 +83,7 @@ func canonicalHostPort(scheme, host string) string {
 	if port == "" {
 		port = defaultPortForScheme(scheme)
 	}
-	return strings.ToLower(hostname) + ":" + port
+	return strings.ToLower(strings.TrimSpace(scheme)) + "://" + strings.ToLower(hostname) + ":" + port
 }
 
 func defaultPortForScheme(scheme string) string {

--- a/backend/internal/datasource/auth_test.go
+++ b/backend/internal/datasource/auth_test.go
@@ -96,3 +96,50 @@ func TestApplyDataSourceAuth_InvalidType(t *testing.T) {
 		t.Fatal("expected error for invalid auth type")
 	}
 }
+
+func TestDataSourceAuthHeader_Bearer(t *testing.T) {
+	ds := models.DataSource{
+		AuthType:   "bearer",
+		AuthConfig: []byte(`{"token":"ws-token"}`),
+	}
+
+	header, err := dataSourceAuthHeader(ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if header.Get("Authorization") != "Bearer ws-token" {
+		t.Fatalf("unexpected authorization header: %s", header.Get("Authorization"))
+	}
+}
+
+func TestDataSourceAuthRoundTripper_StampsBearer(t *testing.T) {
+	ds := models.DataSource{
+		AuthType:   "bearer",
+		AuthConfig: []byte(`{"token":"rt-token"}`),
+	}
+
+	sawAuth := false
+	inner := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("Authorization") != "Bearer rt-token" {
+			t.Fatalf("unexpected authorization header: %s", req.Header.Get("Authorization"))
+		}
+		sawAuth = true
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+	})
+
+	client := wrapDatasourceAuth(&http.Client{Transport: inner}, ds)
+	resp, err := client.Get("http://example.invalid/query")
+	if err != nil {
+		t.Fatalf("round trip failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	if !sawAuth {
+		t.Fatal("expected inner transport to observe the request")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/backend/internal/datasource/auth_test.go
+++ b/backend/internal/datasource/auth_test.go
@@ -114,6 +114,7 @@ func TestDataSourceAuthHeader_Bearer(t *testing.T) {
 
 func TestDataSourceAuthRoundTripper_StampsBearer(t *testing.T) {
 	ds := models.DataSource{
+		URL:        "http://example.invalid/query",
 		AuthType:   "bearer",
 		AuthConfig: []byte(`{"token":"rt-token"}`),
 	}
@@ -135,6 +136,152 @@ func TestDataSourceAuthRoundTripper_StampsBearer(t *testing.T) {
 	_ = resp.Body.Close()
 	if !sawAuth {
 		t.Fatal("expected inner transport to observe the request")
+	}
+}
+
+func TestDataSourceAuthRoundTripper_DoesNotStampCrossOriginRedirect(t *testing.T) {
+	ds := models.DataSource{
+		URL:        "http://origin.invalid/query",
+		AuthType:   "bearer",
+		AuthConfig: []byte(`{"token":"secret-token"}`),
+	}
+
+	var hops []string
+	inner := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		hops = append(hops, req.URL.Host+":"+req.Header.Get("Authorization"))
+		switch req.URL.Host {
+		case "origin.invalid":
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"http://other.invalid/next"}},
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		case "other.invalid":
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+		default:
+			t.Fatalf("unexpected host: %s", req.URL.Host)
+			return nil, nil
+		}
+	})
+
+	client := wrapDatasourceAuth(&http.Client{Transport: inner}, ds)
+	resp, err := client.Get("http://origin.invalid/query")
+	if err != nil {
+		t.Fatalf("round trip failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if len(hops) != 2 {
+		t.Fatalf("expected 2 hops, got %v", hops)
+	}
+	if hops[0] != "origin.invalid:Bearer secret-token" {
+		t.Fatalf("origin hop auth = %q", hops[0])
+	}
+	if hops[1] != "other.invalid:" {
+		t.Fatalf("redirect hop must not regain credentials, got %q", hops[1])
+	}
+}
+
+func TestDataSourceAuthRoundTripper_StripsAPIKeyOnCrossOriginRedirect(t *testing.T) {
+	ds := models.DataSource{
+		URL:        "http://origin.invalid/query",
+		AuthType:   "api_key",
+		AuthConfig: []byte(`{"header":"X-Auth-Token","value":"token-1"}`),
+	}
+
+	var hops []string
+	inner := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		hops = append(hops, req.URL.Host+":"+req.Header.Get("X-Auth-Token"))
+		switch req.URL.Host {
+		case "origin.invalid":
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"http://other.invalid/next"}},
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		case "other.invalid":
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+		default:
+			t.Fatalf("unexpected host: %s", req.URL.Host)
+			return nil, nil
+		}
+	})
+
+	client := wrapDatasourceAuth(&http.Client{Transport: inner}, ds)
+	resp, err := client.Get("http://origin.invalid/query")
+	if err != nil {
+		t.Fatalf("round trip failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if len(hops) != 2 {
+		t.Fatalf("expected 2 hops, got %v", hops)
+	}
+	if hops[0] != "origin.invalid:token-1" {
+		t.Fatalf("origin hop api key = %q", hops[0])
+	}
+	if hops[1] != "other.invalid:" {
+		t.Fatalf("redirect hop must not regain api key, got %q", hops[1])
+	}
+}
+
+func TestDataSourceAuthRoundTripper_SameOriginRedirectKeepsAuth(t *testing.T) {
+	ds := models.DataSource{
+		URL:        "http://origin.invalid/query",
+		AuthType:   "bearer",
+		AuthConfig: []byte(`{"token":"secret-token"}`),
+	}
+
+	var hops []string
+	inner := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		hops = append(hops, req.URL.Path+":"+req.Header.Get("Authorization"))
+		switch req.URL.Path {
+		case "/query":
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"http://origin.invalid/next"}},
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		case "/next":
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+		default:
+			t.Fatalf("unexpected path: %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	client := wrapDatasourceAuth(&http.Client{Transport: inner}, ds)
+	resp, err := client.Get("http://origin.invalid/query")
+	if err != nil {
+		t.Fatalf("round trip failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if len(hops) != 2 {
+		t.Fatalf("expected 2 hops, got %v", hops)
+	}
+	if hops[0] != "/query:Bearer secret-token" || hops[1] != "/next:Bearer secret-token" {
+		t.Fatalf("same-origin hops should keep auth, got %v", hops)
+	}
+}
+
+func TestSameDatasourceOrigin_UsesHostHeaderWhenURLPinned(t *testing.T) {
+	dsURL := "https://metrics.example.com"
+	req, err := http.NewRequest(http.MethodGet, "https://203.0.113.10/api/v1/query", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// SSRF pin rewrites URL.Host to an IP while keeping Host as the original authority.
+	req.Host = "metrics.example.com"
+	if !sameDatasourceOrigin(req, dsURL) {
+		t.Fatal("expected pinned request with original Host header to match datasource origin")
+	}
+	req.Host = "other.example.com"
+	if sameDatasourceOrigin(req, dsURL) {
+		t.Fatal("expected mismatched Host header to fail origin check")
 	}
 }
 

--- a/backend/internal/datasource/auth_test.go
+++ b/backend/internal/datasource/auth_test.go
@@ -2,6 +2,7 @@ package datasource
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/aceobservability/ace/backend/internal/models"
@@ -283,6 +284,23 @@ func TestSameDatasourceOrigin_UsesHostHeaderWhenURLPinned(t *testing.T) {
 	if sameDatasourceOrigin(req, dsURL) {
 		t.Fatal("expected mismatched Host header to fail origin check")
 	}
+}
+
+func TestWrapDatasourceAuth_NilTransportPanics(t *testing.T) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected panic when Transport is nil")
+		}
+		msg, ok := recovered.(string)
+		if !ok {
+			t.Fatalf("panic value type %T, want string", recovered)
+		}
+		if !strings.Contains(msg, "non-nil Transport") {
+			t.Fatalf("panic message %q, want non-nil Transport", msg)
+		}
+	}()
+	_ = wrapDatasourceAuth(&http.Client{}, models.DataSource{})
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/backend/internal/datasource/auth_test.go
+++ b/backend/internal/datasource/auth_test.go
@@ -286,6 +286,50 @@ func TestSameDatasourceOrigin_UsesHostHeaderWhenURLPinned(t *testing.T) {
 	}
 }
 
+func TestDataSourceAuthRoundTripper_SchemeDowngradeDropsCredentials(t *testing.T) {
+	ds := models.DataSource{
+		URL:        "https://origin.invalid:8443/query",
+		AuthType:   "bearer",
+		AuthConfig: []byte(`{"token":"secret-token"}`),
+	}
+
+	var hops []string
+	inner := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		hops = append(hops, req.URL.Scheme+"://"+req.URL.Host+":"+req.Header.Get("Authorization"))
+		switch req.URL.Scheme + "://" + req.URL.Host + req.URL.Path {
+		case "https://origin.invalid:8443/query":
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"http://origin.invalid:8443/next"}},
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		case "http://origin.invalid:8443/next":
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+		default:
+			t.Fatalf("unexpected hop %s://%s%s", req.URL.Scheme, req.URL.Host, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	client := wrapDatasourceAuth(&http.Client{Transport: inner}, ds)
+	resp, err := client.Get("https://origin.invalid:8443/query")
+	if err != nil {
+		t.Fatalf("round trip failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if len(hops) != 2 {
+		t.Fatalf("expected 2 hops, got %v", hops)
+	}
+	if hops[0] != "https://origin.invalid:8443:Bearer secret-token" {
+		t.Fatalf("https hop auth = %q", hops[0])
+	}
+	if hops[1] != "http://origin.invalid:8443:" {
+		t.Fatalf("http scheme-downgrade hop must not keep credentials, got %q", hops[1])
+	}
+}
+
 func TestWrapDatasourceAuth_NilTransportPanics(t *testing.T) {
 	defer func() {
 		recovered := recover()

--- a/backend/internal/datasource/clickhouse.go
+++ b/backend/internal/datasource/clickhouse.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 const (
@@ -68,8 +67,12 @@ func NewClickHouseClient(ds models.DataSource) (*ClickHouseClient, error) {
 
 	return &ClickHouseClient{
 		datasource: ds,
-		httpClient: ssrf.DatasourceClient(30 * time.Second),
+		httpClient: newDatasourceHTTPClient(ds, 30*time.Second),
 	}, nil
+}
+
+func (c *ClickHouseClient) TestConnection(ctx context.Context) error {
+	return runHTTPConnectionCheck(ctx, c.datasource, c.httpClient, []string{"/ping", "/?query=SELECT%201", "/"})
 }
 
 func (c *ClickHouseClient) Query(ctx context.Context, query string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error) {
@@ -155,10 +158,6 @@ func (c *ClickHouseClient) queryRows(ctx context.Context, query string, start, e
 	}
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
 	req.Header.Set("Accept", "application/json")
-
-	if err := applyDataSourceAuth(req, c.datasource); err != nil {
-		return nil, err
-	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/backend/internal/datasource/client.go
+++ b/backend/internal/datasource/client.go
@@ -67,17 +67,59 @@ type Client interface {
 	Query(ctx context.Context, query string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error)
 }
 
+// SignalQueryClient is implemented by datasources that dispatch on signal
+// (ClickHouse, CloudWatch, Elasticsearch).
+type SignalQueryClient interface {
+	QueryWithSignal(ctx context.Context, query, signal string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error)
+}
+
+// StreamClient is implemented by log datasources that support live tail.
+type StreamClient interface {
+	Stream(ctx context.Context, query string, start time.Time, limit int, onLog LogStreamCallback) error
+}
+
+// LabelsClient is implemented by log datasources that expose label/field names.
+type LabelsClient interface {
+	Labels(ctx context.Context) ([]string, error)
+}
+
+// MetricLabelsClient is implemented by PromQL datasources that can scope labels
+// to a metric selector.
+type MetricLabelsClient interface {
+	Labels(ctx context.Context, metric string) ([]string, error)
+}
+
+// LabelValuesClient is implemented by log datasources that expose label values.
+type LabelValuesClient interface {
+	LabelValues(ctx context.Context, labelName string) ([]string, error)
+}
+
+// MetricLabelValuesClient is implemented by PromQL datasources that can scope
+// label values to a metric selector.
+type MetricLabelValuesClient interface {
+	LabelValues(ctx context.Context, label, metric string) ([]string, error)
+}
+
+// MetricNamesClient is implemented by PromQL datasources that expose metric names.
+type MetricNamesClient interface {
+	MetricNames(ctx context.Context, search string) ([]string, error)
+}
+
+type connectionTester interface {
+	TestConnection(ctx context.Context) error
+}
+
 // NewClient creates a datasource client based on the datasource type
 func NewClient(ds models.DataSource) (Client, error) {
 	switch ds.Type {
 	case models.DataSourcePrometheus:
-		return NewPrometheusClient(ds.URL)
+		return NewPrometheusClient(ds)
 	case models.DataSourceVictoriaMetrics:
-		return NewVictoriaMetricsClient(ds.URL)
+		return NewVictoriaMetricsClient(ds)
 	case models.DataSourceLoki:
-		return NewLokiClient(ds.URL)
+		return NewLokiClient(ds)
 	case models.DataSourceVictoriaLogs:
-		return NewVictoriaLogsClient(ds.URL)
+		return NewVictoriaLogsClient(ds)
 	case models.DataSourceTempo:
 		return NewTempoClient(ds)
 	case models.DataSourceVictoriaTraces:
@@ -95,46 +137,32 @@ func NewClient(ds models.DataSource) (Client, error) {
 
 func TestConnection(ctx context.Context, ds models.DataSource) error {
 	switch ds.Type {
-	case models.DataSourcePrometheus:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/-/healthy", "/api/v1/query?query=1", "/"})
-	case models.DataSourceVictoriaMetrics:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/health", "/api/v1/query?query=1", "/"})
-	case models.DataSourceLoki:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/ready", "/loki/api/v1/labels?limit=1", "/"})
-	case models.DataSourceVictoriaLogs:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/health", "/select/logsql/field_names?query=*", "/"})
-	case models.DataSourceTempo:
-		client, err := NewTempoClient(ds)
-		if err != nil {
-			return err
-		}
-		return client.TestConnection(ctx)
-	case models.DataSourceVictoriaTraces:
-		client, err := NewVictoriaTracesClient(ds)
-		if err != nil {
-			return err
-		}
-		return client.TestConnection(ctx)
-	case models.DataSourceClickHouse:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/ping", "/?query=SELECT%201", "/"})
-	case models.DataSourceCloudWatch:
-		client, err := NewCloudWatchClient(ds)
-		if err != nil {
-			return err
-		}
-		return client.TestConnection(ctx)
-	case models.DataSourceElasticsearch:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/_cluster/health", "/_cat/indices?format=json&h=index&bytes=b", "/"})
 	case models.DataSourceVMAlert:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/health", "/api/v1/alerts", "/"})
+		client, err := NewVMAlertClient(ds)
+		if err != nil {
+			return err
+		}
+		return runHTTPConnectionCheck(ctx, ds, client.client, []string{"/health", "/api/v1/alerts", "/"})
 	case models.DataSourceAlertManager:
-		return runHTTPConnectionCheck(ctx, ds, []string{"/api/v2/status", "/api/v2/alerts", "/"})
+		client, err := NewAlertManagerClient(ds)
+		if err != nil {
+			return err
+		}
+		return runHTTPConnectionCheck(ctx, ds, client.client, []string{"/api/v2/status", "/api/v2/alerts", "/"})
 	default:
-		return fmt.Errorf("unsupported datasource type: %s", ds.Type)
+		client, err := NewClient(ds)
+		if err != nil {
+			return err
+		}
+		tester, ok := client.(connectionTester)
+		if !ok {
+			return fmt.Errorf("unsupported datasource type: %s", ds.Type)
+		}
+		return tester.TestConnection(ctx)
 	}
 }
 
-func runHTTPConnectionCheck(ctx context.Context, ds models.DataSource, endpoints []string) error {
+func runHTTPConnectionCheck(ctx context.Context, ds models.DataSource, httpClient *http.Client, endpoints []string) error {
 	// Datasource URLs may legitimately target private/internal networks
 	// (local Victoria stack, in-cluster Prometheus, etc.). Match create/update
 	// policy: only reject non-http(s) and cloud metadata.
@@ -149,11 +177,11 @@ func runHTTPConnectionCheck(ctx context.Context, ds models.DataSource, endpoints
 		return fmt.Errorf("datasource url rejected")
 	}
 
-	baseURL := ds.URL
+	if httpClient == nil {
+		httpClient = newDatasourceHTTPClient(ds, 10*time.Second)
+	}
 
-	// DatasourceClient allows private/internal targets but blocks cloud
-	// metadata at dial time and on redirects (DNS rebinding / open redirect).
-	httpClient := ssrf.DatasourceClient(10 * time.Second)
+	baseURL := ds.URL
 
 	var lastErr error
 	for _, endpoint := range endpoints {
@@ -167,10 +195,6 @@ func runHTTPConnectionCheck(ctx context.Context, ds models.DataSource, endpoints
 		if err != nil {
 			lastErr = fmt.Errorf("failed to create request: %w", err)
 			continue
-		}
-
-		if err := applyDataSourceAuth(req, ds); err != nil {
-			return err
 		}
 
 		resp, err := httpClient.Do(req)

--- a/backend/internal/datasource/client_test.go
+++ b/backend/internal/datasource/client_test.go
@@ -145,6 +145,47 @@ func TestNewClient_InvalidType(t *testing.T) {
 	}
 }
 
+var (
+	_ Client                  = (*PrometheusClient)(nil)
+	_ MetricLabelsClient      = (*PrometheusClient)(nil)
+	_ MetricLabelValuesClient = (*PrometheusClient)(nil)
+	_ MetricNamesClient       = (*PrometheusClient)(nil)
+	_ connectionTester        = (*PrometheusClient)(nil)
+
+	_ Client                  = (*VictoriaMetricsClient)(nil)
+	_ MetricLabelsClient      = (*VictoriaMetricsClient)(nil)
+	_ MetricLabelValuesClient = (*VictoriaMetricsClient)(nil)
+	_ MetricNamesClient       = (*VictoriaMetricsClient)(nil)
+	_ connectionTester        = (*VictoriaMetricsClient)(nil)
+
+	_ Client            = (*LokiClient)(nil)
+	_ StreamClient      = (*LokiClient)(nil)
+	_ LabelsClient      = (*LokiClient)(nil)
+	_ LabelValuesClient = (*LokiClient)(nil)
+	_ connectionTester  = (*LokiClient)(nil)
+
+	_ Client            = (*VictoriaLogsClient)(nil)
+	_ StreamClient      = (*VictoriaLogsClient)(nil)
+	_ LabelsClient      = (*VictoriaLogsClient)(nil)
+	_ LabelValuesClient = (*VictoriaLogsClient)(nil)
+	_ connectionTester  = (*VictoriaLogsClient)(nil)
+
+	_ Client            = (*ClickHouseClient)(nil)
+	_ SignalQueryClient = (*ClickHouseClient)(nil)
+	_ connectionTester  = (*ClickHouseClient)(nil)
+
+	_ Client            = (*CloudWatchClient)(nil)
+	_ SignalQueryClient = (*CloudWatchClient)(nil)
+	_ connectionTester  = (*CloudWatchClient)(nil)
+
+	_ Client            = (*ElasticsearchClient)(nil)
+	_ SignalQueryClient = (*ElasticsearchClient)(nil)
+	_ connectionTester  = (*ElasticsearchClient)(nil)
+
+	_ connectionTester = (*TempoClient)(nil)
+	_ connectionTester = (*VictoriaTracesClient)(nil)
+)
+
 func TestDetectLogLevel(t *testing.T) {
 	tests := []struct {
 		labels map[string]string

--- a/backend/internal/datasource/elasticsearch.go
+++ b/backend/internal/datasource/elasticsearch.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 const (
@@ -69,9 +68,13 @@ func NewElasticsearchClient(ds models.DataSource) (*ElasticsearchClient, error) 
 
 	return &ElasticsearchClient{
 		datasource: ds,
-		httpClient: ssrf.DatasourceClient(30 * time.Second),
+		httpClient: newDatasourceHTTPClient(ds, 30*time.Second),
 		cfg:        cfg,
 	}, nil
+}
+
+func (c *ElasticsearchClient) TestConnection(ctx context.Context) error {
+	return runHTTPConnectionCheck(ctx, c.datasource, c.httpClient, []string{"/_cluster/health", "/_cat/indices?format=json&h=index&bytes=b", "/"})
 }
 
 func (c *ElasticsearchClient) Query(ctx context.Context, query string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error) {
@@ -218,10 +221,6 @@ func (c *ElasticsearchClient) search(ctx context.Context, index string, requestB
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-
-	if err := applyDataSourceAuth(req, c.datasource); err != nil {
-		return nil, err
-	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/backend/internal/datasource/loki.go
+++ b/backend/internal/datasource/loki.go
@@ -13,21 +13,28 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aceobservability/ace/backend/internal/models"
 	"github.com/aceobservability/ace/backend/internal/ssrf"
 	"github.com/gorilla/websocket"
 )
 
 // LokiClient queries Loki using LogQL
 type LokiClient struct {
-	baseURL string
-	client  *http.Client
+	datasource models.DataSource
+	baseURL    string
+	client     *http.Client
 }
 
-func NewLokiClient(baseURL string) (*LokiClient, error) {
+func NewLokiClient(ds models.DataSource) (*LokiClient, error) {
 	return &LokiClient{
-		baseURL: baseURL,
-		client:  ssrf.DatasourceClient(30 * time.Second),
+		datasource: ds,
+		baseURL:    ds.URL,
+		client:     newDatasourceHTTPClient(ds, 30*time.Second),
 	}, nil
+}
+
+func (c *LokiClient) TestConnection(ctx context.Context) error {
+	return runHTTPConnectionCheck(ctx, c.datasource, c.client, []string{"/ready", "/loki/api/v1/labels?limit=1", "/"})
 }
 
 type lokiQueryResponse struct {
@@ -260,9 +267,14 @@ func (c *LokiClient) Stream(ctx context.Context, query string, start time.Time, 
 		return err
 	}
 
+	header, err := dataSourceAuthHeader(c.datasource)
+	if err != nil {
+		return err
+	}
+
 	dialer := *websocket.DefaultDialer
 	dialer.NetDialContext = ssrf.DatasourceDialContext
-	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
+	conn, _, err := dialer.DialContext(ctx, wsURL, header)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Loki tail endpoint: %w", err)
 	}

--- a/backend/internal/datasource/prometheus.go
+++ b/backend/internal/datasource/prometheus.go
@@ -2,22 +2,36 @@ package datasource
 
 import (
 	"context"
+	"net/http"
 	"time"
 
-	"github.com/aceobservability/ace/backend/internal/ssrf"
+	"github.com/aceobservability/ace/backend/internal/models"
 	promclient "github.com/aceobservability/ace/backend/pkg/prometheus"
 )
 
 type PrometheusClient struct {
-	client *promclient.Client
+	datasource models.DataSource
+	client     *promclient.Client
+	httpClient *http.Client
+	meta       *VictoriaMetricsClient
 }
 
-func NewPrometheusClient(url string) (*PrometheusClient, error) {
-	client, err := promclient.NewClient(url, ssrf.DatasourceClient(30*time.Second))
+func NewPrometheusClient(ds models.DataSource) (*PrometheusClient, error) {
+	httpClient := newDatasourceHTTPClient(ds, 30*time.Second)
+	client, err := promclient.NewClient(ds.URL, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	return &PrometheusClient{client: client}, nil
+	return &PrometheusClient{
+		datasource: ds,
+		client:     client,
+		httpClient: httpClient,
+		meta: &VictoriaMetricsClient{
+			datasource: ds,
+			baseURL:    ds.URL,
+			client:     httpClient,
+		},
+	}, nil
 }
 
 func (c *PrometheusClient) Query(ctx context.Context, query string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error) {
@@ -47,4 +61,20 @@ func (c *PrometheusClient) Query(ctx context.Context, query string, start, end t
 	}
 
 	return qr, nil
+}
+
+func (c *PrometheusClient) TestConnection(ctx context.Context) error {
+	return runHTTPConnectionCheck(ctx, c.datasource, c.httpClient, []string{"/-/healthy", "/api/v1/query?query=1", "/"})
+}
+
+func (c *PrometheusClient) Labels(ctx context.Context, metric string) ([]string, error) {
+	return c.meta.Labels(ctx, metric)
+}
+
+func (c *PrometheusClient) LabelValues(ctx context.Context, label, metric string) ([]string, error) {
+	return c.meta.LabelValues(ctx, label, metric)
+}
+
+func (c *PrometheusClient) MetricNames(ctx context.Context, search string) ([]string, error) {
+	return c.meta.MetricNames(ctx, search)
 }

--- a/backend/internal/datasource/prometheus.go
+++ b/backend/internal/datasource/prometheus.go
@@ -13,7 +13,7 @@ type PrometheusClient struct {
 	datasource models.DataSource
 	client     *promclient.Client
 	httpClient *http.Client
-	meta       *VictoriaMetricsClient
+	meta       *promqlMetadata
 }
 
 func NewPrometheusClient(ds models.DataSource) (*PrometheusClient, error) {
@@ -26,10 +26,9 @@ func NewPrometheusClient(ds models.DataSource) (*PrometheusClient, error) {
 		datasource: ds,
 		client:     client,
 		httpClient: httpClient,
-		meta: &VictoriaMetricsClient{
-			datasource: ds,
-			baseURL:    ds.URL,
-			client:     httpClient,
+		meta: &promqlMetadata{
+			baseURL: ds.URL,
+			client:  httpClient,
 		},
 	}, nil
 }

--- a/backend/internal/datasource/promql_metadata.go
+++ b/backend/internal/datasource/promql_metadata.go
@@ -1,0 +1,150 @@
+package datasource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// promqlMetadata is the PromQL labels/values/metric-names API shared by
+// Prometheus and VictoriaMetrics. Paths are /api/v1/labels and
+// /api/v1/label/{}/values — not vendor-specific.
+type promqlMetadata struct {
+	baseURL string
+	client  *http.Client
+}
+
+type promqlMetadataResponse struct {
+	Status string   `json:"status"`
+	Data   []string `json:"data"`
+	Error  string   `json:"error,omitempty"`
+}
+
+// MetricNames returns metric names via GET /api/v1/label/__name__/values,
+// optionally filtered by a case-insensitive substring match.
+func (m *promqlMetadata) MetricNames(ctx context.Context, search string) ([]string, error) {
+	reqURL := fmt.Sprintf("%s/api/v1/label/__name__/values", m.baseURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric names request: %w", err)
+	}
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch metric names: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metric names response: %w", err)
+	}
+
+	var metaResp promqlMetadataResponse
+	if err := json.Unmarshal(body, &metaResp); err != nil {
+		return nil, fmt.Errorf("failed to parse metric names response: %w", err)
+	}
+
+	if metaResp.Status != "success" {
+		return nil, fmt.Errorf("metric names query failed: %s", metaResp.Error)
+	}
+
+	if search == "" {
+		return metaResp.Data, nil
+	}
+
+	searchLower := strings.ToLower(search)
+	var filtered []string
+	for _, name := range metaResp.Data {
+		if strings.Contains(strings.ToLower(name), searchLower) {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered, nil
+}
+
+// Labels returns label names via GET /api/v1/labels, optionally scoped to a
+// metric selector via match[].
+func (m *promqlMetadata) Labels(ctx context.Context, metric string) ([]string, error) {
+	params := url.Values{}
+	if metric != "" {
+		params.Set("match[]", metric)
+	}
+
+	reqURL := fmt.Sprintf("%s/api/v1/labels", m.baseURL)
+	if len(params) > 0 {
+		reqURL += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create labels request: %w", err)
+	}
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch labels: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read labels response: %w", err)
+	}
+
+	var metaResp promqlMetadataResponse
+	if err := json.Unmarshal(body, &metaResp); err != nil {
+		return nil, fmt.Errorf("failed to parse labels response: %w", err)
+	}
+
+	if metaResp.Status != "success" {
+		return nil, fmt.Errorf("labels query failed: %s", metaResp.Error)
+	}
+
+	return metaResp.Data, nil
+}
+
+// LabelValues returns values for a label via GET /api/v1/label/{label}/values,
+// optionally scoped to a metric selector via match[].
+func (m *promqlMetadata) LabelValues(ctx context.Context, label string, metric string) ([]string, error) {
+	params := url.Values{}
+	if metric != "" {
+		params.Set("match[]", metric)
+	}
+
+	reqURL := fmt.Sprintf("%s/api/v1/label/%s/values", m.baseURL, url.PathEscape(label))
+	if len(params) > 0 {
+		reqURL += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create label values request: %w", err)
+	}
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch label values: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read label values response: %w", err)
+	}
+
+	var metaResp promqlMetadataResponse
+	if err := json.Unmarshal(body, &metaResp); err != nil {
+		return nil, fmt.Errorf("failed to parse label values response: %w", err)
+	}
+
+	if metaResp.Status != "success" {
+		return nil, fmt.Errorf("label values query failed: %s", metaResp.Error)
+	}
+
+	return metaResp.Data, nil
+}

--- a/backend/internal/datasource/query_auth_test.go
+++ b/backend/internal/datasource/query_auth_test.go
@@ -1,0 +1,234 @@
+package datasource
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/gorilla/websocket"
+)
+
+func bearerDS(typ models.DataSourceType, rawURL, token string) models.DataSource {
+	return models.DataSource{
+		Type:       typ,
+		URL:        rawURL,
+		AuthType:   "bearer",
+		AuthConfig: []byte(`{"token":"` + token + `"}`),
+	}
+}
+
+func requireBearer(t *testing.T, r *http.Request, token string) {
+	t.Helper()
+	want := "Bearer " + token
+	if got := r.Header.Get("Authorization"); got != want {
+		t.Fatalf("authorization header = %q, want %q", got, want)
+	}
+}
+
+func TestQuerySendsStoredCredentials(t *testing.T) {
+	t.Parallel()
+
+	const token = "query-secret"
+
+	tests := []struct {
+		name    string
+		typ     models.DataSourceType
+		newFn   func(models.DataSource) (Client, error)
+		query   string
+		handler http.HandlerFunc
+	}{
+		{
+			name:  "prometheus",
+			typ:   models.DataSourcePrometheus,
+			newFn: func(ds models.DataSource) (Client, error) { return NewPrometheusClient(ds) },
+			query: "up",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				requireBearer(t, r, token)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+			},
+		},
+		{
+			name:  "victoriametrics",
+			typ:   models.DataSourceVictoriaMetrics,
+			newFn: func(ds models.DataSource) (Client, error) { return NewVictoriaMetricsClient(ds) },
+			query: "up",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				requireBearer(t, r, token)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+			},
+		},
+		{
+			name:  "loki",
+			typ:   models.DataSourceLoki,
+			newFn: func(ds models.DataSource) (Client, error) { return NewLokiClient(ds) },
+			query: `{job="ace"}`,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				requireBearer(t, r, token)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
+			},
+		},
+		{
+			name:  "victorialogs",
+			typ:   models.DataSourceVictoriaLogs,
+			newFn: func(ds models.DataSource) (Client, error) { return NewVictoriaLogsClient(ds) },
+			query: "*",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				requireBearer(t, r, token)
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(tt.handler)
+			t.Cleanup(srv.Close)
+
+			client, err := tt.newFn(bearerDS(tt.typ, srv.URL, token))
+			if err != nil {
+				t.Fatalf("constructor: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			if _, err := client.Query(ctx, tt.query, time.Now().Add(-time.Hour), time.Now(), time.Minute, 10); err != nil {
+				t.Fatalf("query: %v", err)
+			}
+		})
+	}
+}
+
+func TestLokiStreamSendsStoredCredentialsOnWebsocketHeaders(t *testing.T) {
+	t.Parallel()
+
+	const token = "stream-secret"
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	var (
+		mu      sync.Mutex
+		gotAuth string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		payload, _ := json.Marshal(lokiTailResponse{
+			Streams: []struct {
+				Stream map[string]string `json:"stream"`
+				Values [][]string        `json:"values"`
+			}{
+				{
+					Stream: map[string]string{"job": "ace"},
+					Values: [][]string{{"1700000000000000000", "hello"}},
+				},
+			},
+		})
+		_ = conn.WriteMessage(websocket.TextMessage, payload)
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewLokiClient(bearerDS(models.DataSourceLoki, srv.URL, token))
+	if err != nil {
+		t.Fatalf("NewLokiClient: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = client.Stream(ctx, `{job="ace"}`, time.Time{}, 1, func(LogEntry) error {
+		cancel()
+		return context.Canceled
+	})
+	if err != nil && err != context.Canceled && ctx.Err() == nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAuth != "Bearer "+token {
+		t.Fatalf("websocket authorization header = %q, want Bearer %s", gotAuth, token)
+	}
+}
+
+func TestTestConnectionUsesNewClientAuth(t *testing.T) {
+	t.Parallel()
+
+	const token = "test-conn-secret"
+	var sawAuth bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			t.Errorf("authorization header = %q, want Bearer %s", r.Header.Get("Authorization"), token)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		sawAuth = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "OK")
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := bearerDS(models.DataSourcePrometheus, srv.URL, token)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := TestConnection(ctx, ds); err != nil {
+		t.Fatalf("TestConnection: %v", err)
+	}
+	if !sawAuth {
+		t.Fatal("expected Test Connection to send stored credentials")
+	}
+}
+
+func TestLokiLabelsSendsStoredCredentials(t *testing.T) {
+	t.Parallel()
+
+	const token = "labels-secret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireBearer(t, r, token)
+		if !strings.Contains(r.URL.Path, "/loki/api/v1/labels") {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":["job","level"]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewLokiClient(bearerDS(models.DataSourceLoki, srv.URL, token))
+	if err != nil {
+		t.Fatalf("NewLokiClient: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	labels, err := client.Labels(ctx)
+	if err != nil {
+		t.Fatalf("Labels: %v", err)
+	}
+	if len(labels) != 2 {
+		t.Fatalf("expected 2 labels, got %d", len(labels))
+	}
+}

--- a/backend/internal/datasource/ssrf_client_test.go
+++ b/backend/internal/datasource/ssrf_client_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/aceobservability/ace/backend/internal/models"
 )
 
+func testDS(typ models.DataSourceType, rawURL string) models.DataSource {
+	return models.DataSource{Type: typ, URL: rawURL}
+}
+
 const cloudMetadataURL = "http://169.254.169.254/"
 
 func TestDatasourceClientsWireDialAndRedirectPolicy(t *testing.T) {
@@ -33,7 +37,7 @@ func TestDatasourceClientsWireDialAndRedirectPolicy(t *testing.T) {
 	}
 
 	t.Run("victorialogs_stream_timeout", func(t *testing.T) {
-		c, err := NewVictoriaLogsClient("http://127.0.0.1:9428")
+		c, err := NewVictoriaLogsClient(testDS(models.DataSourceVictoriaLogs, "http://127.0.0.1:9428"))
 		if err != nil {
 			t.Fatalf("NewVictoriaLogsClient: %v", err)
 		}
@@ -103,7 +107,7 @@ func TestDatasourceClientsBlockMetadataRedirect(t *testing.T) {
 func TestLokiStreamBlocksMetadata(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewLokiClient(strings.TrimRight(cloudMetadataURL, "/"))
+	client, err := NewLokiClient(testDS(models.DataSourceLoki, strings.TrimRight(cloudMetadataURL, "/")))
 	if err != nil {
 		t.Fatalf("NewLokiClient failed: %v", err)
 	}
@@ -120,7 +124,7 @@ func TestLokiStreamBlocksMetadata(t *testing.T) {
 func TestVictoriaLogsStreamBlocksMetadata(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewVictoriaLogsClient(strings.TrimRight(cloudMetadataURL, "/"))
+	client, err := NewVictoriaLogsClient(testDS(models.DataSourceVictoriaLogs, strings.TrimRight(cloudMetadataURL, "/")))
 	if err != nil {
 		t.Fatalf("NewVictoriaLogsClient failed: %v", err)
 	}
@@ -147,15 +151,19 @@ func isOutboundPolicyError(err error) bool {
 func constructedDatasourceHTTPClients(t *testing.T) map[string]*http.Client {
 	t.Helper()
 
-	vm, err := NewVictoriaMetricsClient("http://127.0.0.1:8428")
+	prom, err := NewPrometheusClient(testDS(models.DataSourcePrometheus, "http://127.0.0.1:9090"))
+	if err != nil {
+		t.Fatalf("NewPrometheusClient: %v", err)
+	}
+	vm, err := NewVictoriaMetricsClient(testDS(models.DataSourceVictoriaMetrics, "http://127.0.0.1:8428"))
 	if err != nil {
 		t.Fatalf("NewVictoriaMetricsClient: %v", err)
 	}
-	loki, err := NewLokiClient("http://127.0.0.1:3100")
+	loki, err := NewLokiClient(testDS(models.DataSourceLoki, "http://127.0.0.1:3100"))
 	if err != nil {
 		t.Fatalf("NewLokiClient: %v", err)
 	}
-	vlogs, err := NewVictoriaLogsClient("http://127.0.0.1:9428")
+	vlogs, err := NewVictoriaLogsClient(testDS(models.DataSourceVictoriaLogs, "http://127.0.0.1:9428"))
 	if err != nil {
 		t.Fatalf("NewVictoriaLogsClient: %v", err)
 	}
@@ -185,6 +193,7 @@ func constructedDatasourceHTTPClients(t *testing.T) map[string]*http.Client {
 	}
 
 	return map[string]*http.Client{
+		"prometheus":          prom.httpClient,
 		"victoriametrics":     vm.client,
 		"loki":                loki.client,
 		"victorialogs":        vlogs.client,
@@ -201,7 +210,7 @@ func constructedDatasourceHTTPClients(t *testing.T) map[string]*http.Client {
 func datasourceQueryFns() map[string]func(context.Context, string) error {
 	return map[string]func(context.Context, string) error{
 		"prometheus": func(ctx context.Context, baseURL string) error {
-			client, err := NewPrometheusClient(baseURL)
+			client, err := NewPrometheusClient(testDS(models.DataSourcePrometheus, baseURL))
 			if err != nil {
 				return err
 			}
@@ -215,7 +224,7 @@ func datasourceQueryFns() map[string]func(context.Context, string) error {
 			return nil
 		},
 		"victoriametrics": func(ctx context.Context, baseURL string) error {
-			client, err := NewVictoriaMetricsClient(baseURL)
+			client, err := NewVictoriaMetricsClient(testDS(models.DataSourceVictoriaMetrics, baseURL))
 			if err != nil {
 				return err
 			}
@@ -223,7 +232,7 @@ func datasourceQueryFns() map[string]func(context.Context, string) error {
 			return err
 		},
 		"loki": func(ctx context.Context, baseURL string) error {
-			client, err := NewLokiClient(baseURL)
+			client, err := NewLokiClient(testDS(models.DataSourceLoki, baseURL))
 			if err != nil {
 				return err
 			}
@@ -231,7 +240,7 @@ func datasourceQueryFns() map[string]func(context.Context, string) error {
 			return err
 		},
 		"victorialogs": func(ctx context.Context, baseURL string) error {
-			client, err := NewVictoriaLogsClient(baseURL)
+			client, err := NewVictoriaLogsClient(testDS(models.DataSourceVictoriaLogs, baseURL))
 			if err != nil {
 				return err
 			}

--- a/backend/internal/datasource/ssrf_client_test.go
+++ b/backend/internal/datasource/ssrf_client_test.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 func testDS(typ models.DataSourceType, rawURL string) models.DataSource {
@@ -21,6 +23,8 @@ const cloudMetadataURL = "http://169.254.169.254/"
 func TestDatasourceClientsWireDialAndRedirectPolicy(t *testing.T) {
 	t.Parallel()
 
+	policyType := reflect.TypeOf(ssrf.DatasourceClient(time.Second).Transport)
+
 	clients := constructedDatasourceHTTPClients(t)
 	for name, client := range clients {
 		t.Run(name, func(t *testing.T) {
@@ -30,8 +34,18 @@ func TestDatasourceClientsWireDialAndRedirectPolicy(t *testing.T) {
 			if client.CheckRedirect == nil {
 				t.Fatal("expected DatasourceClient redirect policy (CheckRedirect)")
 			}
-			if client.Transport == nil {
-				t.Fatal("expected DatasourceClient dial policy (Transport)")
+			authRT, ok := client.Transport.(*dataSourceAuthRoundTripper)
+			if !ok {
+				t.Fatalf("Transport type %T, want *dataSourceAuthRoundTripper", client.Transport)
+			}
+			if authRT.base == nil {
+				t.Fatal("auth round tripper inner transport is nil")
+			}
+			if authRT.base == http.DefaultTransport {
+				t.Fatal("auth round tripper must not fall back to http.DefaultTransport")
+			}
+			if got := reflect.TypeOf(authRT.base); got != policyType {
+				t.Fatalf("inner transport type %s, want DatasourceClient policy %s", got, policyType)
 			}
 		})
 	}

--- a/backend/internal/datasource/tempo.go
+++ b/backend/internal/datasource/tempo.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // TempoClient is used for trace datasource connectivity checks.
@@ -25,7 +24,7 @@ func NewTempoClient(ds models.DataSource) (*TempoClient, error) {
 
 	return &TempoClient{
 		datasource: ds,
-		httpClient: ssrf.DatasourceClient(15 * time.Second),
+		httpClient: newDatasourceHTTPClient(ds, 15*time.Second),
 	}, nil
 }
 
@@ -41,7 +40,7 @@ func (c *TempoClient) Query(ctx context.Context, query string, start, end time.T
 }
 
 func (c *TempoClient) TestConnection(ctx context.Context) error {
-	return runHTTPConnectionCheck(ctx, c.datasource, []string{"/ready", "/api/search?limit=1", "/"})
+	return runHTTPConnectionCheck(ctx, c.datasource, c.httpClient, []string{"/ready", "/api/search?limit=1", "/"})
 }
 
 func (c *TempoClient) GetTrace(ctx context.Context, traceID string) (*Trace, error) {

--- a/backend/internal/datasource/tracing.go
+++ b/backend/internal/datasource/tracing.go
@@ -287,10 +287,6 @@ func doTracingRequest(ctx context.Context, httpClient *http.Client, ds models.Da
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	if err := applyDataSourceAuth(req, ds); err != nil {
-		return nil, err
-	}
-
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)

--- a/backend/internal/datasource/victorialogs.go
+++ b/backend/internal/datasource/victorialogs.go
@@ -13,22 +13,28 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aceobservability/ace/backend/internal/ssrf"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // VictoriaLogsClient queries Victoria Logs using LogsQL
 type VictoriaLogsClient struct {
+	datasource   models.DataSource
 	baseURL      string
 	client       *http.Client
 	streamClient *http.Client
 }
 
-func NewVictoriaLogsClient(baseURL string) (*VictoriaLogsClient, error) {
+func NewVictoriaLogsClient(ds models.DataSource) (*VictoriaLogsClient, error) {
 	return &VictoriaLogsClient{
-		baseURL:      baseURL,
-		client:       ssrf.DatasourceClient(30 * time.Second),
-		streamClient: ssrf.DatasourceClient(0), // Timeout 0: long-lived tails
+		datasource:   ds,
+		baseURL:      ds.URL,
+		client:       newDatasourceHTTPClient(ds, 30*time.Second),
+		streamClient: newDatasourceHTTPClient(ds, 0), // Timeout 0: long-lived tails
 	}, nil
+}
+
+func (c *VictoriaLogsClient) TestConnection(ctx context.Context) error {
+	return runHTTPConnectionCheck(ctx, c.datasource, c.client, []string{"/health", "/select/logsql/field_names?query=*", "/"})
 }
 
 type victoriaLogsFieldNamesResponse struct {

--- a/backend/internal/datasource/victoriametrics.go
+++ b/backend/internal/datasource/victoriametrics.go
@@ -11,20 +11,26 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aceobservability/ace/backend/internal/ssrf"
+	"github.com/aceobservability/ace/backend/internal/models"
 )
 
 // VictoriaMetricsClient queries VictoriaMetrics using PromQL-compatible API
 type VictoriaMetricsClient struct {
-	baseURL string
-	client  *http.Client
+	datasource models.DataSource
+	baseURL    string
+	client     *http.Client
 }
 
-func NewVictoriaMetricsClient(baseURL string) (*VictoriaMetricsClient, error) {
+func NewVictoriaMetricsClient(ds models.DataSource) (*VictoriaMetricsClient, error) {
 	return &VictoriaMetricsClient{
-		baseURL: baseURL,
-		client:  ssrf.DatasourceClient(30 * time.Second),
+		datasource: ds,
+		baseURL:    ds.URL,
+		client:     newDatasourceHTTPClient(ds, 30*time.Second),
 	}, nil
+}
+
+func (c *VictoriaMetricsClient) TestConnection(ctx context.Context) error {
+	return runHTTPConnectionCheck(ctx, c.datasource, c.client, []string{"/health", "/api/v1/query?query=1", "/"})
 }
 
 type vmQueryResponse struct {

--- a/backend/internal/datasource/victoriametrics.go
+++ b/backend/internal/datasource/victoriametrics.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
@@ -19,13 +18,19 @@ type VictoriaMetricsClient struct {
 	datasource models.DataSource
 	baseURL    string
 	client     *http.Client
+	meta       *promqlMetadata
 }
 
 func NewVictoriaMetricsClient(ds models.DataSource) (*VictoriaMetricsClient, error) {
+	httpClient := newDatasourceHTTPClient(ds, 30*time.Second)
 	return &VictoriaMetricsClient{
 		datasource: ds,
 		baseURL:    ds.URL,
-		client:     newDatasourceHTTPClient(ds, 30*time.Second),
+		client:     httpClient,
+		meta: &promqlMetadata{
+			baseURL: ds.URL,
+			client:  httpClient,
+		},
 	}, nil
 }
 
@@ -101,135 +106,14 @@ func (c *VictoriaMetricsClient) Query(ctx context.Context, query string, start, 
 	return result, nil
 }
 
-// vmMetadataResponse represents the standard VictoriaMetrics JSON response
-// for metadata endpoints that return string arrays.
-type vmMetadataResponse struct {
-	Status string   `json:"status"`
-	Data   []string `json:"data"`
-	Error  string   `json:"error,omitempty"`
-}
-
-// MetricNames returns all metric names from VictoriaMetrics, optionally filtered
-// by a case-insensitive substring match on the search parameter.
 func (c *VictoriaMetricsClient) MetricNames(ctx context.Context, search string) ([]string, error) {
-	reqURL := fmt.Sprintf("%s/api/v1/label/__name__/values", c.baseURL)
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create metric names request: %w", err)
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch metric names: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read metric names response: %w", err)
-	}
-
-	var vmResp vmMetadataResponse
-	if err := json.Unmarshal(body, &vmResp); err != nil {
-		return nil, fmt.Errorf("failed to parse metric names response: %w", err)
-	}
-
-	if vmResp.Status != "success" {
-		return nil, fmt.Errorf("metric names query failed: %s", vmResp.Error)
-	}
-
-	if search == "" {
-		return vmResp.Data, nil
-	}
-
-	searchLower := strings.ToLower(search)
-	var filtered []string
-	for _, name := range vmResp.Data {
-		if strings.Contains(strings.ToLower(name), searchLower) {
-			filtered = append(filtered, name)
-		}
-	}
-	return filtered, nil
+	return c.meta.MetricNames(ctx, search)
 }
 
-// Labels returns all label names from VictoriaMetrics, optionally scoped to a
-// specific metric via the match[] query parameter.
 func (c *VictoriaMetricsClient) Labels(ctx context.Context, metric string) ([]string, error) {
-	params := url.Values{}
-	if metric != "" {
-		params.Set("match[]", metric)
-	}
-
-	reqURL := fmt.Sprintf("%s/api/v1/labels", c.baseURL)
-	if len(params) > 0 {
-		reqURL += "?" + params.Encode()
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create labels request: %w", err)
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch labels: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read labels response: %w", err)
-	}
-
-	var vmResp vmMetadataResponse
-	if err := json.Unmarshal(body, &vmResp); err != nil {
-		return nil, fmt.Errorf("failed to parse labels response: %w", err)
-	}
-
-	if vmResp.Status != "success" {
-		return nil, fmt.Errorf("labels query failed: %s", vmResp.Error)
-	}
-
-	return vmResp.Data, nil
+	return c.meta.Labels(ctx, metric)
 }
 
-// LabelValues returns all values for a given label from VictoriaMetrics,
-// optionally scoped to a specific metric via the match[] query parameter.
 func (c *VictoriaMetricsClient) LabelValues(ctx context.Context, label string, metric string) ([]string, error) {
-	params := url.Values{}
-	if metric != "" {
-		params.Set("match[]", metric)
-	}
-
-	reqURL := fmt.Sprintf("%s/api/v1/label/%s/values", c.baseURL, url.PathEscape(label))
-	if len(params) > 0 {
-		reqURL += "?" + params.Encode()
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create label values request: %w", err)
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch label values: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read label values response: %w", err)
-	}
-
-	var vmResp vmMetadataResponse
-	if err := json.Unmarshal(body, &vmResp); err != nil {
-		return nil, fmt.Errorf("failed to parse label values response: %w", err)
-	}
-
-	if vmResp.Status != "success" {
-		return nil, fmt.Errorf("label values query failed: %s", vmResp.Error)
-	}
-
-	return vmResp.Data, nil
+	return c.meta.LabelValues(ctx, label, metric)
 }

--- a/backend/internal/datasource/victoriatraces.go
+++ b/backend/internal/datasource/victoriatraces.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // VictoriaTracesClient is used for trace datasource connectivity checks.
@@ -25,7 +24,7 @@ func NewVictoriaTracesClient(ds models.DataSource) (*VictoriaTracesClient, error
 
 	return &VictoriaTracesClient{
 		datasource: ds,
-		httpClient: ssrf.DatasourceClient(15 * time.Second),
+		httpClient: newDatasourceHTTPClient(ds, 15*time.Second),
 	}, nil
 }
 
@@ -41,7 +40,7 @@ func (c *VictoriaTracesClient) Query(ctx context.Context, query string, start, e
 }
 
 func (c *VictoriaTracesClient) TestConnection(ctx context.Context) error {
-	return runHTTPConnectionCheck(ctx, c.datasource, []string{"/health", "/ready", "/"})
+	return runHTTPConnectionCheck(ctx, c.datasource, c.httpClient, []string{"/health", "/ready", "/"})
 }
 
 func (c *VictoriaTracesClient) GetTrace(ctx context.Context, traceID string) (*Trace, error) {

--- a/backend/internal/datasource/vmalert.go
+++ b/backend/internal/datasource/vmalert.go
@@ -9,14 +9,12 @@ import (
 	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
-	"github.com/aceobservability/ace/backend/internal/ssrf"
 )
 
 // VMAlertClient wraps HTTP calls to VMAlert's API.
 type VMAlertClient struct {
-	baseURL    string
-	client     *http.Client
-	datasource models.DataSource
+	baseURL string
+	client  *http.Client
 }
 
 // NewVMAlertClient creates a new VMAlert client from a datasource record.
@@ -25,9 +23,8 @@ func NewVMAlertClient(ds models.DataSource) (*VMAlertClient, error) {
 		return nil, fmt.Errorf("vmalert datasource URL is required")
 	}
 	return &VMAlertClient{
-		baseURL:    ds.URL,
-		client:     ssrf.DatasourceClient(30 * time.Second),
-		datasource: ds,
+		baseURL: ds.URL,
+		client:  newDatasourceHTTPClient(ds, 30*time.Second),
 	}, nil
 }
 
@@ -105,10 +102,6 @@ func (c *VMAlertClient) Health(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create health request: %w", err)
 	}
-	if err := applyDataSourceAuth(req, c.datasource); err != nil {
-		return err
-	}
-
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("health check failed: %w", err)
@@ -128,10 +121,6 @@ func doVMAlertRequest[T any](ctx context.Context, c *VMAlertClient, path string)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %s: %w", path, err)
 	}
-	if err := applyDataSourceAuth(req, c.datasource); err != nil {
-		return nil, err
-	}
-
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request to %s failed: %w", path, err)

--- a/backend/internal/handlers/datasource.go
+++ b/backend/internal/handlers/datasource.go
@@ -518,94 +518,29 @@ func (h *DataSourceHandler) Query(w http.ResponseWriter, r *http.Request) {
 	var result *datasource.QueryResult
 	var queryErr error
 
-	switch ds.Type {
-	case models.DataSourceClickHouse:
-		clickHouseClient, clientErr := datasource.NewClickHouseClient(ds)
-		if clientErr != nil {
-			analytics.Track(r.Context(), analytics.Event{
-				DistinctID: userID.String(),
-				Name:       "datasource_query_failed",
-				OptOut:     analytics.RequestOptedOut(r),
-				Properties: map[string]any{
-					"user_id":         userID.String(),
-					"organization_id": ds.OrganizationID.String(),
-					"datasource_id":   ds.ID.String(),
-					"datasource_type": ds.Type,
-					"error":           clientErr.Error(),
-				},
-			})
+	client, clientErr := datasource.NewClient(ds)
+	if clientErr != nil {
+		analytics.Track(r.Context(), analytics.Event{
+			DistinctID: userID.String(),
+			Name:       "datasource_query_failed",
+			OptOut:     analytics.RequestOptedOut(r),
+			Properties: map[string]any{
+				"user_id":         userID.String(),
+				"organization_id": ds.OrganizationID.String(),
+				"datasource_id":   ds.ID.String(),
+				"datasource_type": ds.Type,
+				"error":           clientErr.Error(),
+			},
+		})
 
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
+		return
+	}
 
-		result, queryErr = clickHouseClient.QueryWithSignal(ctx, queryReq.Query, signal, start, end, step, queryReq.Limit)
-	case models.DataSourceCloudWatch:
-		cloudWatchClient, clientErr := datasource.NewCloudWatchClient(ds)
-		if clientErr != nil {
-			analytics.Track(r.Context(), analytics.Event{
-				DistinctID: userID.String(),
-				Name:       "datasource_query_failed",
-				OptOut:     analytics.RequestOptedOut(r),
-				Properties: map[string]any{
-					"user_id":         userID.String(),
-					"organization_id": ds.OrganizationID.String(),
-					"datasource_id":   ds.ID.String(),
-					"datasource_type": ds.Type,
-					"error":           clientErr.Error(),
-				},
-			})
-
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
-
-		result, queryErr = cloudWatchClient.QueryWithSignal(ctx, queryReq.Query, signal, start, end, step, queryReq.Limit)
-	case models.DataSourceElasticsearch:
-		elasticsearchClient, clientErr := datasource.NewElasticsearchClient(ds)
-		if clientErr != nil {
-			analytics.Track(r.Context(), analytics.Event{
-				DistinctID: userID.String(),
-				Name:       "datasource_query_failed",
-				OptOut:     analytics.RequestOptedOut(r),
-				Properties: map[string]any{
-					"user_id":         userID.String(),
-					"organization_id": ds.OrganizationID.String(),
-					"datasource_id":   ds.ID.String(),
-					"datasource_type": ds.Type,
-					"error":           clientErr.Error(),
-				},
-			})
-
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
-
-		result, queryErr = elasticsearchClient.QueryWithSignal(ctx, queryReq.Query, signal, start, end, step, queryReq.Limit)
-	default:
-		client, clientErr := datasource.NewClient(ds)
-		if clientErr != nil {
-			analytics.Track(r.Context(), analytics.Event{
-				DistinctID: userID.String(),
-				Name:       "datasource_query_failed",
-				OptOut:     analytics.RequestOptedOut(r),
-				Properties: map[string]any{
-					"user_id":         userID.String(),
-					"organization_id": ds.OrganizationID.String(),
-					"datasource_id":   ds.ID.String(),
-					"datasource_type": ds.Type,
-					"error":           clientErr.Error(),
-				},
-			})
-
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
-
+	if qws, ok := client.(datasource.SignalQueryClient); ok {
+		result, queryErr = qws.QueryWithSignal(ctx, queryReq.Query, signal, start, end, step, queryReq.Limit)
+	} else {
 		result, queryErr = client.Query(ctx, queryReq.Query, start, end, step, queryReq.Limit)
 	}
 
@@ -1220,22 +1155,12 @@ func (h *DataSourceHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var streamErr error
-		switch ds.Type {
-		case models.DataSourceLoki:
-			client, err := datasource.NewLokiClient(ds.URL)
-			if err != nil {
-				streamErr = fmt.Errorf("failed to create datasource client: %w", err)
-				break
-			}
-			streamErr = client.Stream(streamCtx, streamQuery, start, limit, onLog)
-		case models.DataSourceVictoriaLogs:
-			client, err := datasource.NewVictoriaLogsClient(ds.URL)
-			if err != nil {
-				streamErr = fmt.Errorf("failed to create datasource client: %w", err)
-				break
-			}
-			streamErr = client.Stream(streamCtx, streamQuery, start, limit, onLog)
-		default:
+		client, err := datasource.NewClient(ds)
+		if err != nil {
+			streamErr = fmt.Errorf("failed to create datasource client: %w", err)
+		} else if streamer, ok := client.(datasource.StreamClient); ok {
+			streamErr = streamer.Stream(streamCtx, streamQuery, start, limit, onLog)
+		} else {
 			streamErr = fmt.Errorf("live streaming is only supported for log datasources")
 		}
 
@@ -1305,57 +1230,28 @@ func (h *DataSourceHandler) Labels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	client, err := datasource.NewClient(ds)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
+		return
+	}
+
+	metric := r.URL.Query().Get("metric")
 	var labels []string
-	switch ds.Type {
-	case models.DataSourceLoki:
-		client, err := datasource.NewLokiClient(ds.URL)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
-			return
-		}
-
-		labels, err = client.Labels(ctx)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch labels: " + err.Error()})
-			return
-		}
-
-	case models.DataSourceVictoriaLogs:
-		client, err := datasource.NewVictoriaLogsClient(ds.URL)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
-			return
-		}
-
-		labels, err = client.Labels(ctx)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch labels: " + err.Error()})
-			return
-		}
-
-	case models.DataSourceVictoriaMetrics, models.DataSourcePrometheus:
-		client, err := datasource.NewVictoriaMetricsClient(ds.URL)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
-			return
-		}
-
-		metric := r.URL.Query().Get("metric")
-		labels, err = client.Labels(ctx, metric)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch labels: " + err.Error()})
-			return
-		}
-
+	switch c := client.(type) {
+	case datasource.MetricLabelsClient:
+		labels, err = c.Labels(ctx, metric)
+	case datasource.LabelsClient:
+		labels, err = c.Labels(ctx)
 	default:
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "label discovery is not supported for this datasource type"})
+		return
+	}
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch labels: " + err.Error()})
 		return
 	}
 
@@ -1408,55 +1304,28 @@ func (h *DataSourceHandler) LabelValues(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	client, err := datasource.NewClient(ds)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
+		return
+	}
+
+	metric := r.URL.Query().Get("metric")
 	var values []string
-	switch ds.Type {
-	case models.DataSourceLoki:
-		client, err := datasource.NewLokiClient(ds.URL)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
-			return
-		}
-
-		values, err = client.LabelValues(ctx, labelName)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch label values: " + err.Error()})
-			return
-		}
-	case models.DataSourceVictoriaLogs:
-		client, err := datasource.NewVictoriaLogsClient(ds.URL)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
-			return
-		}
-
-		values, err = client.LabelValues(ctx, labelName)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch label values: " + err.Error()})
-			return
-		}
-	case models.DataSourceVictoriaMetrics, models.DataSourcePrometheus:
-		client, err := datasource.NewVictoriaMetricsClient(ds.URL)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
-			return
-		}
-
-		metric := r.URL.Query().Get("metric")
-		values, err = client.LabelValues(ctx, labelName, metric)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch label values: " + err.Error()})
-			return
-		}
-
+	switch c := client.(type) {
+	case datasource.MetricLabelValuesClient:
+		values, err = c.LabelValues(ctx, labelName, metric)
+	case datasource.LabelValuesClient:
+		values, err = c.LabelValues(ctx, labelName)
 	default:
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "label value discovery is not supported for this datasource type"})
+		return
+	}
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch label values: " + err.Error()})
 		return
 	}
 
@@ -1503,27 +1372,25 @@ func (h *DataSourceHandler) MetricNames(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var names []string
-	switch ds.Type {
-	case models.DataSourceVictoriaMetrics, models.DataSourcePrometheus:
-		client, err := datasource.NewVictoriaMetricsClient(ds.URL)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
-			return
-		}
+	client, err := datasource.NewClient(ds)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + err.Error()})
+		return
+	}
 
-		search := r.URL.Query().Get("search")
-		names, err = client.MetricNames(ctx, search)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch metric names: " + err.Error()})
-			return
-		}
-
-	default:
+	namesClient, ok := client.(datasource.MetricNamesClient)
+	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "metric name discovery is only supported for Prometheus and VictoriaMetrics datasources"})
+		return
+	}
+
+	search := r.URL.Query().Get("search")
+	names, err := namesClient.MetricNames(ctx, search)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to fetch metric names: " + err.Error()})
 		return
 	}
 
@@ -1610,45 +1477,18 @@ func (h *DataSourceHandler) QueryByParams(w http.ResponseWriter, r *http.Request
 
 	signal := strings.TrimSpace(r.URL.Query().Get("signal"))
 
+	client, clientErr := datasource.NewClient(ds)
+	if clientErr != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
+		return
+	}
+
 	var result *datasource.QueryResult
 	var queryErr error
-
-	switch ds.Type {
-	case models.DataSourceClickHouse:
-		clickHouseClient, clientErr := datasource.NewClickHouseClient(ds)
-		if clientErr != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
-
-		result, queryErr = clickHouseClient.QueryWithSignal(ctx, query, signal, start, end, step, limit)
-	case models.DataSourceCloudWatch:
-		cloudWatchClient, clientErr := datasource.NewCloudWatchClient(ds)
-		if clientErr != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
-
-		result, queryErr = cloudWatchClient.QueryWithSignal(ctx, query, signal, start, end, step, limit)
-	case models.DataSourceElasticsearch:
-		elasticsearchClient, clientErr := datasource.NewElasticsearchClient(ds)
-		if clientErr != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
-
-		result, queryErr = elasticsearchClient.QueryWithSignal(ctx, query, signal, start, end, step, limit)
-	default:
-		client, clientErr := datasource.NewClient(ds)
-		if clientErr != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "failed to create datasource client: " + clientErr.Error()})
-			return
-		}
-
+	if qws, ok := client.(datasource.SignalQueryClient); ok {
+		result, queryErr = qws.QueryWithSignal(ctx, query, signal, start, end, step, limit)
+	} else {
 		result, queryErr = client.Query(ctx, query, start, end, step, limit)
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #381 (parent: #373)

Datasources with stored credentials now send them on query/stream/labels, not only Test Connection. Auth is composed onto `ssrf.DatasourceClient` via an authenticated `RoundTripper` inside `internal/datasource` — **`ssrf.go` pin/proxy/TLS is unchanged**.

## Changes

### Authenticated HTTP adapter

- Constructors call `ssrf.DatasourceClient(timeout)` then wrap with `dataSourceAuthRoundTripper` (per-type timeouts stay: 15s / 30s / stream 0).
- One credential helper, two call sites: HTTP transport + Loki websocket request headers.
- Loki `Stream` still dials with `ssrf.DatasourceDialContext`.
- `applyDataSourceAuth` stays unexported inside that helper. Test Connection and query both go through `NewClient(ds)` (or the same wrap for VMAlert/AlertManager health).

### Widen `Client`

`NewClient` / vendor constructors take `models.DataSource`. Capability interfaces:

- `Query` (base `Client`)
- `SignalQueryClient` (`QueryWithSignal`) — ClickHouse, CloudWatch, Elasticsearch
- `StreamClient` — Loki, VictoriaLogs
- `LabelsClient` / `MetricLabelsClient` / `LabelValuesClient` / `MetricLabelValuesClient` / `MetricNamesClient`

Handler path: load row, check membership, `NewClient(ds)`, call. No URL-only Loki/VL/Prom rebuilds. No vendor type-switch for QueryWithSignal/Stream/Labels.

CloudWatch stays the AWS SDK adapter behind `QueryWithSignal`. No fake HTTP RoundTripper.

## Testing

- Prom/Loki/VM/VL Query send stored bearer credentials
- Loki Stream stamps the same credentials on websocket headers
- Loki Labels send stored credentials
- Test Connection uses `NewClient(ds)` and sends stored credentials
- Existing `ssrf` policy tests remain the dial contract (updated only for `models.DataSource` constructors)
- `go test ./...` in `backend` (includes `internal/ssrf`)

## Acceptance

- [x] `NewClient` / vendor constructors take `models.DataSource`; Prom/Loki/VM/VL Query/Stream/Labels send stored auth
- [x] Test Connection uses the same `NewClient(ds)` (no public `ApplyDataSourceAuth`; per-request helper is only used inside the RoundTripper/WS header helper)
- [x] Handler has no URL-only Loki/VL rebuild; no vendor type-switch for QueryWithSignal/Stream/Labels
- [x] CloudWatch still AWS SDK via QueryWithSignal
- [x] Loki WS dial still `DatasourceDialContext`; auth on WS headers
- [x] `ssrf.go` pin/proxy/TLS unchanged; existing ssrf tests still pass
- [x] No `PROMETHEUS_URL` / FE / SSO / Speke edits

## Related

- Parent: #373 (architecture/quality pass)
- Dial seam (do not retouch): #374 / #377
- SSO (do not retouch): #379 / #380

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c329821-ec4e-4fc1-b53a-c0e46dc2f733?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c329821-ec4e-4fc1-b53a-c0e46dc2f733&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

