### PR TITLE
fix: close public signup after first user

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -153,6 +153,7 @@ func main() {
 	}
 	authHandler := handlers.NewAuthHandler(pool, jwtManager, rdb)
 	mux.HandleFunc("GET /api/auth/config", authHandler.GetAuthConfig)
+	// POST /api/auth/register is first-user only; once any user exists it returns 403.
 	mux.HandleFunc("POST /api/auth/register", authHandler.Register)
 	mux.HandleFunc("POST /api/auth/login", authHandler.Login)
 	mux.HandleFunc("GET /api/auth/me", auth.RequireAuth(jwtManager, authHandler.Me))

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -104,6 +104,7 @@ func (h *AuthHandler) GetAuthConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // Register creates the first user when the users table is empty. After that it returns 403.
+// Public signup is not available: POST /api/auth/register stays first-user-only then closed.
 func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	var req RegisterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#395 already shipped the first-user-then-closed signup lock (squash `fe7db86`), but the squash title was not conventional (`Lock Ace: no public signup…`). Release Please therefore skipped a bump ([workflow run 32379930030](https://github.com/aceobservability/ace/actions/runs/32379930030) — 0 parseable commits since v0.19.1). Related: #394 / #395.

This PR is the releasable `fix:` marker so Please can count a patch (expected 0.19.2). It does not set a version or `Release-As` footer.

## What

Document existing behavior next to `POST /api/auth/register`: register is first-user only, then 403. No behavior change, no Speke/List changes, no CHANGELOG edit.

## Test plan

- Focused Go tests for auth register if run in CI / locally (`backend/internal/handlers` auth tests).
- Comment-only / docs-adjacent; no new features.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a1b814d-7f46-4d14-ba28-60d5e1bfeb99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a1b814d-7f46-4d14-ba28-60d5e1bfeb99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

