### PR TITLE
feat(ai): register Anthropic Messages LLM plugin

### DIFF
--- a/backend/internal/handlers/ai_anthropic.go
+++ b/backend/internal/handlers/ai_anthropic.go
@@ -78,12 +78,19 @@ type openAIDelta struct {
 
 // Chat sends Messages API requests and writes OpenAI-shaped JSON or SSE to w.
 func (p *AnthropicProvider) Chat(ctx context.Context, chatReq ChatRequest, w http.ResponseWriter) error {
+	if len(chatReq.Tools) > 0 {
+		return fmt.Errorf("provider returned 400: tools not supported")
+	}
+
 	system, messages, err := openaiToAnthropicMessages(chatReq.Messages)
 	if err != nil {
 		return err
 	}
 	if len(messages) == 0 {
 		return fmt.Errorf("anthropic chat requires at least one user or assistant message")
+	}
+	if messages[0].Role != "user" {
+		return fmt.Errorf("anthropic chat requires the first message to be from the user")
 	}
 
 	body := map[string]any{
@@ -139,6 +146,9 @@ func openaiToAnthropicMessages(raw []json.RawMessage) (system string, messages [
 				systemParts = append(systemParts, text)
 			}
 		case "user", "assistant":
+			if text == "" {
+				continue
+			}
 			if len(messages) > 0 && messages[len(messages)-1].Role == role {
 				messages[len(messages)-1].Content += "\n\n" + text
 				continue

--- a/backend/internal/handlers/ai_anthropic.go
+++ b/backend/internal/handlers/ai_anthropic.go
@@ -17,7 +17,6 @@ const (
 	anthropicMaxTokens  = 4096
 )
 
-// AnthropicProvider implements AIProvider for the Anthropic Messages API.
 // Outbound HTTP uses Go's default http.Client (timeout only). Base URLs are
 // checked at save time by validateBaseURL, not by ssrf.SafeClient or
 // ssrf.DatasourceClient — see docs/adr/0003-outbound-http-ssrf-policy-seams.md.
@@ -27,7 +26,6 @@ type AnthropicProvider struct {
 	DisplayName string
 }
 
-// NewAnthropic constructs an Anthropic Messages adapter from LLMConfig.
 func NewAnthropic(cfg LLMConfig) (AIProvider, error) {
 	return &AnthropicProvider{
 		BaseURL:     strings.TrimRight(cfg.BaseURL, "/"),
@@ -43,7 +41,6 @@ var anthropicAllowList = []AIModel{
 	{ID: "claude-fable-5", Name: "Claude Fable 5", Vendor: "anthropic"},
 }
 
-// ListModels returns the static allow-list of Anthropic model ids.
 func (p *AnthropicProvider) ListModels(ctx context.Context) ([]AIModel, error) {
 	out := make([]AIModel, len(anthropicAllowList))
 	copy(out, anthropicAllowList)

--- a/backend/internal/handlers/ai_anthropic.go
+++ b/backend/internal/handlers/ai_anthropic.go
@@ -1,0 +1,297 @@
+package handlers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	anthropicAPIVersion = "2023-06-01"
+	anthropicMaxTokens  = 4096
+)
+
+// AnthropicProvider implements AIProvider for the Anthropic Messages API.
+// Outbound HTTP uses Go's default http.Client (timeout only). Base URLs are
+// checked at save time by validateBaseURL, not by ssrf.SafeClient or
+// ssrf.DatasourceClient — see docs/adr/0003-outbound-http-ssrf-policy-seams.md.
+type AnthropicProvider struct {
+	BaseURL     string
+	APIKey      string
+	DisplayName string
+}
+
+// NewAnthropic constructs an Anthropic Messages adapter from LLMConfig.
+func NewAnthropic(cfg LLMConfig) (AIProvider, error) {
+	return &AnthropicProvider{
+		BaseURL:     strings.TrimRight(cfg.BaseURL, "/"),
+		APIKey:      cfg.APIKey,
+		DisplayName: cfg.DisplayName,
+	}, nil
+}
+
+var anthropicAllowList = []AIModel{
+	{ID: "claude-opus-5", Name: "Claude Opus 5", Vendor: "anthropic"},
+	{ID: "claude-sonnet-5", Name: "Claude Sonnet 5", Vendor: "anthropic"},
+	{ID: "claude-haiku-4-5", Name: "Claude Haiku 4.5", Vendor: "anthropic"},
+	{ID: "claude-fable-5", Name: "Claude Fable 5", Vendor: "anthropic"},
+}
+
+// ListModels returns the static allow-list of Anthropic model ids.
+func (p *AnthropicProvider) ListModels(ctx context.Context) ([]AIModel, error) {
+	out := make([]AIModel, len(anthropicAllowList))
+	copy(out, anthropicAllowList)
+	return out, nil
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicStreamEvent struct {
+	Type  string `json:"type"`
+	Delta struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"delta"`
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type openAIStreamChunk struct {
+	Choices []openAIStreamChoice `json:"choices"`
+}
+
+type openAIStreamChoice struct {
+	Index int         `json:"index"`
+	Delta openAIDelta `json:"delta"`
+}
+
+type openAIDelta struct {
+	Content string `json:"content"`
+}
+
+// Chat sends Messages API requests and writes OpenAI-shaped JSON or SSE to w.
+func (p *AnthropicProvider) Chat(ctx context.Context, chatReq ChatRequest, w http.ResponseWriter) error {
+	system, messages, err := openaiToAnthropicMessages(chatReq.Messages)
+	if err != nil {
+		return err
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("anthropic chat requires at least one user or assistant message")
+	}
+
+	body := map[string]any{
+		"model":      chatReq.Model,
+		"max_tokens": anthropicMaxTokens,
+		"stream":     chatReq.Stream,
+		"messages":   messages,
+	}
+	if system != "" {
+		body["system"] = system
+	}
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.BaseURL+"/v1/messages", bytes.NewReader(bodyJSON))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.APIKey)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to reach provider: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("provider returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if chatReq.Stream {
+		return writeAnthropicStreamAsOpenAI(resp.Body, w)
+	}
+	return writeAnthropicJSONAsOpenAI(resp.Body, w)
+}
+
+func openaiToAnthropicMessages(raw []json.RawMessage) (system string, messages []anthropicMessage, err error) {
+	var systemParts []string
+	for _, item := range raw {
+		role, text, convErr := openaiMessageText(item)
+		if convErr != nil {
+			return "", nil, convErr
+		}
+		switch role {
+		case "system":
+			if text != "" {
+				systemParts = append(systemParts, text)
+			}
+		case "user", "assistant":
+			if len(messages) > 0 && messages[len(messages)-1].Role == role {
+				messages[len(messages)-1].Content += "\n\n" + text
+				continue
+			}
+			messages = append(messages, anthropicMessage{Role: role, Content: text})
+		default:
+			continue
+		}
+	}
+	return strings.Join(systemParts, "\n\n"), messages, nil
+}
+
+func openaiMessageText(raw json.RawMessage) (role, text string, err error) {
+	var m struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", "", fmt.Errorf("invalid chat message: %w", err)
+	}
+	if len(m.Content) == 0 || string(m.Content) == "null" {
+		return m.Role, "", nil
+	}
+	var asString string
+	if err := json.Unmarshal(m.Content, &asString); err == nil {
+		return m.Role, asString, nil
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(m.Content, &parts); err == nil {
+		var b strings.Builder
+		for _, part := range parts {
+			if part.Type == "text" || part.Type == "" {
+				b.WriteString(part.Text)
+			}
+		}
+		return m.Role, b.String(), nil
+	}
+	return m.Role, "", nil
+}
+
+func writeAnthropicStreamAsOpenAI(r io.Reader, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, canFlush := w.(http.Flusher)
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	wroteDone := false
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" {
+			continue
+		}
+		var ev anthropicStreamEvent
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			continue
+		}
+		switch ev.Type {
+		case "content_block_delta":
+			if ev.Delta.Type != "text_delta" || ev.Delta.Text == "" {
+				continue
+			}
+			if err := writeOpenAIDelta(w, ev.Delta.Text); err != nil {
+				return err
+			}
+			if canFlush {
+				flusher.Flush()
+			}
+		case "message_stop":
+			if _, err := io.WriteString(w, "data: [DONE]\n\n"); err != nil {
+				return err
+			}
+			wroteDone = true
+			if canFlush {
+				flusher.Flush()
+			}
+		case "error":
+			msg := ev.Error.Message
+			if msg == "" {
+				msg = "stream error"
+			}
+			return fmt.Errorf("anthropic stream error: %s", msg)
+		default:
+			continue
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	if !wroteDone {
+		if _, err := io.WriteString(w, "data: [DONE]\n\n"); err != nil {
+			return err
+		}
+		if canFlush {
+			flusher.Flush()
+		}
+	}
+	return nil
+}
+
+func writeOpenAIDelta(w http.ResponseWriter, text string) error {
+	chunk := openAIStreamChunk{
+		Choices: []openAIStreamChoice{{
+			Index: 0,
+			Delta: openAIDelta{Content: text},
+		}},
+	}
+	payload, err := json.Marshal(chunk)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "data: %s\n\n", payload)
+	return err
+}
+
+func writeAnthropicJSONAsOpenAI(r io.Reader, w http.ResponseWriter) error {
+	var msg struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.NewDecoder(r).Decode(&msg); err != nil {
+		return fmt.Errorf("failed to decode anthropic response: %w", err)
+	}
+	var text strings.Builder
+	for _, block := range msg.Content {
+		if block.Type == "text" {
+			text.WriteString(block.Text)
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(map[string]any{
+		"choices": []map[string]any{
+			{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": text.String(),
+				},
+				"finish_reason": "stop",
+			},
+		},
+	})
+}

--- a/backend/internal/handlers/ai_anthropic_test.go
+++ b/backend/internal/handlers/ai_anthropic_test.go
@@ -248,6 +248,140 @@ func TestAnthropicChat_MergesSystemAndConsecutiveRoles(t *testing.T) {
 	}
 }
 
+func TestAnthropicChat_ToolsFailClosed(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		t.Error("upstream must not be called when tools are present")
+		http.Error(w, "unreachable", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	p, err := NewAnthropic(LLMConfig{BaseURL: server.URL, APIKey: "k"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	err = p.Chat(context.Background(), ChatRequest{
+		Model:    "claude-sonnet-5",
+		Messages: []json.RawMessage{json.RawMessage(`{"role":"user","content":"hi"}`)},
+		Tools:    []json.RawMessage{json.RawMessage(`{"type":"function","function":{"name":"query_prometheus"}}`)},
+	}, httptest.NewRecorder())
+	if err == nil {
+		t.Fatal("expected tools to fail closed")
+	}
+	if !isToolIncompatibilityError(err.Error()) {
+		t.Fatalf("error must match host tool-degradation predicate, got %v", err)
+	}
+	if called {
+		t.Fatal("must not call Anthropic when tools are present")
+	}
+}
+
+func TestChat_Anthropic_ToolsTriggerHostRetry(t *testing.T) {
+	hits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Errorf("upstream body: %v", err)
+		}
+		if _, ok := body["tools"]; ok {
+			t.Errorf("retry must not forward tools, body=%v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"retried-without-tools"}]}`))
+	}))
+	defer server.Close()
+
+	h := NewAIHandler(nil, nil)
+	rowID := uuid.New()
+	orgID := uuid.New()
+	h.testProviderRow = &providerRow{
+		ID:           rowID,
+		ProviderType: "anthropic",
+		DisplayName:  "Anthropic",
+		BaseURL:      server.URL,
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"provider_id": rowID.String(),
+		"model":       "claude-sonnet-5",
+		"messages":    []map[string]string{{"role": "user", "content": "hi"}},
+		"tools": []map[string]any{
+			{"type": "function", "function": map[string]string{"name": "query_prometheus"}},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/orgs/"+orgID.String()+"/ai/chat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctxWithUserAndOrg(uuid.New(), orgID))
+
+	rr := httptest.NewRecorder()
+	h.Chat(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 after tool retry, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("X-Tools-Unsupported") != "true" {
+		t.Error("expected X-Tools-Unsupported after Anthropic tool rejection")
+	}
+	if hits != 1 {
+		t.Fatalf("expected one upstream call (retry only), got %d", hits)
+	}
+	if !strings.Contains(rr.Body.String(), "retried-without-tools") {
+		t.Errorf("expected retried content, got %s", rr.Body.String())
+	}
+}
+
+func TestAnthropicChat_OmitsEmptyAssistantAndToolTurns(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Errorf("upstream body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	p, err := NewAnthropic(LLMConfig{BaseURL: server.URL, APIKey: "k"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	err = p.Chat(context.Background(), ChatRequest{
+		Model: "claude-sonnet-5",
+		Messages: []json.RawMessage{
+			json.RawMessage(`{"role":"user","content":"hi"}`),
+			json.RawMessage(`{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"query_prometheus","arguments":"{}"}}]}`),
+			json.RawMessage(`{"role":"tool","tool_call_id":"call_1","content":"metric=1"}`),
+			json.RawMessage(`{"role":"assistant","content":""}`),
+			json.RawMessage(`{"role":"user","content":"what next"}`),
+		},
+	}, httptest.NewRecorder())
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	msgs, _ := gotBody["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("expected one merged user message, got %#v", gotBody["messages"])
+	}
+	first, _ := msgs[0].(map[string]any)
+	if first["role"] != "user" {
+		t.Errorf("first role: %#v", first["role"])
+	}
+	if first["content"] != "hi\n\nwhat next" {
+		t.Errorf("content: %#v", first["content"])
+	}
+	for _, raw := range msgs {
+		m, _ := raw.(map[string]any)
+		content, _ := m["content"].(string)
+		if content == "" {
+			t.Errorf("empty content block: %#v", m)
+		}
+	}
+}
+
 func TestAnthropicChat_UpstreamError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/backend/internal/handlers/ai_anthropic_test.go
+++ b/backend/internal/handlers/ai_anthropic_test.go
@@ -1,0 +1,333 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+const anthropicStreamFixture = "" +
+	"event: message_start\n" +
+	"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"role\":\"assistant\",\"content\":[]}}\n" +
+	"\n" +
+	"event: content_block_start\n" +
+	"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+	"\n" +
+	"event: ping\n" +
+	"data: {\"type\":\"ping\"}\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"scratch\"}}\n" +
+	"\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n" +
+	"\n" +
+	"event: content_block_stop\n" +
+	"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+	"\n" +
+	"event: message_delta\n" +
+	"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n" +
+	"\n" +
+	"event: message_stop\n" +
+	"data: {\"type\":\"message_stop\"}\n" +
+	"\n"
+
+func TestAnthropicListModels_StaticAllowList(t *testing.T) {
+	p, err := NewAnthropic(LLMConfig{DisplayName: "Anthropic"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("expected static allow-list, got none")
+	}
+	seen := map[string]bool{}
+	for _, m := range models {
+		if m.ID == "" {
+			t.Fatalf("model missing id: %+v", m)
+		}
+		if m.Vendor != "anthropic" {
+			t.Errorf("expected vendor anthropic for %s, got %q", m.ID, m.Vendor)
+		}
+		if seen[m.ID] {
+			t.Errorf("duplicate model id %q", m.ID)
+		}
+		seen[m.ID] = true
+	}
+	for _, id := range []string{"claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"} {
+		if !seen[id] {
+			t.Errorf("allow-list missing %s", id)
+		}
+	}
+}
+
+func TestAnthropicChat_StreamMapsToOpenAISSE(t *testing.T) {
+	var gotPath, gotAPIKey, gotVersion, gotContentType string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		gotContentType = r.Header.Get("Content-Type")
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Errorf("upstream body: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(anthropicStreamFixture))
+	}))
+	defer server.Close()
+
+	p, err := NewAnthropic(LLMConfig{
+		BaseURL: server.URL,
+		APIKey:  "sk-ant-test",
+	})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	err = p.Chat(context.Background(), ChatRequest{
+		Model: "claude-sonnet-5",
+		Messages: []json.RawMessage{
+			json.RawMessage(`{"role":"system","content":"You are Ace."}`),
+			json.RawMessage(`{"role":"user","content":"hi"}`),
+		},
+		Stream: true,
+	}, rr)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if gotPath != "/v1/messages" {
+		t.Errorf("expected POST /v1/messages, got %s", gotPath)
+	}
+	if gotAPIKey != "sk-ant-test" {
+		t.Errorf("expected x-api-key, got %q", gotAPIKey)
+	}
+	if gotVersion != "2023-06-01" {
+		t.Errorf("expected anthropic-version 2023-06-01, got %q", gotVersion)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", gotContentType)
+	}
+	if gotBody["model"] != "claude-sonnet-5" {
+		t.Errorf("expected model claude-sonnet-5, got %#v", gotBody["model"])
+	}
+	if gotBody["stream"] != true {
+		t.Errorf("expected stream true, got %#v", gotBody["stream"])
+	}
+	if gotBody["system"] != "You are Ace." {
+		t.Errorf("expected system extracted, got %#v", gotBody["system"])
+	}
+	if _, ok := gotBody["tools"]; ok {
+		t.Errorf("tools must not be forwarded, body=%v", gotBody)
+	}
+
+	if ct := rr.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type text/event-stream, got %q", ct)
+	}
+
+	out := rr.Body.String()
+	if strings.Contains(out, "content_block_delta") {
+		t.Errorf("must not leak Anthropic event JSON, got %s", out)
+	}
+	if strings.Contains(out, "thinking") || strings.Contains(out, "scratch") {
+		t.Errorf("must ignore thinking deltas, got %s", out)
+	}
+	if !strings.Contains(out, `data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`) {
+		t.Errorf("missing Hello OpenAI SSE delta, got %s", out)
+	}
+	if !strings.Contains(out, `data: {"choices":[{"index":0,"delta":{"content":" world"}}]}`) {
+		t.Errorf("missing world OpenAI SSE delta, got %s", out)
+	}
+	if !strings.Contains(out, "data: [DONE]") {
+		t.Errorf("missing OpenAI [DONE], got %s", out)
+	}
+
+	if got := collectOpenAISSEContent(out); got != "Hello world" {
+		t.Errorf("concatenated deltas: got %q want %q", got, "Hello world")
+	}
+}
+
+func TestAnthropicChat_NonStreamMapsToOpenAIJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_01","type":"message","role":"assistant","content":[{"type":"text","text":"Hello world"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	p, err := NewAnthropic(LLMConfig{BaseURL: server.URL, APIKey: "sk-ant-test"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	err = p.Chat(context.Background(), ChatRequest{
+		Model:    "claude-sonnet-5",
+		Messages: []json.RawMessage{json.RawMessage(`{"role":"user","content":"hi"}`)},
+	}, rr)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+	var payload struct {
+		Choices []struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("openai json: %v body=%s", err, rr.Body.String())
+	}
+	if len(payload.Choices) != 1 || payload.Choices[0].Message.Content != "Hello world" {
+		t.Fatalf("unexpected openai json: %s", rr.Body.String())
+	}
+	if payload.Choices[0].Message.Role != "assistant" {
+		t.Errorf("expected assistant role, got %q", payload.Choices[0].Message.Role)
+	}
+}
+
+func TestAnthropicChat_MergesSystemAndConsecutiveRoles(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	p, err := NewAnthropic(LLMConfig{BaseURL: server.URL, APIKey: "k"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	err = p.Chat(context.Background(), ChatRequest{
+		Model: "claude-sonnet-5",
+		Messages: []json.RawMessage{
+			json.RawMessage(`{"role":"system","content":"A"}`),
+			json.RawMessage(`{"role":"system","content":"B"}`),
+			json.RawMessage(`{"role":"user","content":"one"}`),
+			json.RawMessage(`{"role":"user","content":"two"}`),
+			json.RawMessage(`{"role":"assistant","content":"prev"}`),
+			json.RawMessage(`{"role":"tool","content":"ignored"}`),
+			json.RawMessage(`{"role":"user","content":"three"}`),
+		},
+	}, httptest.NewRecorder())
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotBody["system"] != "A\n\nB" {
+		t.Errorf("system concat: %#v", gotBody["system"])
+	}
+	msgs, _ := gotBody["messages"].([]any)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 anthropic messages (merged + skip tool), got %#v", gotBody["messages"])
+	}
+	first, _ := msgs[0].(map[string]any)
+	if first["role"] != "user" || first["content"] != "one\n\ntwo" {
+		t.Errorf("first message: %#v", first)
+	}
+}
+
+func TestAnthropicChat_UpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid x-api-key"}}`))
+	}))
+	defer server.Close()
+
+	p, err := NewAnthropic(LLMConfig{BaseURL: server.URL, APIKey: "bad"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	err = p.Chat(context.Background(), ChatRequest{
+		Model:    "claude-sonnet-5",
+		Messages: []json.RawMessage{json.RawMessage(`{"role":"user","content":"hi"}`)},
+		Stream:   true,
+	}, httptest.NewRecorder())
+	if err == nil {
+		t.Fatal("expected upstream error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 in error, got %v", err)
+	}
+}
+
+func TestChat_AnthropicProviderType_Dispatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"from-anthropic"}]}`))
+	}))
+	defer server.Close()
+
+	h := NewAIHandler(nil, nil)
+	rowID := uuid.New()
+	orgID := uuid.New()
+	h.testProviderRow = &providerRow{
+		ID:           rowID,
+		ProviderType: "anthropic",
+		DisplayName:  "Anthropic",
+		BaseURL:      server.URL,
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"provider_id": rowID.String(),
+		"model":       "claude-sonnet-5",
+		"messages":    []map[string]string{{"role": "user", "content": "hi"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/orgs/"+orgID.String()+"/ai/chat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctxWithUserAndOrg(uuid.New(), orgID))
+
+	rr := httptest.NewRecorder()
+	h.Chat(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for registered anthropic, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "from-anthropic") {
+		t.Errorf("expected mapped content, got %s", rr.Body.String())
+	}
+}
+
+func collectOpenAISSEContent(body string) string {
+	var out strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "data: ") || trimmed == "data: [DONE]" {
+			continue
+		}
+		var payload struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(trimmed[6:]), &payload); err != nil {
+			continue
+		}
+		if len(payload.Choices) > 0 {
+			out.WriteString(payload.Choices[0].Delta.Content)
+		}
+	}
+	return out.String()
+}

--- a/backend/internal/handlers/ai_anthropic_test.go
+++ b/backend/internal/handlers/ai_anthropic_test.go
@@ -382,6 +382,57 @@ func TestAnthropicChat_OmitsEmptyAssistantAndToolTurns(t *testing.T) {
 	}
 }
 
+func TestOpenAIToAnthropicMessages_DoesNotMergeOntoSkippedEmpty(t *testing.T) {
+	_, messages, err := openaiToAnthropicMessages([]json.RawMessage{
+		json.RawMessage(`{"role":"user","content":"one"}`),
+		json.RawMessage(`{"role":"assistant","content":""}`),
+		json.RawMessage(`{"role":"assistant","content":"two"}`),
+		json.RawMessage(`{"role":"user","content":""}`),
+		json.RawMessage(`{"role":"user","content":"three"}`),
+	})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("expected user/assistant/user, got %#v", messages)
+	}
+	if messages[0] != (anthropicMessage{Role: "user", Content: "one"}) {
+		t.Errorf("first: %#v", messages[0])
+	}
+	if messages[1] != (anthropicMessage{Role: "assistant", Content: "two"}) {
+		t.Errorf("assistant must not start with skipped empty blob, got %#v", messages[1])
+	}
+	if messages[2] != (anthropicMessage{Role: "user", Content: "three"}) {
+		t.Errorf("user must not start with skipped empty blob, got %#v", messages[2])
+	}
+}
+
+func TestAnthropicChat_FirstMessageMustBeUser(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	p, err := NewAnthropic(LLMConfig{BaseURL: server.URL, APIKey: "k"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	err = p.Chat(context.Background(), ChatRequest{
+		Model:    "claude-sonnet-5",
+		Messages: []json.RawMessage{json.RawMessage(`{"role":"assistant","content":"I started"}`)},
+	}, httptest.NewRecorder())
+	if err == nil {
+		t.Fatal("expected first-message-must-be-user error")
+	}
+	if !strings.Contains(err.Error(), "first message") {
+		t.Errorf("expected clear first-message error, got %v", err)
+	}
+	if called {
+		t.Error("must not call Anthropic when the first message is not user")
+	}
+}
+
 func TestAnthropicChat_UpstreamError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/backend/internal/handlers/ai_plugin.go
+++ b/backend/internal/handlers/ai_plugin.go
@@ -9,7 +9,7 @@ import (
 // LLMConfig is the in-process config passed to an LLM plugin factory.
 type LLMConfig struct {
 	BaseURL string
-	// APIKey is decrypted plaintext for openai/openrouter/ollama/custom.
+	// APIKey is decrypted plaintext for openai/openrouter/ollama/custom/anthropic.
 	// For copilot it is still-encrypted GH token; CopilotProvider decrypts
 	// EncryptedGHToken on ListModels/Chat.
 	APIKey      string
@@ -81,6 +81,7 @@ func init() {
 	RegisterLLM("openrouter", openaiCompat)
 	RegisterLLM("ollama", openaiCompat)
 	RegisterLLM("custom", openaiCompat)
+	RegisterLLM("anthropic", NewAnthropic)
 	// Copilot's live chat path remains provider_id=="copilot" (user GH token).
 	// Registering the type means a stored provider_type=copilot does not
 	// impersonate OpenAI-compat. LLMConfig.APIKey is ciphertext; the factory

--- a/backend/internal/handlers/ai_plugin_test.go
+++ b/backend/internal/handlers/ai_plugin_test.go
@@ -37,18 +37,24 @@ func TestNewLLMProvider_UnknownTypeFailsClosed(t *testing.T) {
 	}
 }
 
-func TestNewLLMProvider_AnthropicNotRegistered(t *testing.T) {
-	// Anthropic is #416. Until that lands, a stored type must 400, not impersonate OpenAI.
+func TestNewLLMProvider_AnthropicRegistered(t *testing.T) {
 	p, err := newLLMProvider("anthropic", LLMConfig{
 		BaseURL:     "https://api.anthropic.com",
 		APIKey:      "sk-ant",
 		DisplayName: "Anthropic",
 	})
-	if !errors.Is(err, ErrUnknownProviderType) {
-		t.Fatalf("expected ErrUnknownProviderType for anthropic, got %v", err)
+	if err != nil {
+		t.Fatalf("anthropic should be registered: %v", err)
 	}
-	if p != nil {
-		t.Fatalf("anthropic must not construct a provider yet, got %T", p)
+	ap, ok := p.(*AnthropicProvider)
+	if !ok {
+		t.Fatalf("expected *AnthropicProvider, got %T", p)
+	}
+	if ap.APIKey != "sk-ant" {
+		t.Errorf("expected plaintext APIKey, got %q", ap.APIKey)
+	}
+	if ap.BaseURL != "https://api.anthropic.com" {
+		t.Errorf("expected BaseURL trimmed from config, got %q", ap.BaseURL)
 	}
 }
 
@@ -352,6 +358,9 @@ func TestChat_RegisteredTypeIsDispatched(t *testing.T) {
 func TestRequireKnownLLMType(t *testing.T) {
 	if err := requireKnownLLMType("openai"); err != nil {
 		t.Errorf("openai should be known: %v", err)
+	}
+	if err := requireKnownLLMType("anthropic"); err != nil {
+		t.Errorf("anthropic should be known: %v", err)
 	}
 	if err := requireKnownLLMType("nope"); !errors.Is(err, ErrUnknownProviderType) {
 		t.Errorf("nope should fail closed, got %v", err)

--- a/frontend/src/components/settings/AIProviderSettings.tsx
+++ b/frontend/src/components/settings/AIProviderSettings.tsx
@@ -31,6 +31,7 @@ const URL_HINTS: Record<string, string> = {
   openai: 'https://api.openai.com/v1',
   openrouter: 'https://openrouter.ai/api/v1',
   ollama: 'http://localhost:11434/v1',
+  anthropic: 'https://api.anthropic.com',
   custom: '',
 }
 
@@ -452,6 +453,7 @@ export function AIProviderSettings({
               <option value="openai">OpenAI</option>
               <option value="openrouter">OpenRouter</option>
               <option value="ollama">Ollama</option>
+              <option value="anthropic">Anthropic</option>
               <option value="custom">Custom</option>
             </select>
           </label>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#417 made `provider_type` select a factory. Anthropic was still unknown, so save and chat returned 400. This is the first in-tree plugin that is not OpenAI-compatible. It proves a foreign protocol can plug in without changing the chat handler.

Parent: #414. Closes #416.

## Scope

- `RegisterLLM("anthropic", NewAnthropic)` in `backend/internal/handlers/ai_plugin.go`.
- `AnthropicProvider` in `backend/internal/handlers/ai_anthropic.go` implements `AIProvider`.
- `Chat` posts `POST {base}/v1/messages` with `x-api-key` and `anthropic-version: 2023-06-01`.
- Stream path maps `content_block_delta` `text_delta` events to OpenAI SSE `data:` / `choices[0].delta.content` and ends with `data: [DONE]`.
- Non-stream path maps Anthropic JSON to OpenAI `choices[0].message.content` so current `sendAiChat` (which sends `stream: false`) still works.
- `ListModels` returns a static allow-list: `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`, `claude-fable-5`.
- Settings form adds Anthropic and defaults the base URL to `https://api.anthropic.com`.
- Save-time `validateBaseURL` is unchanged. Default `http.Client` only. No `SafeClient` / `DatasourceClient`.
- Tools are out. `Chat` returns `provider returned 400: tools not supported` before any upstream call so `AIHandler` retries without tools and sets `X-Tools-Unsupported`. Empty assistant/tool turns are omitted from the Messages payload. Consecutive same-role merge does not glue onto skipped empty blobs. Assistant-first histories fail locally instead of as a raw upstream 400.
- Out: embeddings, prompt-caching, WASM, Gemini/Bedrock, marketplace.

## Tradeoffs

Dual Chat (JSON and SSE) instead of always writing SSE. Ace's live `sendAiChat` path sends `stream: false` whenever tools are present, and omits `stream` otherwise. Always-SSE would work via `parseSseStream`, but it would diverge from the `ChatRequest.Stream` contract the OpenAI adapter already honors.

Static model ids instead of `GET /v1/models`. The ticket allows an allow-list. The list will drift when Anthropic ships new aliases.

## Blast Radius

Org admins can save `provider_type=anthropic` without a 400. Chat and model list for that type hit Anthropic, not OpenAI-compat. Unknown types still fail closed. Handler SSE contract and `frontend/src/api/aiChat.ts` `parseSseStream` are unchanged. Copilot ciphertext handling is unchanged. Datasource-assistant chats that attach tools still work. The host strips tools after Anthropic rejects them.

## Verification

- `go test ./internal/handlers/ -count=1` passed, including:
  - `TestNewLLMProvider_AnthropicRegistered`
  - `TestRequireKnownLLMType` (anthropic known, `nope` still 400)
  - `TestAnthropicChat_StreamMapsToOpenAISSE` (httptest fixture, no live key)
  - `TestAnthropicListModels_StaticAllowList`
  - `TestChat_UnknownProviderType_Returns400`
  - `TestChat_AnthropicProviderType_Dispatches`
  - `TestAnthropicChat_ToolsFailClosed` (`isToolIncompatibilityError` true, no upstream hit)
  - `TestChat_Anthropic_ToolsTriggerHostRetry` (`X-Tools-Unsupported`, one retry call)
  - `TestAnthropicChat_OmitsEmptyAssistantAndToolTurns`
  - `TestOpenAIToAnthropicMessages_DoesNotMergeOntoSkippedEmpty`
  - `TestAnthropicChat_FirstMessageMustBeUser`
- No live Anthropic key in this environment. Browser demo of add-provider / list-models / stream-chat was not run against `api.anthropic.com`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bea78a0e-e9ae-48a4-99a2-1e30786934a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bea78a0e-e9ae-48a4-99a2-1e30786934a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

