### PR TITLE
ci: deploy Coolify after standalone release image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,3 +429,21 @@ jobs:
             release-assets/checksums.txt
             release-assets/sbom/*.spdx.json
           fail_on_unmatched_files: true
+
+  deploy-coolify-standalone:
+    name: Deploy standalone image
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease != true
+    needs:
+      - docker-images
+    steps:
+      - name: Trigger Coolify deploy
+        env:
+          COOLIFY_DEPLOY_WEBHOOK: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK }}
+        run: |
+          set -euo pipefail
+          if [ -z "${COOLIFY_DEPLOY_WEBHOOK}" ]; then
+            echo "COOLIFY_DEPLOY_WEBHOOK secret is not set" >&2
+            exit 1
+          fi
+          curl -fsS -X POST "${COOLIFY_DEPLOY_WEBHOOK}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small `deploy-coolify-standalone` job to `.github/workflows/release.yml` so a published Ace release can trigger Coolify after `ace-standalone` is on GHCR.

- Runs only on this workflow (`release` published and `workflow_dispatch` that republishes a tag). Not on every `main` push.
- `needs: docker-images` only. Does not wait on `smoke-standalone`.
- Skips GitHub prereleases (`github.event.release.prerelease`).
- POSTs `secrets.COOLIFY_DEPLOY_WEBHOOK` with `curl -fsS -X POST`. Fails if the secret is unset or empty. Does not print the secret.

Goblin owns putting the secret on the repo and the Coolify image pin. This PR does not add a webhook URL or change compose/product/auth.

## Test plan

- [ ] Confirm `COOLIFY_DEPLOY_WEBHOOK` is configured on the repo (Goblin).
- [ ] Next non-prerelease: Release Please merge → `docker-images` succeeds → this job POSTs and Coolify pulls the new standalone tag.
- [ ] Prerelease publish: this job is skipped.
- [ ] Secret missing: this job fails without echoing the value.

Fixes #398

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-514c106e-6729-4771-8124-203f8a44233b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-514c106e-6729-4771-8124-203f8a44233b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

