### PR TITLE
Shrink panel registry interface; share traceClickHouse converter

### DIFF
--- a/frontend/src/components/Panel.spec.tsx
+++ b/frontend/src/components/Panel.spec.tsx
@@ -165,12 +165,9 @@ describe('Panel', () => {
   it('renders registry unsupported empty state instead of a blank body', async () => {
     registerPanel({
       type: 'flame_graph',
-      component: async () => ({ default: () => null }),
-      dataAdapter: () => ({}),
       defaultQuery: {},
       category: 'observability',
       label: 'Flame Graph',
-      icon: async () => ({}),
       queryMode: 'none',
       supportStatus: 'unsupported',
       emptyState: {
@@ -282,12 +279,9 @@ describe('Panel', () => {
   it('renders unsupported empty state for registry charts without React bodies', async () => {
     registerPanel({
       type: 'heatmap',
-      component: async () => ({ default: () => null }),
-      dataAdapter: () => ({}),
       defaultQuery: {},
       category: 'charts',
       label: 'Heatmap',
-      icon: async () => ({}),
       supportStatus: 'unsupported',
       emptyState: {
         title: 'Heatmap renderer not available yet',

--- a/frontend/src/components/panels/registerPanelTypes.ts
+++ b/frontend/src/components/panels/registerPanelTypes.ts
@@ -4,31 +4,9 @@
  * React `Panel` only fully renders Core builtins + the `text` widget today.
  * Other registry entries keep metadata for edit/import parity, but are
  * marked `unsupported` / `setup_required` so the picker and grid never imply a
- * live React renderer exists when the component loader is still a stub.
+ * live React renderer exists.
  */
-import {
-  BarChart3,
-  Bell,
-  CandlestickChart as CandlestickIcon,
-  FileText,
-  Flame,
-  GanttChart,
-  GaugeCircle,
-  GitBranch,
-  Globe,
-  Grid3x3,
-  LayoutDashboard,
-  LayoutGrid,
-  Network,
-  PenTool,
-  ScatterChart as ScatterIcon,
-  StickyNote,
-} from 'lucide-react'
-import type { RawQueryResult } from '@/types/panel'
 import { isRegisteredPanel, registerPanel } from '@/utils/panelRegistry'
-
-const stubComponent = () => Promise.resolve({ default: () => null })
-const iconLoader = (icon: unknown) => () => Promise.resolve(icon)
 
 /** Shared empty state for registry types that still need a React panel port. */
 function pendingReactRendererEmptyState(label: string) {
@@ -40,9 +18,7 @@ function pendingReactRendererEmptyState(label: string) {
   }
 }
 
-function ensureRegistered(
-  registration: Parameters<typeof registerPanel>[0],
-): void {
+function ensureRegistered(registration: Parameters<typeof registerPanel>[0]): void {
   if (isRegisteredPanel(registration.type)) return
   registerPanel(registration)
 }
@@ -52,61 +28,44 @@ export function ensurePanelTypesRegistered(): void {
   // Text is the one registry widget with a first-class React body in Panel.tsx.
   ensureRegistered({
     type: 'text',
-    component: stubComponent,
-    dataAdapter: (_raw: RawQueryResult, query?: Record<string, unknown>) => ({
-      content: typeof query?.content === 'string' ? query.content : '',
-    }),
     defaultQuery: { content: '# Hello\n\nEdit this panel to add content.' },
     category: 'widgets',
     label: 'Text',
-    icon: iconLoader(FileText),
     queryMode: 'none',
   })
 
   ensureRegistered({
     type: 'heatmap',
-    component: stubComponent,
-    dataAdapter: () => ({ data: [], yLabels: [] }),
     defaultQuery: {},
     category: 'charts',
     label: 'Heatmap',
-    icon: iconLoader(Grid3x3),
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('Heatmap'),
   })
 
   ensureRegistered({
     type: 'bar_gauge',
-    component: stubComponent,
-    dataAdapter: () => ({ items: [] }),
     defaultQuery: {},
     category: 'stats',
     label: 'Bar Gauge',
-    icon: iconLoader(GaugeCircle),
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('Bar Gauge'),
   })
 
   ensureRegistered({
     type: 'scatter',
-    component: stubComponent,
-    dataAdapter: () => ({ series: [] }),
     defaultQuery: {},
     category: 'charts',
     label: 'Scatter',
-    icon: iconLoader(ScatterIcon),
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('Scatter'),
   })
 
   ensureRegistered({
     type: 'alert_list',
-    component: stubComponent,
-    dataAdapter: () => ({ alerts: [] }),
     defaultQuery: {},
     category: 'widgets',
     label: 'Alert List',
-    icon: iconLoader(Bell),
     queryMode: 'none',
     supportStatus: 'setup_required',
     emptyState: {
@@ -119,51 +78,36 @@ export function ensurePanelTypesRegistered(): void {
 
   ensureRegistered({
     type: 'state_timeline',
-    component: stubComponent,
-    dataAdapter: () => ({ segments: [] }),
     defaultQuery: {},
     category: 'observability',
     label: 'State Timeline',
-    icon: iconLoader(GanttChart),
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('State Timeline'),
   })
 
   ensureRegistered({
     type: 'histogram',
-    component: stubComponent,
-    dataAdapter: () => ({ buckets: [] }),
     defaultQuery: {},
     category: 'charts',
     label: 'Histogram',
-    icon: iconLoader(BarChart3),
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('Histogram'),
   })
 
   ensureRegistered({
     type: 'status_history',
-    component: stubComponent,
-    dataAdapter: () => ({ cells: [] }),
     defaultQuery: {},
     category: 'observability',
     label: 'Status History',
-    icon: iconLoader(LayoutGrid),
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('Status History'),
   })
 
   ensureRegistered({
     type: 'flame_graph',
-    component: stubComponent,
-    dataAdapter: () => ({
-      root: { name: 'root', value: 0, children: [] },
-      unit: 'ms',
-    }),
     defaultQuery: {},
     category: 'observability',
     label: 'Flame Graph',
-    icon: iconLoader(Flame),
     queryMode: 'none',
     supportStatus: 'unsupported',
     emptyState: {
@@ -176,12 +120,9 @@ export function ensurePanelTypesRegistered(): void {
 
   ensureRegistered({
     type: 'node_graph',
-    component: stubComponent,
-    dataAdapter: () => ({ nodes: [], edges: [] }),
     defaultQuery: {},
     category: 'observability',
     label: 'Node Graph',
-    icon: iconLoader(Network),
     queryMode: 'traces',
     supportStatus: 'setup_required',
     emptyState: {
@@ -194,24 +135,18 @@ export function ensurePanelTypesRegistered(): void {
 
   ensureRegistered({
     type: 'candlestick',
-    component: stubComponent,
-    dataAdapter: () => ({ data: [] }),
     defaultQuery: {},
     category: 'charts',
     label: 'Candlestick',
-    icon: iconLoader(CandlestickIcon),
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('Candlestick'),
   })
 
   ensureRegistered({
     type: 'trace_detail',
-    component: stubComponent,
-    dataAdapter: () => ({ spans: [] }),
     defaultQuery: {},
     category: 'observability',
     label: 'Trace Detail',
-    icon: iconLoader(GitBranch),
     queryMode: 'traces',
     supportStatus: 'setup_required',
     emptyState: {
@@ -224,12 +159,9 @@ export function ensurePanelTypesRegistered(): void {
 
   ensureRegistered({
     type: 'annotation_list',
-    component: stubComponent,
-    dataAdapter: () => ({ annotations: [] }),
     defaultQuery: {},
     category: 'widgets',
     label: 'Annotation List',
-    icon: iconLoader(StickyNote),
     queryMode: 'none',
     supportStatus: 'unsupported',
     emptyState: {
@@ -242,12 +174,9 @@ export function ensurePanelTypesRegistered(): void {
 
   ensureRegistered({
     type: 'dashboard_list',
-    component: stubComponent,
-    dataAdapter: () => ({ dashboards: [] }),
     defaultQuery: {},
     category: 'widgets',
     label: 'Dashboard List',
-    icon: iconLoader(LayoutDashboard),
     queryMode: 'none',
     supportStatus: 'setup_required',
     emptyState: {
@@ -260,12 +189,9 @@ export function ensurePanelTypesRegistered(): void {
 
   ensureRegistered({
     type: 'geomap',
-    component: stubComponent,
-    dataAdapter: () => ({ points: [] }),
     defaultQuery: {},
     category: 'charts',
     label: 'Geomap',
-    icon: iconLoader(Globe),
     queryMode: 'none',
     supportStatus: 'unsupported',
     emptyState: {
@@ -278,22 +204,9 @@ export function ensurePanelTypesRegistered(): void {
 
   ensureRegistered({
     type: 'canvas',
-    component: stubComponent,
-    dataAdapter: (_raw: RawQueryResult, query?: Record<string, unknown>) => {
-      const canvasData = query?.canvasData as
-        | { elements?: unknown[]; appState?: unknown }
-        | undefined
-      return {
-        data: {
-          elements: canvasData?.elements ?? [],
-          appState: canvasData?.appState ?? {},
-        },
-      }
-    },
     defaultQuery: { canvasData: { elements: [], appState: {} } },
     category: 'widgets',
     label: 'Canvas',
-    icon: iconLoader(PenTool),
     queryMode: 'none',
     supportStatus: 'unsupported',
     emptyState: pendingReactRendererEmptyState('Canvas'),

--- a/frontend/src/hooks/usePanelData.spec.tsx
+++ b/frontend/src/hooks/usePanelData.spec.tsx
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as datasourceApi from '@/api/datasources'
 import { usePanelData } from '@/hooks/usePanelData'
 import * as promqlClient from '@/promql/client'
+import type { TraceSpan } from '@/types/datasource'
 import type { Panel } from '@/types/panel'
 import { clearRegistry, registerPanel } from '@/utils/panelRegistry'
+import * as traceClickHouse from '@/utils/traceClickHouse'
 
 const panel: Panel = {
   id: 'panel-1',
@@ -85,7 +87,7 @@ describe('usePanelData', () => {
       },
     })
 
-    const { result } = renderHook(() => usePanelData(promPanel, query => query))
+    const { result } = renderHook(() => usePanelData(promPanel, (query) => query))
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
@@ -120,7 +122,7 @@ describe('usePanelData', () => {
       },
     })
 
-    const { result } = renderHook(() => usePanelData(logsPanel, query => query))
+    const { result } = renderHook(() => usePanelData(logsPanel, (query) => query))
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
@@ -152,7 +154,7 @@ describe('usePanelData', () => {
       },
     ])
 
-    const { result } = renderHook(() => usePanelData(tracePanel, query => query))
+    const { result } = renderHook(() => usePanelData(tracePanel, (query) => query))
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
@@ -165,15 +167,70 @@ describe('usePanelData', () => {
     expect(result.current.traceSummaries).toHaveLength(1)
   })
 
+  it.each([
+    'trace_list',
+    'trace_heatmap',
+  ] as const)('converts ClickHouse spans for %s with the shared explore helper', async (panelType) => {
+    const spans: TraceSpan[] = [
+      {
+        spanId: 'root',
+        operationName: 'POST /checkout',
+        serviceName: 'checkout',
+        startTimeUnixNano: 1_000,
+        durationNano: 50,
+        tags: { traceId: 'trace-a' },
+      },
+      {
+        spanId: 'child',
+        parentSpanId: 'root',
+        operationName: 'SELECT orders',
+        serviceName: 'db',
+        startTimeUnixNano: 1_010,
+        durationNano: 20,
+        tags: { traceId: 'trace-a' },
+        status: 'error',
+      },
+    ]
+    const convertSpy = vi.spyOn(traceClickHouse, 'convertClickHouseSpansToTraceSummaries')
+
+    vi.spyOn(datasourceApi, 'queryDataSource').mockResolvedValue({
+      status: 'success',
+      resultType: 'traces',
+      data: {
+        resultType: 'traces',
+        traces: spans,
+      },
+    })
+
+    const tracePanel: Panel = {
+      ...panel,
+      type: panelType,
+      query: {
+        datasource_id: 'ds-clickhouse',
+        expr: 'SELECT * FROM otel_traces',
+        signal: 'traces',
+      },
+    }
+
+    const { result } = renderHook(() => usePanelData(tracePanel, (query) => query))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(convertSpy).toHaveBeenCalledWith(spans)
+    expect(result.current.traceSummaries).toEqual(
+      traceClickHouse.convertClickHouseSpansToTraceSummaries(spans),
+    )
+    expect(result.current.traceSpans).toEqual(spans)
+  })
+
   it('treats queryMode none registry panels as ready without fetching', async () => {
     registerPanel({
       type: 'text',
-      component: async () => ({ default: () => null }),
-      dataAdapter: () => ({}),
       defaultQuery: { content: 'hi' },
       category: 'widgets',
       label: 'Text',
-      icon: async () => ({}),
       queryMode: 'none',
     })
 
@@ -183,7 +240,7 @@ describe('usePanelData', () => {
       query: { content: 'hello' },
     }
 
-    const { result } = renderHook(() => usePanelData(textPanel, query => query))
+    const { result } = renderHook(() => usePanelData(textPanel, (query) => query))
 
     await waitFor(() => {
       expect(result.current.hasQuery).toBe(true)

--- a/frontend/src/hooks/usePanelData.ts
+++ b/frontend/src/hooks/usePanelData.ts
@@ -5,6 +5,7 @@ import { queryPrometheus, transformToChartData, type ChartSeries } from '@/promq
 import type { LogEntry, TraceSpan, TraceSummary } from '@/types/datasource'
 import type { Panel } from '@/types/panel'
 import { lookupPanel } from '@/utils/panelRegistry'
+import { convertClickHouseSpansToTraceSummaries } from '@/utils/traceClickHouse'
 
 type QuerySignal = 'logs' | 'metrics' | 'traces'
 
@@ -12,116 +13,10 @@ function isQuerySignal(value: unknown): value is QuerySignal {
   return value === 'logs' || value === 'metrics' || value === 'traces'
 }
 
-function getTagValue(tags: Record<string, string> | undefined, keys: string[]): string {
-  if (!tags || Object.keys(tags).length === 0) return ''
-
-  const byNormalizedName: Record<string, string> = {}
-  for (const [key, value] of Object.entries(tags)) {
-    const normalizedKey = key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
-    if (normalizedKey && !(normalizedKey in byNormalizedName)) {
-      byNormalizedName[normalizedKey] = value
-    }
-  }
-
-  for (const key of keys) {
-    const normalizedKey = key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
-    if (normalizedKey in byNormalizedName) {
-      const value = byNormalizedName[normalizedKey].trim()
-      if (value) return value
-    }
-  }
-
-  return ''
-}
-
-function isTraceErrorSpan(span: TraceSpan): boolean {
-  if (typeof span.status === 'string' && span.status.toLowerCase() === 'error') {
-    return true
-  }
-
-  const errorTag = getTagValue(span.tags, ['error', 'otelStatusCode', 'statusCode'])
-  const normalized = errorTag.toLowerCase()
-  return normalized === 'true' || normalized === '1' || normalized === 'error'
-}
-
-function getTraceIdForSpan(span: TraceSpan): string {
-  const traceIdFromTags = getTagValue(span.tags, [
-    'traceId',
-    'trace_id',
-    'traceid',
-    'otelTraceId',
-    'trace',
-  ])
-  if (traceIdFromTags) return traceIdFromTags
-  return span.spanId || 'unknown-trace'
-}
-
-function convertClickHouseSpansToTraceSummaries(spans: TraceSpan[]): TraceSummary[] {
-  const grouped = new Map<
-    string,
-    {
-      traceId: string
-      spans: TraceSpan[]
-      services: Set<string>
-      errorSpanCount: number
-      startTimeUnixNano: number
-      endTimeUnixNano: number
-    }
-  >()
-
-  for (const span of spans) {
-    const traceId = getTraceIdForSpan(span)
-    const group = grouped.get(traceId) || {
-      traceId,
-      spans: [],
-      services: new Set<string>(),
-      errorSpanCount: 0,
-      startTimeUnixNano: Number.MAX_SAFE_INTEGER,
-      endTimeUnixNano: 0,
-    }
-
-    group.spans.push(span)
-    if (span.serviceName) group.services.add(span.serviceName)
-    if (isTraceErrorSpan(span)) group.errorSpanCount += 1
-
-    const spanStart = Math.max(0, span.startTimeUnixNano || 0)
-    const spanEnd = spanStart + Math.max(0, span.durationNano || 0)
-    group.startTimeUnixNano = Math.min(group.startTimeUnixNano, spanStart)
-    group.endTimeUnixNano = Math.max(group.endTimeUnixNano, spanEnd)
-    grouped.set(traceId, group)
-  }
-
-  const summaries: TraceSummary[] = []
-  for (const group of grouped.values()) {
-    const spanIds = new Set(group.spans.map(span => span.spanId))
-    const rootSpan =
-      [...group.spans]
-        .sort((left, right) => left.startTimeUnixNano - right.startTimeUnixNano)
-        .find(span => !span.parentSpanId || !spanIds.has(span.parentSpanId)) || group.spans[0]
-
-    const startTimeUnixNano =
-      group.startTimeUnixNano === Number.MAX_SAFE_INTEGER ? 0 : group.startTimeUnixNano
-    const durationNano = Math.max(0, group.endTimeUnixNano - startTimeUnixNano)
-
-    summaries.push({
-      traceId: group.traceId,
-      rootServiceName: rootSpan?.serviceName || 'unknown',
-      rootOperationName: rootSpan?.operationName || '',
-      startTimeUnixNano,
-      durationNano,
-      spanCount: group.spans.length,
-      serviceCount: group.services.size,
-      errorSpanCount: group.errorSpanCount,
-    })
-  }
-
-  return summaries.sort((left, right) => right.startTimeUnixNano - left.startTimeUnixNano)
-}
-
 function metricSeriesFromResult(
   result: Array<{ metric: Record<string, string>; values: [number, string][] }>,
 ): ChartSeries[] {
-  return result.map(row => {
+  return result.map((row) => {
     const labelParts: string[] = []
     for (const [key, value] of Object.entries(row.metric)) {
       if (key !== '__name__') labelParts.push(`${key}="${value}"`)
@@ -172,8 +67,7 @@ export function usePanelData(
   const start = Math.floor(timeRange.start / 1000)
   const end = Math.floor(timeRange.end / 1000)
 
-  const traceServiceFilter =
-    typeof panel.query?.service === 'string' ? panel.query.service : ''
+  const traceServiceFilter = typeof panel.query?.service === 'string' ? panel.query.service : ''
   const rawLimit = panel.query?.limit
   const traceSearchLimit =
     typeof rawLimit === 'number' && Number.isFinite(rawLimit)
@@ -201,14 +95,7 @@ export function usePanelData(
     }
 
     return !!datasourceId || !!queryExpr.trim()
-  }, [
-    datasourceId,
-    explicitQuerySignal,
-    isBuiltinTracePanel,
-    isLogPanel,
-    queryExpr,
-    registry,
-  ])
+  }, [datasourceId, explicitQuerySignal, isBuiltinTracePanel, isLogPanel, queryExpr, registry])
 
   const interpolateRef = useRef(interpolate)
   interpolateRef.current = interpolate

--- a/frontend/src/utils/panelRegistry.ts
+++ b/frontend/src/utils/panelRegistry.ts
@@ -1,10 +1,3 @@
-import type { RawQueryResult } from '../types/panel'
-
-/** Lazy panel component loader — React `lazy()` factory. */
-export type PanelComponentLoader = () => Promise<unknown>
-
-export type { RawQueryResult }
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -23,20 +16,15 @@ export interface PanelEmptyState {
   actionLabel?: string
 }
 
+/** Metadata for the panel type picker, default queries, and empty-state copy. */
 export interface PanelRegistration {
   /** Unique identifier, e.g. 'heatmap' */
   type: string
-  /** Lazy-loaded panel component factory */
-  component: PanelComponentLoader
-  /** Transforms raw query result into chart-specific option data */
-  dataAdapter: (raw: RawQueryResult, query?: Record<string, unknown>) => Record<string, unknown>
   /** Default query object shown in the panel editor */
   defaultQuery: Record<string, unknown>
   category: PanelCategory
   /** Human-readable display name, e.g. "Heatmap" */
   label: string
-  /** Lucide icon component */
-  icon: PanelComponentLoader
   /** What data/signal this panel requires. Defaults to 'metrics' when omitted. */
   queryMode?: PanelQueryMode
   /** Optional support status for panels that should not look fully live/wired. */
@@ -73,15 +61,6 @@ export function registerPanel(registration: PanelRegistration): void {
  */
 export function lookupPanel(type: string): PanelRegistration | null {
   return registry.get(type) ?? null
-}
-
-/**
- * Returns all panels belonging to `category`, sorted alphabetically by label.
- */
-export function getPanelsByCategory(category: PanelCategory): PanelRegistration[] {
-  return Array.from(registry.values())
-    .filter((p) => p.category === category)
-    .sort(byLabel)
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to architecture pass #373 (Panel query module). YAGNI shrink of the panel registry plus one span→summary policy for dashboard and explore.

**Closes #383.** Parent: #373.

## What changed
- `PanelRegistration` is metadata only: dropped unused `dataAdapter`, stub `component`, and `icon`. Kept `type`, `category`, `label`, `queryMode`, `defaultQuery`, `supportStatus`, `emptyState`.
- Removed unused `getPanelsByCategory` (picker already groups via `getAllPanels`).
- Registry entries in `registerPanelTypes` no longer carry stub loaders or Lucide icons.
- `usePanelData` imports `convertClickHouseSpansToTraceSummaries` from `@/utils/traceClickHouse` (same helper as explore). Private copy deleted.
- Specs compile after the field removal. New test pins trace_list/heatmap ClickHouse summaries to the shared helper. Panel empty-state tests kept.

## Unchanged (on purpose)
- Core nine types still hardcoded in `Panel.tsx` + `BUILTIN_PANEL_TYPES` (not registered onto the metadata registry).
- `text` still renders from `query.content`.
- Picker, empty states, `defaultQuery`, `queryMode` behavior unchanged.
- No plugin loader, no `Panel` loading `component`, no new PanelQuery class.
- No explore-run rewrite, no prometheus-fallback change, no backend / SSO / datasource.Client edits.
- No ADR, no `CONTEXT.md`.

## Test plan
- [x] `bun run type-check` in `frontend`
- [x] Panel / usePanelData / panelEditHelpers / PanelEditModal specs (37 passed)
- [x] Full frontend suite (`bun run test`: 489 passed)
- [x] Confirm empty-state tests still pass
- [x] Confirm no `dataAdapter` call sites remain

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-437c80fe-7a5a-49f8-b791-316518dde5dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-437c80fe-7a5a-49f8-b791-316518dde5dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

