### PR TITLE
Lock Ace: no public signup, first-user then closed

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -152,6 +152,7 @@ func main() {
 		rdb = valkeyClient.GetRedis()
 	}
 	authHandler := handlers.NewAuthHandler(pool, jwtManager, rdb)
+	mux.HandleFunc("GET /api/auth/config", authHandler.GetAuthConfig)
 	mux.HandleFunc("POST /api/auth/register", authHandler.Register)
 	mux.HandleFunc("POST /api/auth/login", authHandler.Login)
 	mux.HandleFunc("GET /api/auth/me", auth.RequireAuth(jwtManager, authHandler.Me))

--- a/backend/internal/handlers/audit_test.go
+++ b/backend/internal/handlers/audit_test.go
@@ -128,25 +128,10 @@ func auditTestSetup(t *testing.T) (
 	return handler, orgID, tokens, cleanup
 }
 
-// createTestUserWithEmail registers a fresh user and returns the auth response.
+// createTestUserWithEmail inserts a user with a password and returns the auth response.
 func createTestUserWithEmail(t *testing.T, authHandler *AuthHandler, email string) AuthResponse {
 	t.Helper()
-	ctx := context.Background()
-	testPool.Exec(ctx, "DELETE FROM users WHERE email = $1", email)
-
-	body := `{"email":"` + email + `","password":"TestPassword123!","name":"Test User"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/auth/register", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	authHandler.Register(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("register %s: %d %s", email, w.Code, w.Body.String())
-	}
-
-	var resp AuthResponse
-	json.NewDecoder(w.Body).Decode(&resp)
-	return resp
+	return createTestUser(t, authHandler, email)
 }
 
 // doListAuditLog fires GET /api/orgs/{id}/audit-log with the given token and params.

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/mail"
 	"time"
@@ -10,12 +11,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/aceobservability/ace/backend/internal/analytics"
 	"github.com/aceobservability/ace/backend/internal/auth"
 )
+
+// Serializes first-user bootstrap so two empty-DB registers cannot both succeed.
+const registerBootstrapLockKey int64 = 394001
 
 type AuthHandler struct {
 	pool                *pgxpool.Pool
@@ -33,6 +38,11 @@ func NewAuthHandler(pool *pgxpool.Pool, jwtManager *auth.JWTManager, rdb *redis.
 		jwtManager:          jwtManager,
 		refreshTokenManager: rtm,
 	}
+}
+
+// AuthConfigResponse is the public auth configuration for the login SPA.
+type AuthConfigResponse struct {
+	RegistrationOpen bool `json:"registrationOpen"`
 }
 
 // RegisterRequest represents the registration request body
@@ -78,7 +88,22 @@ type OrganizationMembership struct {
 	Role             string    `json:"role"`
 }
 
-// Register handles user registration
+// GetAuthConfig reports whether first-user registration is still open.
+func (h *AuthHandler) GetAuthConfig(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	open, err := registrationOpen(ctx, h.pool)
+	if err != nil {
+		http.Error(w, `{"error":"failed to load auth config"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(AuthConfigResponse{RegistrationOpen: open})
+}
+
+// Register creates the first user when the users table is empty. After that it returns 403.
 func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	var req RegisterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -98,33 +123,52 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Hash password
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	// Fast path: closed deploys should not pay for password hashing.
+	open, err := registrationOpen(ctx, h.pool)
+	if err != nil {
+		http.Error(w, `{"error":"failed to check registration"}`, http.StatusInternalServerError)
+		return
+	}
+	if !open {
+		http.Error(w, `{"error":"registration is closed"}`, http.StatusForbidden)
+		return
+	}
+
 	passwordHash, err := auth.HashPassword(req.Password)
 	if err != nil {
 		http.Error(w, `{"error":"failed to process password"}`, http.StatusInternalServerError)
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-	defer cancel()
-
-	// Check if user already exists
-	var existingID uuid.UUID
-	err = h.pool.QueryRow(ctx, `SELECT id FROM users WHERE email = $1`, req.Email).Scan(&existingID)
-	if err == nil {
-		http.Error(w, `{"error":"email already registered"}`, http.StatusConflict)
+	tx, err := h.pool.Begin(ctx)
+	if err != nil {
+		http.Error(w, `{"error":"failed to start transaction"}`, http.StatusInternalServerError)
 		return
 	}
-	if err != pgx.ErrNoRows {
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, registerBootstrapLockKey); err != nil {
+		http.Error(w, `{"error":"failed to lock registration"}`, http.StatusInternalServerError)
+		return
+	}
+
+	var taken bool
+	if err := tx.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM users)`).Scan(&taken); err != nil {
 		http.Error(w, `{"error":"failed to check existing user"}`, http.StatusInternalServerError)
 		return
 	}
+	if taken {
+		http.Error(w, `{"error":"registration is closed"}`, http.StatusForbidden)
+		return
+	}
 
-	// Create user
 	var userID uuid.UUID
 	var userEmail string
 	var userName *string
-	err = h.pool.QueryRow(ctx,
+	err = tx.QueryRow(ctx,
 		`INSERT INTO users (email, password_hash, name)
 		 VALUES ($1, $2, $3)
 		 RETURNING id, email, name`,
@@ -132,6 +176,16 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	).Scan(&userID, &userEmail, &userName)
 
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			http.Error(w, `{"error":"email already registered"}`, http.StatusConflict)
+			return
+		}
+		http.Error(w, `{"error":"failed to create user"}`, http.StatusInternalServerError)
+		return
+	}
+
+	if err := tx.Commit(ctx); err != nil {
 		http.Error(w, `{"error":"failed to create user"}`, http.StatusInternalServerError)
 		return
 	}
@@ -511,6 +565,15 @@ type passwordError struct {
 
 func (e *passwordError) Error() string {
 	return e.message
+}
+
+func registrationOpen(ctx context.Context, pool *pgxpool.Pool) (bool, error) {
+	var taken bool
+	err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM users)`).Scan(&taken)
+	if err != nil {
+		return false, err
+	}
+	return !taken, nil
 }
 
 // AuthMethodResponse represents a user's authentication method

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -60,13 +60,47 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestRegisterUser(t *testing.T) {
+func TestGetAuthConfigRegistrationOpen(t *testing.T) {
 	if testPool == nil {
 		t.Skip("Database not available")
 	}
 
-	// Cleanup before test
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testregister@example.com'")
+	req := httptest.NewRequest("GET", "/api/auth/config", nil)
+	w := httptest.NewRecorder()
+	testAuthHandler.GetAuthConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var cfg AuthConfigResponse
+	if err := json.NewDecoder(w.Body).Decode(&cfg); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	var taken bool
+	if err := testPool.QueryRow(context.Background(), `SELECT EXISTS (SELECT 1 FROM users)`).Scan(&taken); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	wantOpen := !taken
+	if cfg.RegistrationOpen != wantOpen {
+		t.Errorf("registrationOpen = %v, want %v", cfg.RegistrationOpen, wantOpen)
+	}
+}
+
+func TestRegisterFirstUserThenClosed(t *testing.T) {
+	if testPool == nil {
+		t.Skip("Database not available")
+	}
+
+	ctx := context.Background()
+	var taken bool
+	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM users)`).Scan(&taken); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if taken {
+		t.Skip("users table is not empty; first-user bootstrap needs an empty table")
+	}
 
 	body := `{"email":"testregister@example.com","password":"TestPassword123!","name":"Test User"}`
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(body))
@@ -76,14 +110,13 @@ func TestRegisterUser(t *testing.T) {
 	testAuthHandler.Register(w, req)
 
 	if w.Code != http.StatusCreated {
-		t.Errorf("Expected status 201, got %d: %s", w.Code, w.Body.String())
+		t.Fatalf("Expected status 201 for first user, got %d: %s", w.Code, w.Body.String())
 	}
 
 	var response AuthResponse
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("Failed to decode response: %v", err)
 	}
-
 	if response.AccessToken == "" {
 		t.Error("Expected access token in response")
 	}
@@ -93,35 +126,33 @@ func TestRegisterUser(t *testing.T) {
 	if response.ExpiresIn != 900 {
 		t.Errorf("Expected expires_in 900, got %d", response.ExpiresIn)
 	}
+
+	second := `{"email":"testregister2@example.com","password":"TestPassword123!","name":"Second User"}`
+	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(second))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	testAuthHandler.Register(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status 403 for second register, got %d: %s", w.Code, w.Body.String())
+	}
 }
 
-func TestRegisterUserDuplicate(t *testing.T) {
+func TestRegisterClosedWhenUsersExist(t *testing.T) {
 	if testPool == nil {
 		t.Skip("Database not available")
 	}
 
-	// Cleanup and create initial user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testdupe@example.com'")
+	createTestUser(t, testAuthHandler, "testregisterclosed@example.com")
 
-	body := `{"email":"testdupe@example.com","password":"TestPassword123!","name":"Test User"}`
+	body := `{"email":"testregisterclosed2@example.com","password":"TestPassword123!","name":"Should Fail"}`
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
 	testAuthHandler.Register(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("Failed to create first user: %d", w.Code)
-	}
 
-	// Try to register again
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-
-	testAuthHandler.Register(w, req)
-
-	if w.Code != http.StatusConflict {
-		t.Errorf("Expected status 409 for duplicate email, got %d", w.Code)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status 403 when users exist, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -178,18 +209,7 @@ func TestLoginCorrectPassword(t *testing.T) {
 		t.Skip("Database not available")
 	}
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testlogin@example.com'")
-
-	regBody := `{"email":"testlogin@example.com","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	testAuthHandler.Register(regW, regReq)
-
-	if regW.Code != http.StatusCreated {
-		t.Fatalf("Failed to register user: %d", regW.Code)
-	}
+	createTestUserNamed(t, testAuthHandler, "testlogin@example.com", "Test User")
 
 	// Login
 	loginBody := `{"email":"testlogin@example.com","password":"TestPassword123!"}`
@@ -218,14 +238,7 @@ func TestLoginWrongPassword(t *testing.T) {
 		t.Skip("Database not available")
 	}
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testloginwrong@example.com'")
-
-	regBody := `{"email":"testloginwrong@example.com","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	testAuthHandler.Register(regW, regReq)
+	createTestUserNamed(t, testAuthHandler, "testloginwrong@example.com", "Test User")
 
 	// Login with wrong password
 	loginBody := `{"email":"testloginwrong@example.com","password":"WrongPassword123!"}`
@@ -262,17 +275,7 @@ func TestMeWithValidToken(t *testing.T) {
 		t.Skip("Database not available")
 	}
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testme@example.com'")
-
-	regBody := `{"email":"testme@example.com","password":"TestPassword123!","name":"Test Me User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	testAuthHandler.Register(regW, regReq)
-
-	var regResponse AuthResponse
-	json.NewDecoder(regW.Body).Decode(&regResponse)
+	regResponse := createTestUserNamed(t, testAuthHandler, "testme@example.com", "Test Me User")
 
 	// Call /me endpoint
 	meReq := httptest.NewRequest("GET", "/api/auth/me", nil)
@@ -358,18 +361,7 @@ func TestLoginReturnsRefreshToken(t *testing.T) {
 	handler, cleanup := setupTestWithRedis(t)
 	defer cleanup()
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testloginrefresh@example.com'")
-
-	regBody := `{"email":"testloginrefresh@example.com","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	handler.Register(regW, regReq)
-
-	if regW.Code != http.StatusCreated {
-		t.Fatalf("Failed to register user: %d", regW.Code)
-	}
+	createTestUserNamed(t, handler, "testloginrefresh@example.com", "Test User")
 
 	// Login
 	loginBody := `{"email":"testloginrefresh@example.com","password":"TestPassword123!"}`
@@ -400,17 +392,7 @@ func TestRefreshTokenEndpoint(t *testing.T) {
 	handler, cleanup := setupTestWithRedis(t)
 	defer cleanup()
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testrefreshendpoint@example.com'")
-
-	regBody := `{"email":"testrefreshendpoint@example.com","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	handler.Register(regW, regReq)
-
-	var regResponse AuthResponse
-	json.NewDecoder(regW.Body).Decode(&regResponse)
+	regResponse := createTestUserNamed(t, handler, "testrefreshendpoint@example.com", "Test User")
 
 	// Use refresh token to get new tokens
 	refreshBody := `{"refresh_token":"` + regResponse.RefreshToken + `"}`
@@ -444,17 +426,7 @@ func TestRefreshTokenRotation(t *testing.T) {
 	handler, cleanup := setupTestWithRedis(t)
 	defer cleanup()
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testrotation@example.com'")
-
-	regBody := `{"email":"testrotation@example.com","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	handler.Register(regW, regReq)
-
-	var regResponse AuthResponse
-	json.NewDecoder(regW.Body).Decode(&regResponse)
+	regResponse := createTestUserNamed(t, handler, "testrotation@example.com", "Test User")
 
 	oldRefreshToken := regResponse.RefreshToken
 
@@ -481,17 +453,7 @@ func TestLogoutEndpoint(t *testing.T) {
 	handler, cleanup := setupTestWithRedis(t)
 	defer cleanup()
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testlogout@example.com'")
-
-	regBody := `{"email":"testlogout@example.com","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	handler.Register(regW, regReq)
-
-	var regResponse AuthResponse
-	json.NewDecoder(regW.Body).Decode(&regResponse)
+	regResponse := createTestUserNamed(t, handler, "testlogout@example.com", "Test User")
 
 	// Logout
 	logoutBody := `{"refresh_token":"` + regResponse.RefreshToken + `"}`
@@ -522,17 +484,7 @@ func TestLogoutAllEndpoint(t *testing.T) {
 	handler, cleanup := setupTestWithRedis(t)
 	defer cleanup()
 
-	// Cleanup and register user
-	testPool.Exec(context.Background(), "DELETE FROM users WHERE email = 'testlogoutall@example.com'")
-
-	regBody := `{"email":"testlogoutall@example.com","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	handler.Register(regW, regReq)
-
-	var regResponse AuthResponse
-	json.NewDecoder(regW.Body).Decode(&regResponse)
+	regResponse := createTestUserNamed(t, handler, "testlogoutall@example.com", "Test User")
 
 	// Login again to get a second refresh token
 	loginBody := `{"email":"testlogoutall@example.com","password":"TestPassword123!"}`
@@ -592,17 +544,7 @@ func TestGetAuthMethods(t *testing.T) {
 		t.Skip("Database not available")
 	}
 
-	ctx := context.Background()
-	testPool.Exec(ctx, "DELETE FROM users WHERE email = 'testgetmethods@example.com'")
-
-	regBody := `{"email":"testgetmethods@example.com","password":"TestPassword123!","name":"Test Methods"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	testAuthHandler.Register(regW, regReq)
-
-	var regResponse AuthResponse
-	json.NewDecoder(regW.Body).Decode(&regResponse)
+	regResponse := createTestUserNamed(t, testAuthHandler, "testgetmethods@example.com", "Test Methods")
 
 	getReq := httptest.NewRequest("GET", "/api/auth/me/methods", nil)
 	getReq.Header.Set("Authorization", "Bearer "+regResponse.AccessToken)
@@ -632,17 +574,7 @@ func TestUnlinkLastAuthMethodFails(t *testing.T) {
 		t.Skip("Database not available")
 	}
 
-	ctx := context.Background()
-	testPool.Exec(ctx, "DELETE FROM users WHERE email = 'testunlink@example.com'")
-
-	regBody := `{"email":"testunlink@example.com","password":"TestPassword123!","name":"Test Unlink User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	testAuthHandler.Register(regW, regReq)
-
-	var regResponse AuthResponse
-	json.NewDecoder(regW.Body).Decode(&regResponse)
+	regResponse := createTestUserNamed(t, testAuthHandler, "testunlink@example.com", "Test Unlink User")
 
 	unlinkReq := httptest.NewRequest("DELETE", "/api/auth/me/methods/00000000-0000-0000-0000-000000000000", nil)
 	unlinkReq.Header.Set("Authorization", "Bearer "+regResponse.AccessToken)

--- a/backend/internal/handlers/organization_test.go
+++ b/backend/internal/handlers/organization_test.go
@@ -41,24 +41,54 @@ func setupOrgTestWithRedis(t *testing.T) (*OrganizationHandler, *AuthHandler, fu
 	return orgHandler, authHandler, cleanup
 }
 
-func createTestUser(t *testing.T, authHandler *AuthHandler, email string) AuthResponse {
+func createTestUserNamed(t *testing.T, authHandler *AuthHandler, email, name string) AuthResponse {
+	t.Helper()
 	ctx := context.Background()
 	testPool.Exec(ctx, "DELETE FROM organization_memberships WHERE user_id IN (SELECT id FROM users WHERE email = $1)", email)
+	testPool.Exec(ctx, "DELETE FROM user_auth_methods WHERE user_id IN (SELECT id FROM users WHERE email = $1)", email)
 	testPool.Exec(ctx, "DELETE FROM users WHERE email = $1", email)
 
-	regBody := `{"email":"` + email + `","password":"TestPassword123!","name":"Test User"}`
-	regReq := httptest.NewRequest("POST", "/api/auth/register", bytes.NewBufferString(regBody))
-	regReq.Header.Set("Content-Type", "application/json")
-	regW := httptest.NewRecorder()
-	authHandler.Register(regW, regReq)
-
-	if regW.Code != http.StatusCreated {
-		t.Fatalf("Failed to register user: %d - %s", regW.Code, regW.Body.String())
+	hash, err := auth.HashPassword("TestPassword123!")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
 	}
 
-	var response AuthResponse
-	json.NewDecoder(regW.Body).Decode(&response)
+	var userID uuid.UUID
+	err = testPool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, name) VALUES ($1, $2, $3) RETURNING id`,
+		email, hash, name,
+	).Scan(&userID)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	accessToken, err := testJWTManager.GenerateAccessToken(userID, email, name)
+	if err != nil {
+		t.Fatalf("jwt: %v", err)
+	}
+
+	response := AuthResponse{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresIn:   900,
+	}
+
+	if authHandler != nil && authHandler.refreshTokenManager != nil {
+		refreshToken, err := auth.GenerateRefreshToken()
+		if err != nil {
+			t.Fatalf("refresh token: %v", err)
+		}
+		if err := authHandler.refreshTokenManager.StoreRefreshToken(ctx, refreshToken, userID, email, name); err != nil {
+			t.Fatalf("store refresh: %v", err)
+		}
+		response.RefreshToken = refreshToken
+	}
 	return response
+}
+
+func createTestUser(t *testing.T, authHandler *AuthHandler, email string) AuthResponse {
+	t.Helper()
+	return createTestUserNamed(t, authHandler, email, "Test User")
 }
 
 func TestCreateOrganization(t *testing.T) {

--- a/backend/internal/handlers/sso_http.go
+++ b/backend/internal/handlers/sso_http.go
@@ -60,6 +60,8 @@ func writeSSOFinishError(w http.ResponseWriter, err error) {
 		status = http.StatusUnauthorized
 	case errors.Is(err, sso.ErrNotConfigured), errors.Is(err, sso.ErrNotEnabled):
 		status = http.StatusBadRequest
+	case errors.Is(err, sso.ErrNoAccount):
+		status = http.StatusForbidden
 	}
 	writeSSOJSON(w, status, err.Error())
 }

--- a/backend/internal/handlers/sso_http_test.go
+++ b/backend/internal/handlers/sso_http_test.go
@@ -23,6 +23,7 @@ func TestWriteSSOFinishError_mapsSentinels(t *testing.T) {
 		{"id token", fmt.Errorf("%w", sso.ErrIDToken), http.StatusUnauthorized},
 		{"not configured", fmt.Errorf("%s %w", sso.ProviderGoogle, sso.ErrNotConfigured), http.StatusBadRequest},
 		{"not enabled", fmt.Errorf("%s %w", sso.ProviderOkta, sso.ErrNotEnabled), http.StatusBadRequest},
+		{"no account", sso.ErrNoAccount, http.StatusForbidden},
 		{"other", errors.New("failed to exchange code for token"), http.StatusInternalServerError},
 	}
 	for _, tt := range tests {

--- a/backend/internal/sso/errors.go
+++ b/backend/internal/sso/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrIDToken         = errors.New("failed to verify ID token")
 	ErrNotConfigured   = errors.New("SSO not configured for this organization")
 	ErrNotEnabled      = errors.New("SSO is not enabled for this organization")
+	ErrNoAccount       = errors.New("no existing account for this email")
 )

--- a/backend/internal/sso/finish.go
+++ b/backend/internal/sso/finish.go
@@ -24,7 +24,7 @@ type FinishRequest struct {
 	Code        string
 }
 
-// FinishResult is the local user identity after exchange + upsert.
+// FinishResult is the local user identity after exchange + existing-user lookup.
 type FinishResult struct {
 	UserID uuid.UUID
 	Email  string
@@ -54,9 +54,10 @@ type idpIdentity struct {
 }
 
 // Finish exchanges the authorization code, fetches identity from the IdP
-// through the injected client, upserts the user, and applies membership.
-// Google/Microsoft insert viewer if the user has no membership. Okta applies
-// role mappings (and respects manual role_source overrides).
+// through the injected client, signs in an existing user (email match), and
+// applies membership. Google/Microsoft never create users or insert viewer
+// membership. Okta applies role mappings for existing users only (and respects
+// manual role_source overrides).
 func (m *Module) Finish(ctx context.Context, pool *pgxpool.Pool, req FinishRequest) (*FinishResult, error) {
 	cfg, err := loadEnabledConfig(ctx, pool, req.OrgSlug, req.Provider)
 	if err != nil {
@@ -78,16 +79,14 @@ func (m *Module) Finish(ctx context.Context, pool *pgxpool.Pool, req FinishReque
 		return nil, err
 	}
 
-	userID, email, name, err := upsertUser(ctx, pool, identity.email, identity.name)
+	userID, email, name, err := findExistingUser(ctx, pool, identity.email)
 	if err != nil {
 		return nil, err
 	}
 
 	switch req.Provider {
 	case ProviderGoogle, ProviderMicrosoft:
-		if err := ensureViewerMembership(ctx, pool, userID, cfg.orgID); err != nil {
-			return nil, err
-		}
+		// Sign-in only. Do not create org memberships for strangers.
 	case ProviderOkta:
 		if err := applyOktaMembership(ctx, pool, userID, cfg, identity.groups); err != nil {
 			return nil, err
@@ -248,7 +247,7 @@ func oktaIdentity(ctx context.Context, cfg *providerConfig, token *oauth2.Token)
 	}, nil
 }
 
-func upsertUser(ctx context.Context, pool *pgxpool.Pool, email, name string) (uuid.UUID, string, string, error) {
+func findExistingUser(ctx context.Context, pool *pgxpool.Pool, email string) (uuid.UUID, string, string, error) {
 	var userID uuid.UUID
 	var userEmail string
 	var userName *string
@@ -257,16 +256,10 @@ func upsertUser(ctx context.Context, pool *pgxpool.Pool, email, name string) (uu
 		`SELECT id, email, name FROM users WHERE email = $1`,
 		email,
 	).Scan(&userID, &userEmail, &userName)
-
 	if err == pgx.ErrNoRows {
-		err = pool.QueryRow(ctx,
-			`INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id, email, name`,
-			email, &name,
-		).Scan(&userID, &userEmail, &userName)
-		if err != nil {
-			return uuid.Nil, "", "", fmt.Errorf("failed to create user")
-		}
-	} else if err != nil {
+		return uuid.Nil, "", "", ErrNoAccount
+	}
+	if err != nil {
 		return uuid.Nil, "", "", fmt.Errorf("failed to check user")
 	}
 
@@ -275,28 +268,6 @@ func upsertUser(ctx context.Context, pool *pgxpool.Pool, email, name string) (uu
 		displayName = *userName
 	}
 	return userID, userEmail, displayName, nil
-}
-
-func ensureViewerMembership(ctx context.Context, pool *pgxpool.Pool, userID, orgID uuid.UUID) error {
-	var membershipExists bool
-	err := pool.QueryRow(ctx,
-		`SELECT EXISTS(SELECT 1 FROM organization_memberships WHERE user_id = $1 AND organization_id = $2)`,
-		userID, orgID,
-	).Scan(&membershipExists)
-	if err != nil {
-		return fmt.Errorf("failed to check membership")
-	}
-	if membershipExists {
-		return nil
-	}
-	_, err = pool.Exec(ctx,
-		`INSERT INTO organization_memberships (user_id, organization_id, role) VALUES ($1, $2, 'viewer')`,
-		userID, orgID,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to add user to organization")
-	}
-	return nil
 }
 
 func applyOktaMembership(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, cfg *providerConfig, userGroups []string) error {

--- a/backend/internal/sso/finish_test.go
+++ b/backend/internal/sso/finish_test.go
@@ -200,11 +200,88 @@ func TestMicrosoftIdentity_rejectsNon2xx(t *testing.T) {
 	}
 }
 
-func TestFinish_googleExchangeUpsertViewer(t *testing.T) {
+func TestFinish_googleUnknownEmailDoesNotCreateUser(t *testing.T) {
+	slug := "g-nouser-" + uuid.NewString()[:8]
+	email := "stranger@" + slug + ".example"
+	orgID, cleanup := setupOrgWithSSO(t, "google", slug, "")
+	defer cleanup()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/token"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "mock-access",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case strings.HasSuffix(r.URL.Path, "/userinfo"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(googleUserInfo{
+				ID:            "google-stranger-1",
+				Email:         email,
+				VerifiedEmail: true,
+				Name:          "Stranger",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	prevEndpoint, prevUserInfo := googleEndpoint, googleUserInfoURL
+	googleEndpoint = oauth2.Endpoint{AuthURL: srv.URL + "/auth", TokenURL: srv.URL + "/token"}
+	googleUserInfoURL = srv.URL + "/userinfo"
+	defer func() {
+		googleEndpoint = prevEndpoint
+		googleUserInfoURL = prevUserInfo
+	}()
+
+	mod := New(&http.Client{})
+	ctx := context.Background()
+	_, err := mod.Finish(ctx, testPool, FinishRequest{
+		Provider:    ProviderGoogle,
+		OrgSlug:     slug,
+		RedirectURL: "http://localhost:8080/api/auth/google/callback",
+		Code:        "auth-code",
+	})
+	if !errors.Is(err, ErrNoAccount) {
+		t.Fatalf("Finish: %v, want ErrNoAccount", err)
+	}
+
+	var userCount int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM users WHERE email = $1`, email).Scan(&userCount); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if userCount != 0 {
+		t.Fatalf("must not create user for unknown Google email, count=%d", userCount)
+	}
+
+	var membershipCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM organization_memberships WHERE organization_id = $1`, orgID,
+	).Scan(&membershipCount); err != nil {
+		t.Fatalf("count memberships: %v", err)
+	}
+	if membershipCount != 0 {
+		t.Fatalf("must not insert membership for stranger, count=%d", membershipCount)
+	}
+}
+
+func TestFinish_googleExistingUserNoViewerInsert(t *testing.T) {
 	slug := "g-finish-" + uuid.NewString()[:8]
 	email := "user@" + slug + ".example"
 	orgID, cleanup := setupOrgWithSSO(t, "google", slug, "")
 	defer cleanup()
+
+	ctx := context.Background()
+	var existingID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id`,
+		email, "Google User",
+	).Scan(&existingID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
 
 	var hits struct {
 		token, userinfo int
@@ -245,8 +322,6 @@ func TestFinish_googleExchangeUpsertViewer(t *testing.T) {
 	rec := &recordingTransport{base: http.DefaultTransport}
 	mod := New(&http.Client{Transport: rec})
 
-	// Seed a Google role mapping — Finish must still insert viewer, not apply it.
-	ctx := context.Background()
 	var ssoConfigID uuid.UUID
 	if err := testPool.QueryRow(ctx,
 		`SELECT id FROM sso_configs WHERE organization_id = $1 AND provider = 'google'`, orgID,
@@ -269,6 +344,9 @@ func TestFinish_googleExchangeUpsertViewer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Finish: %v", err)
 	}
+	if result.UserID != existingID {
+		t.Errorf("user id = %s, want existing %s", result.UserID, existingID)
+	}
 	if result.Email != email {
 		t.Errorf("email = %q, want %q", result.Email, email)
 	}
@@ -279,15 +357,15 @@ func TestFinish_googleExchangeUpsertViewer(t *testing.T) {
 		t.Fatalf("injected client did not see token/userinfo: %v", rec.urls)
 	}
 
-	var role string
+	var membershipCount int
 	if err := testPool.QueryRow(ctx,
-		`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
+		`SELECT COUNT(*) FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
 		result.UserID, orgID,
-	).Scan(&role); err != nil {
-		t.Fatalf("membership: %v", err)
+	).Scan(&membershipCount); err != nil {
+		t.Fatalf("membership count: %v", err)
 	}
-	if role != "viewer" {
-		t.Errorf("google login must stay viewer-if-missing, got %q", role)
+	if membershipCount != 0 {
+		t.Errorf("google login must not auto-insert viewer membership, count=%d", membershipCount)
 	}
 
 	var providerUserID string
@@ -302,11 +380,82 @@ func TestFinish_googleExchangeUpsertViewer(t *testing.T) {
 	}
 }
 
-func TestFinish_microsoftExchangeUpsertViewer(t *testing.T) {
+func TestFinish_microsoftUnknownEmailDoesNotCreateUser(t *testing.T) {
+	slug := "ms-nouser-" + uuid.NewString()[:8]
+	email := "stranger@" + slug + ".example"
+	orgID, cleanup := setupOrgWithSSO(t, "microsoft", slug, "common")
+	defer cleanup()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/token"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "mock-ms",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(microsoftUserInfo{
+				ID:          "ms-stranger-1",
+				DisplayName: "MS Stranger",
+				Mail:        email,
+			})
+		}
+	}))
+	defer srv.Close()
+
+	prevGraph := microsoftGraphURL
+	microsoftGraphURL = srv.URL + "/v1.0/me"
+	defer func() { microsoftGraphURL = prevGraph }()
+
+	rec := &recordingTransport{base: rewriteHost{target: srv.URL, base: http.DefaultTransport}}
+	mod := New(&http.Client{Transport: rec})
+
+	_, err := mod.Finish(context.Background(), testPool, FinishRequest{
+		Provider:    ProviderMicrosoft,
+		OrgSlug:     slug,
+		RedirectURL: "http://localhost:8080/api/auth/microsoft/callback",
+		Code:        "auth-code",
+	})
+	if !errors.Is(err, ErrNoAccount) {
+		t.Fatalf("Finish: %v, want ErrNoAccount", err)
+	}
+
+	var userCount int
+	if err := testPool.QueryRow(context.Background(), `SELECT COUNT(*) FROM users WHERE email = $1`, email).Scan(&userCount); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if userCount != 0 {
+		t.Fatalf("must not create user for unknown Microsoft email, count=%d", userCount)
+	}
+
+	var membershipCount int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM organization_memberships WHERE organization_id = $1`, orgID,
+	).Scan(&membershipCount); err != nil {
+		t.Fatalf("count memberships: %v", err)
+	}
+	if membershipCount != 0 {
+		t.Fatalf("must not insert membership for stranger, count=%d", membershipCount)
+	}
+}
+
+func TestFinish_microsoftExistingUserNoViewerInsert(t *testing.T) {
 	slug := "ms-finish-" + uuid.NewString()[:8]
 	email := "user@" + slug + ".example"
 	orgID, cleanup := setupOrgWithSSO(t, "microsoft", slug, "common")
 	defer cleanup()
+
+	ctx := context.Background()
+	var existingID uuid.UUID
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id`,
+		email, "MS User",
+	).Scan(&existingID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -334,12 +483,10 @@ func TestFinish_microsoftExchangeUpsertViewer(t *testing.T) {
 	microsoftGraphURL = srv.URL + "/v1.0/me"
 	defer func() { microsoftGraphURL = prevGraph }()
 
-	// Microsoft token URL is built from tenant_id (login.microsoftonline.com/...).
-	// Point the oauth2 config at the mock by swapping tenant host via a rewrite client.
 	rec := &recordingTransport{base: rewriteHost{target: srv.URL, base: http.DefaultTransport}}
 	mod := New(&http.Client{Transport: rec})
 
-	result, err := mod.Finish(context.Background(), testPool, FinishRequest{
+	result, err := mod.Finish(ctx, testPool, FinishRequest{
 		Provider:    ProviderMicrosoft,
 		OrgSlug:     slug,
 		RedirectURL: "http://localhost:8080/api/auth/microsoft/callback",
@@ -348,19 +495,22 @@ func TestFinish_microsoftExchangeUpsertViewer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Finish: %v", err)
 	}
+	if result.UserID != existingID {
+		t.Errorf("user id = %s, want existing %s", result.UserID, existingID)
+	}
 	if result.Email != email {
 		t.Errorf("email = %q, want %q", result.Email, email)
 	}
 
-	var role string
-	if err := testPool.QueryRow(context.Background(),
-		`SELECT role FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
+	var membershipCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM organization_memberships WHERE user_id = $1 AND organization_id = $2`,
 		result.UserID, orgID,
-	).Scan(&role); err != nil {
-		t.Fatalf("membership: %v", err)
+	).Scan(&membershipCount); err != nil {
+		t.Fatalf("membership count: %v", err)
 	}
-	if role != "viewer" {
-		t.Errorf("microsoft login must stay viewer-if-missing, got %q", role)
+	if membershipCount != 0 {
+		t.Errorf("microsoft login must not auto-insert viewer membership, count=%d", membershipCount)
 	}
 	if !rec.seen("login.microsoftonline.com") && !rec.seen("/token") {
 		t.Fatalf("injected client did not see token exchange: %v", rec.urls)

--- a/deploy/docker/standalone/README.md
+++ b/deploy/docker/standalone/README.md
@@ -24,7 +24,7 @@ Open http://localhost:8080 — the SPA and API share the same origin (`/api` is 
 
 ## First admin user
 
-Migrations run automatically on startup. Create the first user via the registration UI or API:
+Migrations run automatically on startup. Create the **first** user via the registration UI or API while no users exist (`GET /api/auth/config` → `"registrationOpen": true`). After that, `POST /api/auth/register` returns 403 and the login page hides “Create one”.
 
 ```bash
 curl -fsS -X POST http://localhost:8080/api/auth/register \

--- a/frontend/src/api/auth.spec.ts
+++ b/frontend/src/api/auth.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fetchSSOProviders } from './auth'
+import { fetchAuthConfig, fetchSSOProviders } from './auth'
 
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
@@ -29,5 +29,25 @@ describe('auth API', () => {
     const result = await fetchSSOProviders('acme')
 
     expect(result).toEqual([])
+  })
+
+  it('returns registrationOpen from fetchAuthConfig', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ registrationOpen: true }),
+    })
+
+    const result = await fetchAuthConfig()
+
+    expect(result).toEqual({ registrationOpen: true })
+    expect(mockFetch).toHaveBeenCalledWith('/api/auth/config')
+  })
+
+  it('fails closed when fetchAuthConfig is unavailable', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network'))
+
+    const result = await fetchAuthConfig()
+
+    expect(result).toEqual({ registrationOpen: false })
   })
 })

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -55,6 +55,10 @@ export type SSOProvider = {
   provider: string
 }
 
+export type AuthConfig = {
+  registrationOpen: boolean
+}
+
 function normalizeMe(me: MeApiResponse): MeResponse {
   return {
     ...me,
@@ -106,6 +110,9 @@ export async function register(data: RegisterRequest): Promise<AuthResponse> {
   if (!response.ok) {
     if (response.status === 409) {
       throw new Error('Email already registered')
+    }
+    if (response.status === 403) {
+      throw new Error('Registration is closed')
     }
     if (response.status === 400) {
       const error = await response.json().catch(() => ({}))
@@ -189,6 +196,17 @@ export async function fetchSSOProviders(orgSlug: string): Promise<SSOProvider[]>
     return (await response.json()) as SSOProvider[]
   } catch {
     return []
+  }
+}
+
+export async function fetchAuthConfig(): Promise<AuthConfig> {
+  try {
+    const response = await fetch(`${API_BASE}/api/auth/config`)
+    if (!response.ok) return { registrationOpen: false }
+    const data = (await response.json()) as AuthConfig
+    return { registrationOpen: Boolean(data.registrationOpen) }
+  } catch {
+    return { registrationOpen: false }
   }
 }
 

--- a/frontend/src/pages/LoginPage.spec.tsx
+++ b/frontend/src/pages/LoginPage.spec.tsx
@@ -38,6 +38,7 @@ describe('LoginPage', () => {
       isAuthenticated: false,
     })
     vi.restoreAllMocks()
+    vi.spyOn(authApi, 'fetchAuthConfig').mockResolvedValue({ registrationOpen: false })
   })
 
   it('submits credentials and navigates to the redirect target', async () => {
@@ -74,5 +75,23 @@ describe('LoginPage', () => {
 
     expect(await screen.findByTestId('sso-providers')).toBeTruthy()
     expect(screen.getByTestId('sso-btn-google')).toBeTruthy()
+  })
+
+  it('hides create-account when registration is closed', async () => {
+    renderLogin()
+
+    await waitFor(() => {
+      expect(authApi.fetchAuthConfig).toHaveBeenCalled()
+    })
+    expect(screen.queryByTestId('auth-mode-switch-btn')).toBeNull()
+    expect(screen.queryByText('Create one')).toBeNull()
+  })
+
+  it('shows create-account when registration is open', async () => {
+    vi.spyOn(authApi, 'fetchAuthConfig').mockResolvedValue({ registrationOpen: true })
+    renderLogin()
+
+    expect(await screen.findByTestId('auth-mode-switch-btn')).toBeTruthy()
+    expect(screen.getByText('Create one')).toBeTruthy()
   })
 })

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 import { API_BASE } from '@/api/base'
 import type { SSOProvider } from '@/api/auth'
-import { fetchSSOProviders } from '@/api/auth'
+import { fetchAuthConfig, fetchSSOProviders } from '@/api/auth'
 import { Button } from '@/components/ui/button'
 import { safeRedirectPath } from '@/lib/safeRedirect'
 import { storeSsoRedirect } from '@/lib/ssoRedirect'
@@ -35,6 +35,16 @@ export function LoginPage() {
   const [orgSlug, setOrgSlug] = useState<string | null>(null)
   const [ssoProviders, setSsoProviders] = useState<SSOProvider[]>([])
   const [ssoLoading, setSsoLoading] = useState(false)
+  const [registrationOpen, setRegistrationOpen] = useState(false)
+
+  useEffect(() => {
+    void fetchAuthConfig().then(config => {
+      setRegistrationOpen(config.registrationOpen)
+      if (!config.registrationOpen) {
+        setMode('login')
+      }
+    })
+  }, [])
 
   useEffect(() => {
     const org = searchParams.get('org')
@@ -265,19 +275,21 @@ export function LoginPage() {
           </button>
         </form>
 
-        <div className="mt-6 text-center">
-          <p className="text-sm text-[var(--color-outline)]">
-            {mode === 'login' ? "Don't have an account?" : 'Already have an account?'}{' '}
-            <button
-              type="button"
-              className="ml-1 cursor-pointer border-none bg-transparent p-0 text-sm font-medium text-[var(--color-primary)] hover:underline"
-              onClick={switchMode}
-              data-testid="auth-mode-switch-btn"
-            >
-              {mode === 'login' ? 'Create one' : 'Sign in'}
-            </button>
-          </p>
-        </div>
+        {registrationOpen && (
+          <div className="mt-6 text-center">
+            <p className="text-sm text-[var(--color-outline)]">
+              {mode === 'login' ? "Don't have an account?" : 'Already have an account?'}{' '}
+              <button
+                type="button"
+                className="ml-1 cursor-pointer border-none bg-transparent p-0 text-sm font-medium text-[var(--color-primary)] hover:underline"
+                onClick={switchMode}
+                data-testid="auth-mode-switch-btn"
+              >
+                {mode === 'login' ? 'Create one' : 'Sign in'}
+              </button>
+            </p>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -14,7 +14,7 @@ Most endpoints require a Bearer JWT token in the `Authorization` header:
 Authorization: Bearer <access_token>
 ```
 
-Obtain tokens via `POST /api/auth/login` or `POST /api/auth/register`. Tokens expire after 15 minutes. Use `POST /api/auth/refresh` with a refresh token to obtain a new access token.
+Obtain tokens via `POST /api/auth/login`. First-user bootstrap uses `POST /api/auth/register` only while `GET /api/auth/config` reports `"registrationOpen": true` (empty `users` table); after that register returns 403. Tokens expire after 15 minutes. Use `POST /api/auth/refresh` with a refresh token to obtain a new access token.
 
 ## Organization scope
 

--- a/website/api/routes.md
+++ b/website/api/routes.md
@@ -16,7 +16,8 @@ title: API Routes
 
 | Method | Path | Auth | Org Member | Description |
 |--------|------|------|------------|-------------|
-| POST | `/api/auth/register` | - | - | Register handles user registration |
+| GET | `/api/auth/config` | - | - | GetAuthConfig reports whether first-user registration is still open. |
+| POST | `/api/auth/register` | - | - | Register creates the first user when the users table is empty. After that it returns 403. |
 | POST | `/api/auth/login` | - | - | Login handles user login |
 | GET | `/api/auth/me` | Yes | - | Me returns the current user's profile |
 | GET | `/api/auth/me/methods` | Yes | - | GetAuthMethods lists all auth methods for the current user |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #394.

ace.janhoon.app cannot have public signup. This PR closes the live hole: `POST /api/auth/register` is no longer always open, the login page no longer shows a public “Create one” toggle after the first user, and Google/Microsoft SSO no longer upserts strangers as viewers.

## Locked grill (Jan/PMO 2026-08-20 — do not reopen)

1. **First-user bootstrap, then closed.** `POST /api/auth/register` succeeds only when `users` is empty. After that it returns **403**. No env flag required for the default; this is the product.
2. **Login UI.** Hide “Don’t have an account? Create one” when register is closed. Expose a small public config (`GET /api/auth/config` with `{ "registrationOpen": bool }`) so the SPA does not guess.
3. **Google / Microsoft SSO.** Do not create users or org memberships for strangers. SSO signs in an existing user (email match) or fails. No auto-viewer insert. Okta role mapping stays for orgs that use it; still no silent account create unless the email already exists.
4. **This deploy.** One operator: Jan. First register on ace.janhoon.app is him. After that, only he (and later Google on that same account) can get in.

## What changed

- Register is serialized with a transaction + advisory lock so two empty-DB posts cannot both succeed.
- `GET /api/auth/config` is public and fail-closed on the SPA (hide Create one unless `registrationOpen` is true).
- `sso.Finish` looks up an existing email instead of upserting; Google/Microsoft no longer insert viewer membership. Linking `user_auth_methods` still works for an existing user (needed once #393 is enabled).
- Test helpers seed users via INSERT rather than `POST /register`, since register is now one-shot.

## Acceptance

- Empty DB: one register works and becomes the only local admin path
- Second `POST /api/auth/register` is 403
- Login page has no Create-one after first user (`registrationOpen: false`)
- Google/Microsoft callback does not upsert a new user
- Existing user can still password-login and (once #393 is set up) Google-login

## Out of scope

Authentik on Ace. Invite-only multi-user. Datasource wiring. Speke. List. Cadac. Speke #179. #393 (Google SSO enable-and-link) is not implemented here.

## Tests

- Frontend: `LoginPage` + `auth` API vitest (8 passing). `tsc --noEmit` clean.
- Backend: `go test ./...` (handlers/SSO DB cases skip in this environment without Postgres, same as CI). New coverage: register 403 when users exist, auth config, SSO unknown email does not create a user, existing Google/Microsoft login does not insert viewer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e6a7b39-7380-4957-a5f4-40a9c1dbfd99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e6a7b39-7380-4957-a5f4-40a9c1dbfd99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

