### PR TITLE
Dispatch LLM providers by registered provider_type

### DIFF
--- a/backend/internal/handlers/ai_handler.go
+++ b/backend/internal/handlers/ai_handler.go
@@ -307,12 +307,7 @@ type providerQuota struct {
 
 func (h *AIHandler) buildDBProvider(ctx context.Context, providerID, orgID uuid.UUID) (AIProvider, providerQuota, error) {
 	if h.testProviderRow != nil {
-		p := *h.testProviderRow
-		apiKey := ""
-		if p.APIKey != nil {
-			apiKey = *p.APIKey
-		}
-		return instantiateDBProvider(p, apiKey)
+		return instantiateDBProvider(*h.testProviderRow)
 	}
 
 	if h.pool == nil {
@@ -331,23 +326,35 @@ func (h *AIHandler) buildDBProvider(ctx context.Context, providerID, orgID uuid.
 		return nil, providerQuota{}, fmt.Errorf("provider not found")
 	}
 
-	apiKey := ""
-	if p.APIKey != nil && *p.APIKey != "" {
-		decrypted, err := crypto.DecryptToken(*p.APIKey)
-		if err != nil {
-			return nil, providerQuota{}, fmt.Errorf("failed to decrypt provider API key: %w", err)
-		}
-		apiKey = decrypted
-	}
-
-	return instantiateDBProvider(p, apiKey)
+	return instantiateDBProvider(p)
 }
 
-func instantiateDBProvider(p providerRow, apiKey string) (AIProvider, providerQuota, error) {
+// dbAPIKeyForFactory returns LLMConfig.APIKey for a stored ai_providers row.
+// OpenAI-compat types get decrypted plaintext. Copilot keeps ciphertext because
+// CopilotProvider decrypts EncryptedGHToken on ListModels/Chat.
+func dbAPIKeyForFactory(providerType string, stored *string) (string, error) {
+	if stored == nil || *stored == "" {
+		return "", nil
+	}
+	if providerType == "copilot" {
+		return *stored, nil
+	}
+	decrypted, err := crypto.DecryptToken(*stored)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt provider API key: %w", err)
+	}
+	return decrypted, nil
+}
+
+func instantiateDBProvider(p providerRow) (AIProvider, providerQuota, error) {
 	quota := providerQuota{
 		ProviderID: p.ID,
 		Limit:      p.RateLimitPerUser,
 		WindowSecs: p.RateLimitWindowSeconds,
+	}
+	apiKey, err := dbAPIKeyForFactory(p.ProviderType, p.APIKey)
+	if err != nil {
+		return nil, quota, err
 	}
 	provider, err := newLLMProvider(p.ProviderType, LLMConfig{
 		BaseURL:     p.BaseURL,

--- a/backend/internal/handlers/ai_handler.go
+++ b/backend/internal/handlers/ai_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -129,6 +130,10 @@ type AIHandler struct {
 
 	// testProvider allows tests to inject a mock AIProvider, bypassing DB resolution.
 	testProvider AIProvider
+
+	// testProviderRow, if set, is dispatched by provider_type in buildDBProvider
+	// without hitting the database. Tests use this to exercise register+dispatch.
+	testProviderRow *providerRow
 }
 
 // NewAIHandler creates a new AI handler.
@@ -264,6 +269,14 @@ func (h *AIHandler) resolveProvider(ctx context.Context, providerID string, user
 	return h.buildDBProvider(ctx, pid, orgID)
 }
 
+func writeResolveError(w http.ResponseWriter, err error) {
+	status := http.StatusNotFound
+	if errors.Is(err, ErrUnknownProviderType) {
+		status = http.StatusBadRequest
+	}
+	jsonError(w, err.Error(), status)
+}
+
 func (h *AIHandler) buildCopilotProvider(ctx context.Context, userID uuid.UUID) (*CopilotProvider, error) {
 	if h.pool == nil {
 		return nil, fmt.Errorf("failed to load copilot connection")
@@ -292,7 +305,16 @@ type providerQuota struct {
 	WindowSecs int
 }
 
-func (h *AIHandler) buildDBProvider(ctx context.Context, providerID, orgID uuid.UUID) (*OpenAICompatibleProvider, providerQuota, error) {
+func (h *AIHandler) buildDBProvider(ctx context.Context, providerID, orgID uuid.UUID) (AIProvider, providerQuota, error) {
+	if h.testProviderRow != nil {
+		p := *h.testProviderRow
+		apiKey := ""
+		if p.APIKey != nil {
+			apiKey = *p.APIKey
+		}
+		return instantiateDBProvider(p, apiKey)
+	}
+
 	if h.pool == nil {
 		return nil, providerQuota{}, fmt.Errorf("failed to load provider")
 	}
@@ -318,13 +340,24 @@ func (h *AIHandler) buildDBProvider(ctx context.Context, providerID, orgID uuid.
 		apiKey = decrypted
 	}
 
+	return instantiateDBProvider(p, apiKey)
+}
+
+func instantiateDBProvider(p providerRow, apiKey string) (AIProvider, providerQuota, error) {
 	quota := providerQuota{
 		ProviderID: p.ID,
 		Limit:      p.RateLimitPerUser,
 		WindowSecs: p.RateLimitWindowSeconds,
 	}
-
-	return NewOpenAICompatibleProvider(p.BaseURL, apiKey, p.DisplayName), quota, nil
+	provider, err := newLLMProvider(p.ProviderType, LLMConfig{
+		BaseURL:     p.BaseURL,
+		APIKey:      apiKey,
+		DisplayName: p.DisplayName,
+	})
+	if err != nil {
+		return nil, quota, err
+	}
+	return provider, quota, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -446,7 +479,7 @@ func (h *AIHandler) ListModels(w http.ResponseWriter, r *http.Request) {
 
 	provider, _, err := h.resolveProvider(ctx, providerID, userID, orgID)
 	if err != nil {
-		jsonError(w, err.Error(), http.StatusNotFound)
+		writeResolveError(w, err)
 		return
 	}
 
@@ -540,7 +573,7 @@ func (h *AIHandler) Chat(w http.ResponseWriter, r *http.Request) {
 	// Resolve provider
 	provider, quota, err := h.resolveProvider(ctx, reqBody.ProviderID, userID, orgID)
 	if err != nil {
-		jsonError(w, err.Error(), http.StatusNotFound)
+		writeResolveError(w, err)
 		return
 	}
 
@@ -650,6 +683,11 @@ func (h *AIHandler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 
 	if reqBody.ProviderType == "" || reqBody.DisplayName == "" || reqBody.BaseURL == "" {
 		jsonError(w, "provider_type, display_name, and base_url are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := requireKnownLLMType(reqBody.ProviderType); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -780,6 +818,11 @@ func (h *AIHandler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 	if reqBody.RateLimitWindowSeconds != nil {
 		existing.RateLimitWindowSeconds = *reqBody.RateLimitWindowSeconds
+	}
+
+	if err := requireKnownLLMType(existing.ProviderType); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	// Fix #1: SSRF validation on base_url (validate the final URL after applying updates)

--- a/backend/internal/handlers/ai_plugin.go
+++ b/backend/internal/handlers/ai_plugin.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+const pluginKindLLM = "llm"
+
+// LLMConfig is the in-process config passed to an LLM plugin factory.
+type LLMConfig struct {
+	BaseURL     string
+	APIKey      string
+	DisplayName string
+}
+
+// LLMFactory constructs an AIProvider from LLMConfig.
+type LLMFactory func(LLMConfig) (AIProvider, error)
+
+// ErrUnknownProviderType is returned when ai_providers.provider_type has no
+// registered factory. Callers must fail closed: never fall through to
+// OpenAI-compat.
+var ErrUnknownProviderType = errors.New("unknown provider_type")
+
+// pluginRegistry is kind → id → factory. v1 wires kind=llm only.
+var pluginRegistry = struct {
+	mu sync.RWMutex
+	m  map[string]map[string]LLMFactory
+}{
+	m: map[string]map[string]LLMFactory{
+		pluginKindLLM: {},
+	},
+}
+
+// RegisterLLM records a factory for provider_type under kind=llm.
+func RegisterLLM(providerType string, factory LLMFactory) {
+	if providerType == "" {
+		panic("RegisterLLM: empty provider_type")
+	}
+	if factory == nil {
+		panic("RegisterLLM: nil factory")
+	}
+	pluginRegistry.mu.Lock()
+	defer pluginRegistry.mu.Unlock()
+	pluginRegistry.m[pluginKindLLM][providerType] = factory
+}
+
+func lookupLLM(providerType string) (LLMFactory, bool) {
+	pluginRegistry.mu.RLock()
+	defer pluginRegistry.mu.RUnlock()
+	kind, ok := pluginRegistry.m[pluginKindLLM]
+	if !ok {
+		return nil, false
+	}
+	f, ok := kind[providerType]
+	return f, ok
+}
+
+func unregisterLLM(providerType string) {
+	pluginRegistry.mu.Lock()
+	defer pluginRegistry.mu.Unlock()
+	delete(pluginRegistry.m[pluginKindLLM], providerType)
+}
+
+func newLLMProvider(providerType string, cfg LLMConfig) (AIProvider, error) {
+	factory, ok := lookupLLM(providerType)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownProviderType, providerType)
+	}
+	return factory(cfg)
+}
+
+func requireKnownLLMType(providerType string) error {
+	if _, ok := lookupLLM(providerType); !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownProviderType, providerType)
+	}
+	return nil
+}
+
+func init() {
+	openaiCompat := func(cfg LLMConfig) (AIProvider, error) {
+		return NewOpenAICompatibleProvider(cfg.BaseURL, cfg.APIKey, cfg.DisplayName), nil
+	}
+	RegisterLLM("openai", openaiCompat)
+	RegisterLLM("openrouter", openaiCompat)
+	RegisterLLM("ollama", openaiCompat)
+	RegisterLLM("custom", openaiCompat)
+	// Copilot's live chat path remains provider_id=="copilot" (user GH token).
+	// Registering the type means a stored provider_type=copilot does not
+	// impersonate OpenAI-compat. LLMConfig.APIKey is the encrypted GH token.
+	RegisterLLM("copilot", func(cfg LLMConfig) (AIProvider, error) {
+		return &CopilotProvider{EncryptedGHToken: cfg.APIKey}, nil
+	})
+}

--- a/backend/internal/handlers/ai_plugin.go
+++ b/backend/internal/handlers/ai_plugin.go
@@ -6,11 +6,12 @@ import (
 	"sync"
 )
 
-const pluginKindLLM = "llm"
-
 // LLMConfig is the in-process config passed to an LLM plugin factory.
 type LLMConfig struct {
-	BaseURL     string
+	BaseURL string
+	// APIKey is decrypted plaintext for openai/openrouter/ollama/custom.
+	// For copilot it is still-encrypted GH token; CopilotProvider decrypts
+	// EncryptedGHToken on ListModels/Chat.
 	APIKey      string
 	DisplayName string
 }
@@ -23,17 +24,15 @@ type LLMFactory func(LLMConfig) (AIProvider, error)
 // OpenAI-compat.
 var ErrUnknownProviderType = errors.New("unknown provider_type")
 
-// pluginRegistry is kind → id → factory. v1 wires kind=llm only.
+// pluginRegistry maps provider_type to factory.
 var pluginRegistry = struct {
 	mu sync.RWMutex
-	m  map[string]map[string]LLMFactory
+	m  map[string]LLMFactory
 }{
-	m: map[string]map[string]LLMFactory{
-		pluginKindLLM: {},
-	},
+	m: map[string]LLMFactory{},
 }
 
-// RegisterLLM records a factory for provider_type under kind=llm.
+// RegisterLLM records a factory for provider_type.
 func RegisterLLM(providerType string, factory LLMFactory) {
 	if providerType == "" {
 		panic("RegisterLLM: empty provider_type")
@@ -43,24 +42,20 @@ func RegisterLLM(providerType string, factory LLMFactory) {
 	}
 	pluginRegistry.mu.Lock()
 	defer pluginRegistry.mu.Unlock()
-	pluginRegistry.m[pluginKindLLM][providerType] = factory
+	pluginRegistry.m[providerType] = factory
 }
 
 func lookupLLM(providerType string) (LLMFactory, bool) {
 	pluginRegistry.mu.RLock()
 	defer pluginRegistry.mu.RUnlock()
-	kind, ok := pluginRegistry.m[pluginKindLLM]
-	if !ok {
-		return nil, false
-	}
-	f, ok := kind[providerType]
+	f, ok := pluginRegistry.m[providerType]
 	return f, ok
 }
 
 func unregisterLLM(providerType string) {
 	pluginRegistry.mu.Lock()
 	defer pluginRegistry.mu.Unlock()
-	delete(pluginRegistry.m[pluginKindLLM], providerType)
+	delete(pluginRegistry.m, providerType)
 }
 
 func newLLMProvider(providerType string, cfg LLMConfig) (AIProvider, error) {
@@ -88,7 +83,8 @@ func init() {
 	RegisterLLM("custom", openaiCompat)
 	// Copilot's live chat path remains provider_id=="copilot" (user GH token).
 	// Registering the type means a stored provider_type=copilot does not
-	// impersonate OpenAI-compat. LLMConfig.APIKey is the encrypted GH token.
+	// impersonate OpenAI-compat. LLMConfig.APIKey is ciphertext; the factory
+	// must not receive a decrypted key (CopilotProvider decrypts on use).
 	RegisterLLM("copilot", func(cfg LLMConfig) (AIProvider, error) {
 		return &CopilotProvider{EncryptedGHToken: cfg.APIKey}, nil
 	})

--- a/backend/internal/handlers/ai_plugin_test.go
+++ b/backend/internal/handlers/ai_plugin_test.go
@@ -1,0 +1,226 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+type probeProvider struct {
+	id string
+	mockAIProvider
+}
+
+func TestNewLLMProvider_UnknownTypeFailsClosed(t *testing.T) {
+	p, err := newLLMProvider("nope", LLMConfig{
+		BaseURL:     "https://api.openai.com/v1",
+		APIKey:      "sk-should-not-be-used",
+		DisplayName: "Nope",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown provider_type")
+	}
+	if !errors.Is(err, ErrUnknownProviderType) {
+		t.Fatalf("expected ErrUnknownProviderType, got %v", err)
+	}
+	if p != nil {
+		t.Fatalf("unknown type must not construct a provider, got %T", p)
+	}
+	if _, ok := p.(*OpenAICompatibleProvider); ok {
+		t.Fatal("unknown provider_type must not fall through to OpenAICompatibleProvider")
+	}
+}
+
+func TestNewLLMProvider_AnthropicNotRegistered(t *testing.T) {
+	// Anthropic is #416. Until that lands, a stored type must 400, not impersonate OpenAI.
+	p, err := newLLMProvider("anthropic", LLMConfig{
+		BaseURL:     "https://api.anthropic.com",
+		APIKey:      "sk-ant",
+		DisplayName: "Anthropic",
+	})
+	if !errors.Is(err, ErrUnknownProviderType) {
+		t.Fatalf("expected ErrUnknownProviderType for anthropic, got %v", err)
+	}
+	if p != nil {
+		t.Fatalf("anthropic must not construct a provider yet, got %T", p)
+	}
+}
+
+func TestNewLLMProvider_OpenAICompatListsAndChats(t *testing.T) {
+	modelsJSON := `{"data":[{"id":"gpt-4o","owned_by":"openai"}]}`
+	chatJSON := `{"id":"chatcmpl-1","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/models":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(modelsJSON))
+		case r.Method == http.MethodPost && r.URL.Path == "/chat/completions":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(chatJSON))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	for _, providerType := range []string{"openai", "openrouter", "ollama", "custom"} {
+		t.Run(providerType, func(t *testing.T) {
+			p, err := newLLMProvider(providerType, LLMConfig{
+				BaseURL:     server.URL,
+				APIKey:      "test-api-key",
+				DisplayName: providerType,
+			})
+			if err != nil {
+				t.Fatalf("newLLMProvider(%q): %v", providerType, err)
+			}
+			if _, ok := p.(*OpenAICompatibleProvider); !ok {
+				t.Fatalf("expected *OpenAICompatibleProvider, got %T", p)
+			}
+
+			models, err := p.ListModels(context.Background())
+			if err != nil {
+				t.Fatalf("ListModels: %v", err)
+			}
+			if len(models) != 1 || models[0].ID != "gpt-4o" {
+				t.Fatalf("unexpected models: %+v", models)
+			}
+
+			rr := httptest.NewRecorder()
+			err = p.Chat(context.Background(), ChatRequest{
+				Model:    "gpt-4o",
+				Messages: []json.RawMessage{json.RawMessage(`{"role":"user","content":"hi"}`)},
+			}, rr)
+			if err != nil {
+				t.Fatalf("Chat: %v", err)
+			}
+			if !strings.Contains(rr.Body.String(), `"content":"hi"`) {
+				t.Fatalf("chat body missing content, got %s", rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestNewLLMProvider_CopilotRegistered(t *testing.T) {
+	p, err := newLLMProvider("copilot", LLMConfig{APIKey: "encrypted-gh-token"})
+	if err != nil {
+		t.Fatalf("copilot should be registered: %v", err)
+	}
+	cp, ok := p.(*CopilotProvider)
+	if !ok {
+		t.Fatalf("expected *CopilotProvider, got %T", p)
+	}
+	if cp.EncryptedGHToken != "encrypted-gh-token" {
+		t.Errorf("expected EncryptedGHToken from LLMConfig.APIKey, got %q", cp.EncryptedGHToken)
+	}
+}
+
+func TestRegisterLLM_DispatchUsesRegisteredFactory(t *testing.T) {
+	const providerType = "probe-dispatch"
+	RegisterLLM(providerType, func(cfg LLMConfig) (AIProvider, error) {
+		return &probeProvider{id: cfg.DisplayName}, nil
+	})
+	t.Cleanup(func() { unregisterLLM(providerType) })
+
+	p, err := newLLMProvider(providerType, LLMConfig{DisplayName: "probe-one"})
+	if err != nil {
+		t.Fatalf("dispatch registered type: %v", err)
+	}
+	got, ok := p.(*probeProvider)
+	if !ok {
+		t.Fatalf("expected *probeProvider, got %T", p)
+	}
+	if got.id != "probe-one" {
+		t.Errorf("factory did not receive LLMConfig, id=%q", got.id)
+	}
+}
+
+func TestChat_UnknownProviderType_Returns400(t *testing.T) {
+	h := NewAIHandler(nil, nil)
+	h.testProviderRow = &providerRow{
+		ID:           uuid.New(),
+		ProviderType: "nope",
+		DisplayName:  "Nope",
+		BaseURL:      "https://example.com/v1",
+	}
+
+	userID := uuid.New()
+	orgID := uuid.New()
+	body, _ := json.Marshal(map[string]any{
+		"provider_id": h.testProviderRow.ID.String(),
+		"model":       "gpt-4o",
+		"messages":    []map[string]string{{"role": "user", "content": "hi"}},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/orgs/"+orgID.String()+"/ai/chat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctxWithUserAndOrg(userID, orgID))
+
+	rr := httptest.NewRecorder()
+	h.Chat(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown provider_type, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "unknown provider_type") {
+		t.Errorf("expected unknown provider_type in body, got %s", rr.Body.String())
+	}
+}
+
+func TestChat_RegisteredTypeIsDispatched(t *testing.T) {
+	const providerType = "probe-chat-dispatch"
+	mock := &mockAIProvider{chatBody: `{"choices":[{"index":0,"delta":{"content":"from-probe"}}]}`}
+	RegisterLLM(providerType, func(LLMConfig) (AIProvider, error) {
+		return mock, nil
+	})
+	t.Cleanup(func() { unregisterLLM(providerType) })
+
+	h := NewAIHandler(nil, nil)
+	h.testProviderRow = &providerRow{
+		ID:           uuid.New(),
+		ProviderType: providerType,
+		DisplayName:  "Probe",
+		BaseURL:      "https://example.com/v1",
+	}
+
+	userID := uuid.New()
+	orgID := uuid.New()
+	body, _ := json.Marshal(map[string]any{
+		"provider_id": h.testProviderRow.ID.String(),
+		"model":       "probe-model",
+		"messages":    []map[string]string{{"role": "user", "content": "hi"}},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/orgs/"+orgID.String()+"/ai/chat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctxWithUserAndOrg(userID, orgID))
+
+	rr := httptest.NewRecorder()
+	h.Chat(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !mock.chatCalled {
+		t.Fatal("registered factory was not used for chat")
+	}
+	if !strings.Contains(rr.Body.String(), "from-probe") {
+		t.Errorf("expected probe chat body, got %s", rr.Body.String())
+	}
+}
+
+func TestRequireKnownLLMType(t *testing.T) {
+	if err := requireKnownLLMType("openai"); err != nil {
+		t.Errorf("openai should be known: %v", err)
+	}
+	if err := requireKnownLLMType("nope"); !errors.Is(err, ErrUnknownProviderType) {
+		t.Errorf("nope should fail closed, got %v", err)
+	}
+}

--- a/backend/internal/handlers/ai_plugin_test.go
+++ b/backend/internal/handlers/ai_plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -145,6 +146,85 @@ func TestInstantiateDBProvider_CopilotKeepsCiphertext(t *testing.T) {
 	}
 	if cp.EncryptedGHToken != ciphertext {
 		t.Errorf("expected ciphertext EncryptedGHToken, got %q", cp.EncryptedGHToken)
+	}
+}
+
+func TestInstantiateDBProvider_CopilotEncryptedKeyListsAndChats(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-for-copilot-tests")
+
+	copilotToken := "tid=uuid-copilot-row-token"
+	expiresAt := time.Now().Unix() + 3600
+	chatJSON := `{"id":"chatcmpl-uuid","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`
+
+	copilotAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/models":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(copilotModelsPayload()))
+		case r.Method == http.MethodPost && r.URL.Path == "/chat/completions":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(chatJSON))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer copilotAPI.Close()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"token":      copilotToken,
+			"expires_at": expiresAt,
+			"endpoints":  map[string]string{"api": copilotAPI.URL},
+		})
+	}))
+	defer tokenServer.Close()
+
+	enc := encryptTestToken(t, "ghp_uuid_copilot_row")
+	row := providerRow{
+		ID:           uuid.New(),
+		ProviderType: "copilot",
+		DisplayName:  "Copilot",
+		APIKey:       &enc,
+	}
+
+	copilotTokenCache.Range(func(key, value any) bool {
+		copilotTokenCache.Delete(key)
+		return true
+	})
+
+	p, _, err := instantiateDBProvider(row)
+	if err != nil {
+		t.Fatalf("instantiateDBProvider: %v", err)
+	}
+	cp, ok := p.(*CopilotProvider)
+	if !ok {
+		t.Fatalf("expected *CopilotProvider, got %T", p)
+	}
+	if cp.EncryptedGHToken != enc {
+		t.Fatal("EncryptedGHToken must still be the stored ciphertext")
+	}
+	cp.tokenEndpoint = tokenServer.URL + "/copilot_internal/v2/token"
+
+	models, err := cp.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels after one decrypt: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("expected copilot models")
+	}
+
+	rr := httptest.NewRecorder()
+	err = cp.Chat(context.Background(), ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []json.RawMessage{json.RawMessage(`{"role":"user","content":"hi"}`)},
+	}, rr)
+	if err != nil {
+		t.Fatalf("Chat after one decrypt: %v", err)
+	}
+	if !strings.Contains(rr.Body.String(), `"content":"ok"`) {
+		t.Fatalf("chat body missing content, got %s", rr.Body.String())
 	}
 }
 

--- a/backend/internal/handlers/ai_plugin_test.go
+++ b/backend/internal/handlers/ai_plugin_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
+	"github.com/aceobservability/ace/backend/internal/crypto"
 )
 
 type probeProvider struct {
@@ -31,9 +33,6 @@ func TestNewLLMProvider_UnknownTypeFailsClosed(t *testing.T) {
 	}
 	if p != nil {
 		t.Fatalf("unknown type must not construct a provider, got %T", p)
-	}
-	if _, ok := p.(*OpenAICompatibleProvider); ok {
-		t.Fatal("unknown provider_type must not fall through to OpenAICompatibleProvider")
 	}
 }
 
@@ -119,6 +118,60 @@ func TestNewLLMProvider_CopilotRegistered(t *testing.T) {
 	}
 	if cp.EncryptedGHToken != "encrypted-gh-token" {
 		t.Errorf("expected EncryptedGHToken from LLMConfig.APIKey, got %q", cp.EncryptedGHToken)
+	}
+}
+
+func TestInstantiateDBProvider_CopilotKeepsCiphertext(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-for-plugin-tests")
+	// DecryptToken rejects this blob (invalid encoding). If build/instantiate
+	// decrypted before the factory, this would fail instead of constructing.
+	ciphertext := "not-valid-aes-gcm-ciphertext"
+	if _, err := crypto.DecryptToken(ciphertext); err == nil {
+		t.Fatal("sanity: blob must fail DecryptToken so a double-decrypt would be visible")
+	}
+
+	p, _, err := instantiateDBProvider(providerRow{
+		ID:           uuid.New(),
+		ProviderType: "copilot",
+		DisplayName:  "Copilot",
+		APIKey:       &ciphertext,
+	})
+	if err != nil {
+		t.Fatalf("copilot DB path must not decrypt API key: %v", err)
+	}
+	cp, ok := p.(*CopilotProvider)
+	if !ok {
+		t.Fatalf("expected *CopilotProvider, got %T", p)
+	}
+	if cp.EncryptedGHToken != ciphertext {
+		t.Errorf("expected ciphertext EncryptedGHToken, got %q", cp.EncryptedGHToken)
+	}
+}
+
+func TestInstantiateDBProvider_OpenAIDecryptsAPIKey(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret-for-plugin-tests")
+	plain := "sk-test-openai-key"
+	enc, err := crypto.EncryptToken(plain)
+	if err != nil {
+		t.Fatalf("EncryptToken: %v", err)
+	}
+
+	p, _, err := instantiateDBProvider(providerRow{
+		ID:           uuid.New(),
+		ProviderType: "openai",
+		DisplayName:  "OpenAI",
+		BaseURL:      "https://api.openai.com/v1",
+		APIKey:       &enc,
+	})
+	if err != nil {
+		t.Fatalf("openai DB path: %v", err)
+	}
+	op, ok := p.(*OpenAICompatibleProvider)
+	if !ok {
+		t.Fatalf("expected *OpenAICompatibleProvider, got %T", p)
+	}
+	if op.APIKey != plain {
+		t.Errorf("openai factory must receive plaintext, got %q", op.APIKey)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #415. Parent #414.

`buildDBProvider` stored `provider_type` and then ignored it, always constructing `OpenAICompatibleProvider` (except magic `provider_id == "copilot"`). A new LLM was either a compile-in `if` or a silent OpenAI-compat impersonation.

This is the potato plugin: an in-process map, not a host.

**Registry.** `provider_type → factory`. `RegisterLLM(provider_type, func(LLMConfig) (AIProvider, error))`. Built-ins register at process start:

- `openai` / `openrouter` / `ollama` / `custom` → existing OpenAI-compat (decrypted API key)
- `copilot` → existing Copilot. Stored `provider_type=copilot` keeps ciphertext in `LLMConfig.APIKey` because `CopilotProvider` decrypts `EncryptedGHToken` on use. Magic `provider_id == "copilot"` still uses the user GitHub token path so current rows keep working.

**Fail closed.** Unknown `provider_type` is 400 on save (create/update) and on use (list models / chat). Never falls through to OpenAI-compat. Anthropic is still unknown; that is #416.

Chat to the browser is still OpenAI SSE. AI URL policy is still save-time `validateBaseURL` (ADR-0003).

**Tests**

- unknown `provider_type` fails closed (no OpenAI-compat impersonation)
- openai-compat still lists models and chats (`openai`, `openrouter`, `ollama`, `custom`)
- copilot DB path receives ciphertext (decrypt is not applied twice)
- openai DB path still decrypts
- copilot still resolves via `provider_id`
- register+dispatch uses the registered factory

**Demo.** Save/use `provider_type=nope` → error. Existing openai / ollama / copilot still chat.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c192d92-05a7-43ab-b28f-654429e9a40a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c192d92-05a7-43ab-b28f-654429e9a40a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

