### PR TITLE
Refresh Dashboard to Figma 11:40

### DIFF
--- a/frontend/src/components/DashboardGrid.spec.tsx
+++ b/frontend/src/components/DashboardGrid.spec.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { DashboardGrid, GRID_GUTTER } from '@/components/DashboardGrid'
+import type { Panel as PanelType } from '@/types/panel'
+
+vi.mock('@/components/Panel', () => ({
+  Panel: ({ panel }: { panel: PanelType }) => (
+    <div data-testid={`dashboard-panel-${panel.id}`}>{panel.title}</div>
+  ),
+}))
+
+vi.mock('react-grid-layout/legacy', () => ({
+  default: ({ children, margin }: { children: ReactNode; margin?: [number, number] }) => (
+    <div data-testid="grid-layout" data-margin={margin?.join(',')}>
+      {children}
+    </div>
+  ),
+}))
+
+const panels: PanelType[] = [
+  {
+    id: 'panel-1',
+    dashboard_id: 'dash-1',
+    title: 'CPU',
+    type: 'line_chart',
+    grid_pos: { x: 0, y: 0, w: 6, h: 3 },
+    query: { expr: 'up' },
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+describe('DashboardGrid', () => {
+  it('uses the 16px design-system grid gutter', () => {
+    expect(GRID_GUTTER).toBe(16)
+
+    render(<DashboardGrid panels={panels} onPanelsChange={() => undefined} />)
+
+    expect(screen.getByTestId('dashboard-grid')).toBeTruthy()
+    expect(screen.getByTestId('grid-layout').getAttribute('data-margin')).toBe('16,16')
+    expect(screen.getByTestId('dashboard-panel-panel-1')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/DashboardGrid.tsx
+++ b/frontend/src/components/DashboardGrid.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import GridLayout, { type Layout } from 'react-grid-layout/legacy'
 import 'react-grid-layout/css/styles.css'
-import { Panel } from '@/components/Panel'
 import { updatePanel } from '@/api/panels'
+import { Panel } from '@/components/Panel'
 import type { Panel as PanelType } from '@/types/panel'
 
 type DashboardGridProps = {
@@ -15,6 +15,8 @@ type DashboardGridProps = {
 
 const COL_NUM = 12
 const ROW_HEIGHT = 100
+/** DESIGN.md panel chrome: dashboard grid gutter. */
+export const GRID_GUTTER = 16
 
 export function DashboardGrid({
   panels,
@@ -35,7 +37,7 @@ export function DashboardGrid({
 
   const layout = useMemo<Layout>(
     () =>
-      panels.map(panel => ({
+      panels.map((panel) => ({
         i: panel.id,
         x: panel.grid_pos.x,
         y: panel.grid_pos.y,
@@ -52,7 +54,7 @@ export function DashboardGrid({
 
   useEffect(() => {
     if (!containerRef.current) return
-    const observer = new ResizeObserver(entries => {
+    const observer = new ResizeObserver((entries) => {
       const width = entries[0]?.contentRect.width
       if (width && width > 0) setGridWidth(width)
     })
@@ -60,29 +62,32 @@ export function DashboardGrid({
     return () => observer.disconnect()
   }, [])
 
-  const saveLayoutToDatabase = useCallback(async (nextLayout: Layout) => {
-    for (const item of nextLayout) {
-      const panel = panels.find(entry => entry.id === item.i)
-      if (!panel) continue
-      try {
-        await updatePanel(panel.id, {
-          grid_pos: {
-            x: item.x,
-            y: item.y,
-            w: item.w,
-            h: item.h,
-          },
-        })
-      } catch (cause) {
-        console.error('Failed to save panel position:', cause)
+  const saveLayoutToDatabase = useCallback(
+    async (nextLayout: Layout) => {
+      for (const item of nextLayout) {
+        const panel = panels.find((entry) => entry.id === item.i)
+        if (!panel) continue
+        try {
+          await updatePanel(panel.id, {
+            grid_pos: {
+              x: item.x,
+              y: item.y,
+              w: item.w,
+              h: item.h,
+            },
+          })
+        } catch (cause) {
+          console.error('Failed to save panel position:', cause)
+        }
       }
-    }
-  }, [panels])
+    },
+    [panels],
+  )
 
   const handleLayoutChange = useCallback(
     (nextLayout: Layout) => {
-      const updatedPanels = panels.map(panel => {
-        const item = nextLayout.find(entry => entry.i === panel.id)
+      const updatedPanels = panels.map((panel) => {
+        const item = nextLayout.find((entry) => entry.i === panel.id)
         if (!item) return panel
         return {
           ...panel,
@@ -115,7 +120,7 @@ export function DashboardGrid({
         cols={COL_NUM}
         rowHeight={ROW_HEIGHT}
         width={gridWidth}
-        margin={[12, 12]}
+        margin={[GRID_GUTTER, GRID_GUTTER]}
         containerPadding={[0, 0]}
         isDraggable
         isResizable
@@ -123,7 +128,7 @@ export function DashboardGrid({
         draggableHandle=".panel-header"
         onLayoutChange={handleLayoutChange}
       >
-        {panels.map(panel => (
+        {panels.map((panel) => (
           <div key={panel.id} data-testid={`dashboard-grid-item-${panel.id}`}>
             <Panel
               panel={panel}

--- a/frontend/src/components/Panel.spec.tsx
+++ b/frontend/src/components/Panel.spec.tsx
@@ -96,6 +96,11 @@ describe('Panel', () => {
   it('renders line chart content for metrics panels', () => {
     render(<Panel panel={basePanel} />)
     expect(screen.getByTestId('line-chart')).toBeTruthy()
+    const chrome = screen.getByTestId('dashboard-panel-p1')
+    expect(chrome.style.backgroundColor).toBe('var(--color-surface-container-low)')
+    expect(chrome.style.borderColor).toBe('var(--color-stroke-subtle)')
+    expect(chrome.style.borderWidth).toBe('1px')
+    expect(screen.getByTestId('panel-header-meta').textContent).toBe('1h')
   })
 
   it('renders stat panels', () => {
@@ -121,6 +126,23 @@ describe('Panel', () => {
 
     render(<Panel panel={{ ...basePanel, type: 'stat' }} />)
     expect(screen.getByTestId('stat-panel')).toBeTruthy()
+  })
+
+  it('shows the live query on wide chart panel chrome', () => {
+    render(
+      <Panel
+        panel={{
+          ...basePanel,
+          grid_pos: { x: 0, y: 2, w: 8, h: 4 },
+          query: { expr: 'rate(http_requests_total[5m])', datasource_id: 'ds-1' },
+        }}
+      />,
+    )
+    expect(screen.getByTestId('line-chart')).toBeTruthy()
+    expect(screen.getByTestId('panel-header-meta').textContent).toBe(
+      'rate(http_requests_total[5m])',
+    )
+    expect(screen.getByTestId('panel-title').className).toContain('text-[13px]')
   })
 
   it('renders logs and trace list panels', () => {

--- a/frontend/src/components/Panel.spec.tsx
+++ b/frontend/src/components/Panel.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Panel } from '@/components/Panel'
+import { useTimeRangeStore } from '@/stores/timeRangeStore'
 import type { Panel as PanelType } from '@/types/panel'
 import { clearRegistry, registerPanel } from '@/utils/panelRegistry'
 
@@ -70,6 +71,7 @@ const basePanel: PanelType = {
 
 describe('Panel', () => {
   beforeEach(() => {
+    useTimeRangeStore.getState()._reset()
     clearRegistry()
     mockUsePanelData.mockReset()
     mockUsePanelData.mockReturnValue({
@@ -143,6 +145,40 @@ describe('Panel', () => {
       'rate(http_requests_total[5m])',
     )
     expect(screen.getByTestId('panel-title').className).toContain('text-[13px]')
+  })
+
+  it('shows promql on wide chrome when expr is absent', () => {
+    render(
+      <Panel
+        panel={{
+          ...basePanel,
+          grid_pos: { x: 0, y: 2, w: 8, h: 4 },
+          query: { promql: 'node_memory_MemAvailable_bytes', datasource_id: 'ds-1' },
+        }}
+      />,
+    )
+    expect(screen.getByTestId('panel-header-meta').textContent).toBe(
+      'node_memory_MemAvailable_bytes',
+    )
+  })
+
+  it('prefers expr over promql on wide chrome', () => {
+    render(
+      <Panel
+        panel={{
+          ...basePanel,
+          grid_pos: { x: 0, y: 2, w: 8, h: 4 },
+          query: { expr: 'cpu', promql: 'up', datasource_id: 'ds-1' },
+        }}
+      />,
+    )
+    expect(screen.getByTestId('panel-header-meta').textContent).toBe('cpu')
+  })
+
+  it('omits compact chrome meta during a custom range', () => {
+    useTimeRangeStore.getState().setCustomRange(1, 2)
+    render(<Panel panel={basePanel} />)
+    expect(screen.queryByTestId('panel-header-meta')).toBeNull()
   })
 
   it('keeps edit and delete actions visible', () => {

--- a/frontend/src/components/Panel.spec.tsx
+++ b/frontend/src/components/Panel.spec.tsx
@@ -145,6 +145,14 @@ describe('Panel', () => {
     expect(screen.getByTestId('panel-title').className).toContain('text-[13px]')
   })
 
+  it('keeps edit and delete actions visible', () => {
+    render(<Panel panel={basePanel} onEdit={() => undefined} onDelete={() => undefined} />)
+    const actions = screen.getByTestId('panel-edit-btn').parentElement
+    expect(actions?.className).toContain('panel-actions')
+    expect(actions?.className).not.toContain('opacity-0')
+    expect(screen.getByTestId('panel-delete-btn')).toBeTruthy()
+  })
+
   it('renders logs and trace list panels', () => {
     mockUsePanelData.mockReturnValue({
       loading: false,

--- a/frontend/src/components/Panel.tsx
+++ b/frontend/src/components/Panel.tsx
@@ -5,17 +5,27 @@ import { GaugeChart, type Threshold } from '@/components/GaugeChart'
 import { LineChart } from '@/components/LineChart'
 import { LogViewer } from '@/components/LogViewer'
 import { PieChart, type PieDataItem } from '@/components/PieChart'
+import { ensurePanelTypesRegistered } from '@/components/panels/registerPanelTypes'
 import { StatPanel } from '@/components/StatPanel'
 import { TablePanel } from '@/components/TablePanel'
 import { TraceHeatmapPanel } from '@/components/TraceHeatmapPanel'
 import { TraceListPanel } from '@/components/TraceListPanel'
-import { ensurePanelTypesRegistered } from '@/components/panels/registerPanelTypes'
 import { useCrosshairSync } from '@/contexts/CrosshairSyncContext'
 import { useDashboardVariables } from '@/contexts/VariablesContext'
 import { usePanelData } from '@/hooks/usePanelData'
+import { useTimeRange } from '@/hooks/useTimeRange'
 import type { Panel as PanelType } from '@/types/panel'
 
 ensurePanelTypesRegistered()
+
+const WIDE_PANEL_COLS = 8
+
+function panelQueryExpr(query: PanelType['query']): string {
+  if (!query) return ''
+  if (typeof query.expr === 'string' && query.expr.trim()) return query.expr
+  if (typeof query.promql === 'string' && query.promql.trim()) return query.promql
+  return ''
+}
 
 type PanelProps = {
   panel: PanelType
@@ -27,10 +37,11 @@ type PanelProps = {
 export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
   const { interpolate, variables } = useDashboardVariables()
   const { groupId } = useCrosshairSync()
+  const { selectedPreset, isCustomRange } = useTimeRange()
   const variableSignature = useMemo(
     () =>
       variables
-        .map(variable => {
+        .map((variable) => {
           const current = Array.isArray(variable.current)
             ? variable.current.join(',')
             : (variable.current ?? '')
@@ -39,15 +50,11 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
         .join('|'),
     [variables],
   )
-  const {
-    loading,
-    error,
-    chartSeries,
-    logs,
-    traceSummaries,
-    hasQuery,
-    registry,
-  } = usePanelData(panel, interpolate, variableSignature)
+  const { loading, error, chartSeries, logs, traceSummaries, hasQuery, registry } = usePanelData(
+    panel,
+    interpolate,
+    variableSignature,
+  )
 
   const gaugeValue = useMemo(() => {
     if (chartSeries.length === 0) return 0
@@ -69,7 +76,7 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
 
   const pieData = useMemo<PieDataItem[]>(
     () =>
-      chartSeries.map(series => ({
+      chartSeries.map((series) => ({
         name: series.name,
         value: series.data.length > 0 ? series.data[series.data.length - 1]!.value : 0,
       })),
@@ -87,7 +94,7 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
 
   const statData = useMemo(
     () =>
-      chartSeries[0]?.data.map(point => ({
+      chartSeries[0]?.data.map((point) => ({
         timestamp: point.timestamp,
         value: point.value,
       })) ?? [],
@@ -115,8 +122,7 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
     }
   }, [panel.query])
 
-  const textContent =
-    typeof panel.query?.content === 'string' ? panel.query.content : ''
+  const textContent = typeof panel.query?.content === 'string' ? panel.query.content : ''
 
   const isLineChart = panel.type === 'line_chart'
   const isBarChart = panel.type === 'bar_chart'
@@ -132,6 +138,9 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
   const registryEmptyState = registry?.emptyState ?? null
   const isUnsupportedRegistryPanel = registry?.supportStatus === 'unsupported'
   const isSetupRequiredRegistryPanel = registry?.supportStatus === 'setup_required'
+  const isWidePanel = panel.grid_pos.w >= WIDE_PANEL_COLS
+  const queryExpr = panelQueryExpr(panel.query)
+  const headerMeta = isWidePanel && queryExpr ? queryExpr : isCustomRange ? '' : selectedPreset
 
   function handleOpenTrace(traceId: string) {
     const datasourceId = panel.query?.datasource_id
@@ -337,48 +346,68 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
 
   return (
     <div
-      className="relative flex h-full flex-col overflow-hidden rounded-lg"
-      style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+      className="group relative flex h-full flex-col gap-2 overflow-hidden rounded-lg p-[var(--panel-padding)]"
+      style={{
+        backgroundColor: 'var(--color-surface-container-low)',
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: 'var(--color-stroke-subtle)',
+      }}
       data-testid={`dashboard-panel-${panel.id}`}
     >
-      <div
-        className="panel-header flex items-center justify-between px-4 py-2"
-        style={{ borderBottom: '1px solid var(--color-outline-variant)' }}
-      >
-        <h3 className="truncate text-sm font-semibold" style={{ color: 'var(--color-on-surface)' }}>
+      <div className="panel-header flex items-center justify-between gap-2">
+        <h3
+          className={`min-w-0 truncate font-medium ${isWidePanel ? 'text-[13px]' : 'text-xs'}`}
+          style={{
+            color: isWidePanel ? 'var(--color-on-surface)' : 'var(--color-on-surface-variant)',
+          }}
+          data-testid="panel-title"
+        >
           {panel.title}
         </h3>
-        {(onEdit || onDelete) && (
-          <div className="panel-actions flex gap-1">
-            {onEdit ? (
-              <button
-                type="button"
-                className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
-                style={{ color: 'var(--color-outline)' }}
-                data-testid="panel-edit-btn"
-                title="Edit panel"
-                onClick={() => onEdit(panel)}
-              >
-                <Pencil size={16} />
-              </button>
-            ) : null}
-            {onDelete ? (
-              <button
-                type="button"
-                className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
-                style={{ color: 'var(--color-outline)' }}
-                data-testid="panel-delete-btn"
-                title="Delete panel"
-                onClick={() => onDelete(panel)}
-              >
-                <Trash2 size={16} />
-              </button>
-            ) : null}
-          </div>
-        )}
+        <div className="flex min-w-0 shrink-0 items-center gap-1">
+          {headerMeta ? (
+            <span
+              className={`max-w-[220px] truncate ${isWidePanel ? 'font-mono text-[11px]' : 'text-[11px]'}`}
+              style={{ color: 'var(--color-on-surface-variant)' }}
+              data-testid="panel-header-meta"
+              title={headerMeta}
+            >
+              {headerMeta}
+            </span>
+          ) : null}
+          {(onEdit || onDelete) && (
+            <div className="panel-actions flex gap-1 opacity-0 transition-opacity duration-[var(--motion-fast)] group-focus-within:opacity-100 group-hover:opacity-100">
+              {onEdit ? (
+                <button
+                  type="button"
+                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
+                  style={{ color: 'var(--color-outline)' }}
+                  data-testid="panel-edit-btn"
+                  title="Edit panel"
+                  onClick={() => onEdit(panel)}
+                >
+                  <Pencil size={16} />
+                </button>
+              ) : null}
+              {onDelete ? (
+                <button
+                  type="button"
+                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
+                  style={{ color: 'var(--color-outline)' }}
+                  data-testid="panel-delete-btn"
+                  title="Delete panel"
+                  onClick={() => onDelete(panel)}
+                >
+                  <Trash2 size={16} />
+                </button>
+              ) : null}
+            </div>
+          )}
+        </div>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-2">{renderBody()}</div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{renderBody()}</div>
     </div>
   )
 }

--- a/frontend/src/components/Panel.tsx
+++ b/frontend/src/components/Panel.tsx
@@ -1,9 +1,10 @@
-import { AlertCircle, BarChart3, Pencil, Trash2 } from 'lucide-react'
+import { AlertCircle, BarChart3 } from 'lucide-react'
 import { useMemo } from 'react'
 import { BarChart } from '@/components/BarChart'
 import { GaugeChart, type Threshold } from '@/components/GaugeChart'
 import { LineChart } from '@/components/LineChart'
 import { LogViewer } from '@/components/LogViewer'
+import { PanelChrome, panelHeaderMeta, WIDE_PANEL_COLS } from '@/components/PanelChrome'
 import { PieChart, type PieDataItem } from '@/components/PieChart'
 import { ensurePanelTypesRegistered } from '@/components/panels/registerPanelTypes'
 import { StatPanel } from '@/components/StatPanel'
@@ -14,18 +15,9 @@ import { useCrosshairSync } from '@/contexts/CrosshairSyncContext'
 import { useDashboardVariables } from '@/contexts/VariablesContext'
 import { usePanelData } from '@/hooks/usePanelData'
 import { useTimeRange } from '@/hooks/useTimeRange'
-import type { Panel as PanelType } from '@/types/panel'
+import { type Panel as PanelType, readPanelQueryExpr } from '@/types/panel'
 
 ensurePanelTypesRegistered()
-
-const WIDE_PANEL_COLS = 8
-
-function panelQueryExpr(query: PanelType['query']): string {
-  if (!query) return ''
-  if (typeof query.expr === 'string' && query.expr.trim()) return query.expr
-  if (typeof query.promql === 'string' && query.promql.trim()) return query.promql
-  return ''
-}
 
 type PanelProps = {
   panel: PanelType
@@ -138,9 +130,6 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
   const registryEmptyState = registry?.emptyState ?? null
   const isUnsupportedRegistryPanel = registry?.supportStatus === 'unsupported'
   const isSetupRequiredRegistryPanel = registry?.supportStatus === 'setup_required'
-  const isWidePanel = panel.grid_pos.w >= WIDE_PANEL_COLS
-  const queryExpr = panelQueryExpr(panel.query)
-  const headerMeta = isWidePanel && queryExpr ? queryExpr : isCustomRange ? '' : selectedPreset
 
   function handleOpenTrace(traceId: string) {
     const datasourceId = panel.query?.datasource_id
@@ -345,69 +334,20 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
   }
 
   return (
-    <div
-      className="relative flex h-full flex-col gap-2 overflow-hidden rounded-lg p-[var(--panel-padding)]"
-      style={{
-        backgroundColor: 'var(--color-surface-container-low)',
-        borderWidth: '1px',
-        borderStyle: 'solid',
-        borderColor: 'var(--color-stroke-subtle)',
-      }}
-      data-testid={`dashboard-panel-${panel.id}`}
+    <PanelChrome
+      panelId={panel.id}
+      title={panel.title}
+      wide={panel.grid_pos.w >= WIDE_PANEL_COLS}
+      headerMeta={panelHeaderMeta({
+        gridWidth: panel.grid_pos.w,
+        queryExpr: readPanelQueryExpr(panel.query),
+        selectedPreset,
+        isCustomRange,
+      })}
+      onEdit={onEdit ? () => onEdit(panel) : undefined}
+      onDelete={onDelete ? () => onDelete(panel) : undefined}
     >
-      <div className="panel-header flex items-center justify-between gap-2">
-        <h3
-          className={`min-w-0 truncate font-medium ${isWidePanel ? 'text-[13px]' : 'text-xs'}`}
-          style={{
-            color: isWidePanel ? 'var(--color-on-surface)' : 'var(--color-on-surface-variant)',
-          }}
-          data-testid="panel-title"
-        >
-          {panel.title}
-        </h3>
-        <div className="flex min-w-0 shrink-0 items-center gap-1">
-          {headerMeta ? (
-            <span
-              className={`max-w-[220px] truncate ${isWidePanel ? 'font-mono text-[11px]' : 'text-[11px]'}`}
-              style={{ color: 'var(--color-on-surface-variant)' }}
-              data-testid="panel-header-meta"
-              title={headerMeta}
-            >
-              {headerMeta}
-            </span>
-          ) : null}
-          {(onEdit || onDelete) && (
-            <div className="panel-actions flex gap-1">
-              {onEdit ? (
-                <button
-                  type="button"
-                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
-                  style={{ color: 'var(--color-outline)' }}
-                  data-testid="panel-edit-btn"
-                  title="Edit panel"
-                  onClick={() => onEdit(panel)}
-                >
-                  <Pencil size={16} />
-                </button>
-              ) : null}
-              {onDelete ? (
-                <button
-                  type="button"
-                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
-                  style={{ color: 'var(--color-outline)' }}
-                  data-testid="panel-delete-btn"
-                  title="Delete panel"
-                  onClick={() => onDelete(panel)}
-                >
-                  <Trash2 size={16} />
-                </button>
-              ) : null}
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{renderBody()}</div>
-    </div>
+      {renderBody()}
+    </PanelChrome>
   )
 }

--- a/frontend/src/components/Panel.tsx
+++ b/frontend/src/components/Panel.tsx
@@ -4,7 +4,7 @@ import { BarChart } from '@/components/BarChart'
 import { GaugeChart, type Threshold } from '@/components/GaugeChart'
 import { LineChart } from '@/components/LineChart'
 import { LogViewer } from '@/components/LogViewer'
-import { PanelChrome, panelHeaderMeta, WIDE_PANEL_COLS } from '@/components/PanelChrome'
+import { PanelChrome } from '@/components/PanelChrome'
 import { PieChart, type PieDataItem } from '@/components/PieChart'
 import { ensurePanelTypesRegistered } from '@/components/panels/registerPanelTypes'
 import { StatPanel } from '@/components/StatPanel'
@@ -14,8 +14,7 @@ import { TraceListPanel } from '@/components/TraceListPanel'
 import { useCrosshairSync } from '@/contexts/CrosshairSyncContext'
 import { useDashboardVariables } from '@/contexts/VariablesContext'
 import { usePanelData } from '@/hooks/usePanelData'
-import { useTimeRange } from '@/hooks/useTimeRange'
-import { type Panel as PanelType, readPanelQueryExpr } from '@/types/panel'
+import type { Panel as PanelType } from '@/types/panel'
 
 ensurePanelTypesRegistered()
 
@@ -29,7 +28,6 @@ type PanelProps = {
 export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
   const { interpolate, variables } = useDashboardVariables()
   const { groupId } = useCrosshairSync()
-  const { selectedPreset, isCustomRange } = useTimeRange()
   const variableSignature = useMemo(
     () =>
       variables
@@ -334,19 +332,7 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
   }
 
   return (
-    <PanelChrome
-      panelId={panel.id}
-      title={panel.title}
-      wide={panel.grid_pos.w >= WIDE_PANEL_COLS}
-      headerMeta={panelHeaderMeta({
-        gridWidth: panel.grid_pos.w,
-        queryExpr: readPanelQueryExpr(panel.query),
-        selectedPreset,
-        isCustomRange,
-      })}
-      onEdit={onEdit ? () => onEdit(panel) : undefined}
-      onDelete={onDelete ? () => onDelete(panel) : undefined}
-    >
+    <PanelChrome panel={panel} onEdit={onEdit} onDelete={onDelete}>
       {renderBody()}
     </PanelChrome>
   )

--- a/frontend/src/components/Panel.tsx
+++ b/frontend/src/components/Panel.tsx
@@ -346,7 +346,7 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
 
   return (
     <div
-      className="group relative flex h-full flex-col gap-2 overflow-hidden rounded-lg p-[var(--panel-padding)]"
+      className="relative flex h-full flex-col gap-2 overflow-hidden rounded-lg p-[var(--panel-padding)]"
       style={{
         backgroundColor: 'var(--color-surface-container-low)',
         borderWidth: '1px',
@@ -377,7 +377,7 @@ export function Panel({ panel, onEdit, onDelete, onOpenTrace }: PanelProps) {
             </span>
           ) : null}
           {(onEdit || onDelete) && (
-            <div className="panel-actions flex gap-1 opacity-0 transition-opacity duration-[var(--motion-fast)] group-focus-within:opacity-100 group-hover:opacity-100">
+            <div className="panel-actions flex gap-1">
               {onEdit ? (
                 <button
                   type="button"

--- a/frontend/src/components/PanelChrome.spec.tsx
+++ b/frontend/src/components/PanelChrome.spec.tsx
@@ -68,11 +68,7 @@ describe('PanelChrome', () => {
 
   it('uses surface-card tokens and keeps actions visible', () => {
     render(
-      <PanelChrome
-        panel={chromePanel}
-        onEdit={() => undefined}
-        onDelete={() => undefined}
-      >
+      <PanelChrome panel={chromePanel} onEdit={() => undefined} onDelete={() => undefined}>
         <div data-testid="live-body" />
       </PanelChrome>,
     )

--- a/frontend/src/components/PanelChrome.spec.tsx
+++ b/frontend/src/components/PanelChrome.spec.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { PanelChrome, panelHeaderMeta, WIDE_PANEL_COLS } from '@/components/PanelChrome'
+
+describe('panelHeaderMeta', () => {
+  it('shows the query on wide panels', () => {
+    expect(
+      panelHeaderMeta({
+        gridWidth: WIDE_PANEL_COLS,
+        queryExpr: 'rate(http_requests_total[5m])',
+        selectedPreset: '1h',
+        isCustomRange: false,
+      }),
+    ).toBe('rate(http_requests_total[5m])')
+  })
+
+  it('shows the short range on compact panels', () => {
+    expect(
+      panelHeaderMeta({
+        gridWidth: 4,
+        queryExpr: 'up',
+        selectedPreset: '1h',
+        isCustomRange: false,
+      }),
+    ).toBe('1h')
+  })
+
+  it('hides meta for a custom range on compact panels', () => {
+    expect(
+      panelHeaderMeta({
+        gridWidth: 4,
+        queryExpr: 'up',
+        selectedPreset: '1h',
+        isCustomRange: true,
+      }),
+    ).toBe('')
+  })
+})
+
+describe('PanelChrome', () => {
+  it('uses surface-card tokens and keeps actions visible', () => {
+    render(
+      <PanelChrome
+        panelId="p1"
+        title="Request rate"
+        wide={false}
+        headerMeta="1h"
+        onEdit={() => undefined}
+        onDelete={() => undefined}
+      >
+        <div data-testid="live-body" />
+      </PanelChrome>,
+    )
+
+    const chrome = screen.getByTestId('dashboard-panel-p1')
+    expect(chrome.style.backgroundColor).toBe('var(--color-surface-container-low)')
+    expect(chrome.style.borderColor).toBe('var(--color-stroke-subtle)')
+    expect(screen.getByTestId('live-body')).toBeTruthy()
+    expect(screen.getByTestId('panel-edit-btn').parentElement?.className).not.toContain('opacity-0')
+  })
+})

--- a/frontend/src/components/PanelChrome.spec.tsx
+++ b/frontend/src/components/PanelChrome.spec.tsx
@@ -1,26 +1,50 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
-import { PanelChrome, panelHeaderMeta, WIDE_PANEL_COLS } from '@/components/PanelChrome'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { PanelChrome, panelHeaderMeta } from '@/components/PanelChrome'
+import { useTimeRangeStore } from '@/stores/timeRangeStore'
+import type { Panel as PanelType } from '@/types/panel'
+
+const chromePanel: PanelType = {
+  id: 'p1',
+  dashboard_id: 'd1',
+  title: 'Request rate',
+  type: 'line_chart',
+  grid_pos: { x: 0, y: 0, w: 6, h: 4 },
+  query: { expr: 'up' },
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
 
 describe('panelHeaderMeta', () => {
   it('shows the query on wide panels', () => {
     expect(
       panelHeaderMeta({
-        gridWidth: WIDE_PANEL_COLS,
+        isWidePanel: true,
         queryExpr: 'rate(http_requests_total[5m])',
-        selectedPreset: '1h',
         isCustomRange: false,
+        selectedPreset: '1h',
       }),
     ).toBe('rate(http_requests_total[5m])')
+  })
+
+  it('keeps the query on wide panels even for a custom range', () => {
+    expect(
+      panelHeaderMeta({
+        isWidePanel: true,
+        queryExpr: 'up',
+        isCustomRange: true,
+        selectedPreset: '1h',
+      }),
+    ).toBe('up')
   })
 
   it('shows the short range on compact panels', () => {
     expect(
       panelHeaderMeta({
-        gridWidth: 4,
+        isWidePanel: false,
         queryExpr: 'up',
-        selectedPreset: '1h',
         isCustomRange: false,
+        selectedPreset: '1h',
       }),
     ).toBe('1h')
   })
@@ -28,23 +52,24 @@ describe('panelHeaderMeta', () => {
   it('hides meta for a custom range on compact panels', () => {
     expect(
       panelHeaderMeta({
-        gridWidth: 4,
+        isWidePanel: false,
         queryExpr: 'up',
-        selectedPreset: '1h',
         isCustomRange: true,
+        selectedPreset: '1h',
       }),
     ).toBe('')
   })
 })
 
 describe('PanelChrome', () => {
+  beforeEach(() => {
+    useTimeRangeStore.getState()._reset()
+  })
+
   it('uses surface-card tokens and keeps actions visible', () => {
     render(
       <PanelChrome
-        panelId="p1"
-        title="Request rate"
-        wide={false}
-        headerMeta="1h"
+        panel={chromePanel}
         onEdit={() => undefined}
         onDelete={() => undefined}
       >
@@ -56,6 +81,7 @@ describe('PanelChrome', () => {
     expect(chrome.style.backgroundColor).toBe('var(--color-surface-container-low)')
     expect(chrome.style.borderColor).toBe('var(--color-stroke-subtle)')
     expect(screen.getByTestId('live-body')).toBeTruthy()
+    expect(screen.getByTestId('panel-header-meta').textContent).toBe('1h')
     expect(screen.getByTestId('panel-edit-btn').parentElement?.className).not.toContain('opacity-0')
   })
 })

--- a/frontend/src/components/PanelChrome.tsx
+++ b/frontend/src/components/PanelChrome.tsx
@@ -1,0 +1,107 @@
+import { Pencil, Trash2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+export const WIDE_PANEL_COLS = 8
+
+export function panelHeaderMeta({
+  gridWidth,
+  queryExpr,
+  selectedPreset,
+  isCustomRange,
+}: {
+  gridWidth: number
+  queryExpr: string
+  selectedPreset: string
+  isCustomRange: boolean
+}): string {
+  if (gridWidth >= WIDE_PANEL_COLS && queryExpr) return queryExpr
+  if (isCustomRange) return ''
+  return selectedPreset
+}
+
+type PanelChromeProps = {
+  panelId: string
+  title: string
+  wide: boolean
+  headerMeta: string
+  onEdit?: () => void
+  onDelete?: () => void
+  children: ReactNode
+}
+
+export function PanelChrome({
+  panelId,
+  title,
+  wide,
+  headerMeta,
+  onEdit,
+  onDelete,
+  children,
+}: PanelChromeProps) {
+  return (
+    <div
+      className="relative flex h-full flex-col gap-2 overflow-hidden rounded-lg p-[var(--panel-padding)]"
+      style={{
+        backgroundColor: 'var(--color-surface-container-low)',
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: 'var(--color-stroke-subtle)',
+      }}
+      data-testid={`dashboard-panel-${panelId}`}
+    >
+      <div className="panel-header flex items-center justify-between gap-2">
+        <h3
+          className={`min-w-0 truncate font-medium ${wide ? 'text-[13px]' : 'text-xs'}`}
+          style={{
+            color: wide ? 'var(--color-on-surface)' : 'var(--color-on-surface-variant)',
+          }}
+          data-testid="panel-title"
+        >
+          {title}
+        </h3>
+        <div className="flex min-w-0 shrink-0 items-center gap-1">
+          {headerMeta ? (
+            <span
+              className={`max-w-[220px] truncate ${wide ? 'font-mono text-[11px]' : 'text-[11px]'}`}
+              style={{ color: 'var(--color-on-surface-variant)' }}
+              data-testid="panel-header-meta"
+              title={headerMeta}
+            >
+              {headerMeta}
+            </span>
+          ) : null}
+          {(onEdit || onDelete) && (
+            <div className="panel-actions flex gap-1">
+              {onEdit ? (
+                <button
+                  type="button"
+                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
+                  style={{ color: 'var(--color-outline)' }}
+                  data-testid="panel-edit-btn"
+                  title="Edit panel"
+                  onClick={onEdit}
+                >
+                  <Pencil size={16} />
+                </button>
+              ) : null}
+              {onDelete ? (
+                <button
+                  type="button"
+                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent transition hover:opacity-80"
+                  style={{ color: 'var(--color-outline)' }}
+                  data-testid="panel-delete-btn"
+                  title="Delete panel"
+                  onClick={onDelete}
+                >
+                  <Trash2 size={16} />
+                </button>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/PanelChrome.tsx
+++ b/frontend/src/components/PanelChrome.tsx
@@ -1,43 +1,43 @@
 import { Pencil, Trash2 } from 'lucide-react'
 import type { ReactNode } from 'react'
+import { useTimeRange } from '@/hooks/useTimeRange'
+import { panelQueryExpr, type Panel as PanelType } from '@/types/panel'
 
-export const WIDE_PANEL_COLS = 8
+const WIDE_PANEL_COLS = 8
 
 export function panelHeaderMeta({
-  gridWidth,
+  isWidePanel,
   queryExpr,
-  selectedPreset,
   isCustomRange,
+  selectedPreset,
 }: {
-  gridWidth: number
+  isWidePanel: boolean
   queryExpr: string
-  selectedPreset: string
   isCustomRange: boolean
+  selectedPreset: string
 }): string {
-  if (gridWidth >= WIDE_PANEL_COLS && queryExpr) return queryExpr
+  if (isWidePanel && queryExpr) return queryExpr
   if (isCustomRange) return ''
   return selectedPreset
 }
 
 type PanelChromeProps = {
-  panelId: string
-  title: string
-  wide: boolean
-  headerMeta: string
-  onEdit?: () => void
-  onDelete?: () => void
+  panel: PanelType
+  onEdit?: (panel: PanelType) => void
+  onDelete?: (panel: PanelType) => void
   children: ReactNode
 }
 
-export function PanelChrome({
-  panelId,
-  title,
-  wide,
-  headerMeta,
-  onEdit,
-  onDelete,
-  children,
-}: PanelChromeProps) {
+export function PanelChrome({ panel, onEdit, onDelete, children }: PanelChromeProps) {
+  const { selectedPreset, isCustomRange } = useTimeRange()
+  const isWidePanel = panel.grid_pos.w >= WIDE_PANEL_COLS
+  const headerMeta = panelHeaderMeta({
+    isWidePanel,
+    queryExpr: panelQueryExpr(panel.query),
+    isCustomRange,
+    selectedPreset,
+  })
+
   return (
     <div
       className="relative flex h-full flex-col gap-2 overflow-hidden rounded-lg p-[var(--panel-padding)]"
@@ -47,22 +47,22 @@ export function PanelChrome({
         borderStyle: 'solid',
         borderColor: 'var(--color-stroke-subtle)',
       }}
-      data-testid={`dashboard-panel-${panelId}`}
+      data-testid={`dashboard-panel-${panel.id}`}
     >
       <div className="panel-header flex items-center justify-between gap-2">
         <h3
-          className={`min-w-0 truncate font-medium ${wide ? 'text-[13px]' : 'text-xs'}`}
+          className={`min-w-0 truncate font-medium ${isWidePanel ? 'text-[13px]' : 'text-xs'}`}
           style={{
-            color: wide ? 'var(--color-on-surface)' : 'var(--color-on-surface-variant)',
+            color: isWidePanel ? 'var(--color-on-surface)' : 'var(--color-on-surface-variant)',
           }}
           data-testid="panel-title"
         >
-          {title}
+          {panel.title}
         </h3>
         <div className="flex min-w-0 shrink-0 items-center gap-1">
           {headerMeta ? (
             <span
-              className={`max-w-[220px] truncate ${wide ? 'font-mono text-[11px]' : 'text-[11px]'}`}
+              className={`max-w-[220px] truncate ${isWidePanel ? 'font-mono text-[11px]' : 'text-[11px]'}`}
               style={{ color: 'var(--color-on-surface-variant)' }}
               data-testid="panel-header-meta"
               title={headerMeta}
@@ -79,7 +79,7 @@ export function PanelChrome({
                   style={{ color: 'var(--color-outline)' }}
                   data-testid="panel-edit-btn"
                   title="Edit panel"
-                  onClick={onEdit}
+                  onClick={() => onEdit(panel)}
                 >
                   <Pencil size={16} />
                 </button>
@@ -91,7 +91,7 @@ export function PanelChrome({
                   style={{ color: 'var(--color-outline)' }}
                   data-testid="panel-delete-btn"
                   title="Delete panel"
-                  onClick={onDelete}
+                  onClick={() => onDelete(panel)}
                 >
                   <Trash2 size={16} />
                 </button>

--- a/frontend/src/hooks/usePanelData.spec.tsx
+++ b/frontend/src/hooks/usePanelData.spec.tsx
@@ -105,7 +105,7 @@ describe('usePanelData', () => {
   it('uses panelQueryExpr so fetch matches chrome when both expr and promql are set', async () => {
     const mixed: Panel = {
       ...panel,
-      query: { promql: 'up', expr: 'node_cpu_seconds_total' },
+      query: { promql: 'up', expr: '  node_cpu_seconds_total  ' },
     }
 
     vi.spyOn(promqlClient, 'queryPrometheus').mockResolvedValue({
@@ -135,6 +135,29 @@ describe('usePanelData', () => {
       expect.any(Number),
       expect.any(Number),
       15,
+    )
+  })
+
+  it('prefers trimmed expr over promql on datasource-backed fetch', async () => {
+    const mixed: Panel = {
+      ...panel,
+      query: {
+        datasource_id: 'ds-1',
+        expr: '  cpu  ',
+        promql: 'up',
+        signal: 'metrics',
+      },
+    }
+
+    const { result } = renderHook(() => usePanelData(mixed, (query) => query))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(datasourceApi.queryDataSource).toHaveBeenCalledWith(
+      'ds-1',
+      expect.objectContaining({ query: 'cpu' }),
     )
   })
 

--- a/frontend/src/hooks/usePanelData.spec.tsx
+++ b/frontend/src/hooks/usePanelData.spec.tsx
@@ -102,6 +102,42 @@ describe('usePanelData', () => {
     expect(result.current.chartSeries).toHaveLength(1)
   })
 
+  it('uses panelQueryExpr so fetch matches chrome when both expr and promql are set', async () => {
+    const mixed: Panel = {
+      ...panel,
+      query: { promql: 'up', expr: 'node_cpu_seconds_total' },
+    }
+
+    vi.spyOn(promqlClient, 'queryPrometheus').mockResolvedValue({
+      status: 'success',
+      data: {
+        resultType: 'matrix',
+        result: [
+          {
+            metric: { __name__: 'node_cpu_seconds_total' },
+            values: [
+              [1_700_000_000, '1'],
+              [1_700_000_015, '1'],
+            ],
+          },
+        ],
+      },
+    })
+
+    const { result } = renderHook(() => usePanelData(mixed, (query) => query))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(promqlClient.queryPrometheus).toHaveBeenCalledWith(
+      'node_cpu_seconds_total',
+      expect.any(Number),
+      expect.any(Number),
+      15,
+    )
+  })
+
   it('fetches logs for logs panels', async () => {
     const logsPanel: Panel = {
       ...panel,

--- a/frontend/src/hooks/usePanelData.ts
+++ b/frontend/src/hooks/usePanelData.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { queryDataSource, searchDataSourceTraces } from '@/api/datasources'
 import { useTimeRange } from '@/hooks/useTimeRange'
-import { queryPrometheus, transformToChartData, type ChartSeries } from '@/promql/client'
+import { type ChartSeries, queryPrometheus, transformToChartData } from '@/promql/client'
 import type { LogEntry, TraceSpan, TraceSummary } from '@/types/datasource'
-import type { Panel } from '@/types/panel'
+import { type Panel, readPanelQueryExpr } from '@/types/panel'
 import { lookupPanel } from '@/utils/panelRegistry'
 import { convertClickHouseSpansToTraceSummaries } from '@/utils/traceClickHouse'
 
@@ -48,7 +48,7 @@ export function usePanelData(
   const [traceSpans, setTraceSpans] = useState<TraceSpan[]>([])
 
   const datasourceId = panel.query?.datasource_id as string | undefined
-  const queryExpr = (panel.query?.promql || panel.query?.expr || '') as string
+  const queryExpr = readPanelQueryExpr(panel.query)
   const explicitQuerySignal = isQuerySignal(panel.query?.signal) ? panel.query.signal : null
   const registry = lookupPanel(panel.type)
   const isBuiltinTracePanel = panel.type === 'trace_list' || panel.type === 'trace_heatmap'

--- a/frontend/src/hooks/usePanelData.ts
+++ b/frontend/src/hooks/usePanelData.ts
@@ -3,7 +3,7 @@ import { queryDataSource, searchDataSourceTraces } from '@/api/datasources'
 import { useTimeRange } from '@/hooks/useTimeRange'
 import { type ChartSeries, queryPrometheus, transformToChartData } from '@/promql/client'
 import type { LogEntry, TraceSpan, TraceSummary } from '@/types/datasource'
-import { type Panel, readPanelQueryExpr } from '@/types/panel'
+import type { Panel } from '@/types/panel'
 import { lookupPanel } from '@/utils/panelRegistry'
 import { convertClickHouseSpansToTraceSummaries } from '@/utils/traceClickHouse'
 
@@ -48,7 +48,7 @@ export function usePanelData(
   const [traceSpans, setTraceSpans] = useState<TraceSpan[]>([])
 
   const datasourceId = panel.query?.datasource_id as string | undefined
-  const queryExpr = readPanelQueryExpr(panel.query)
+  const queryExpr = (panel.query?.promql || panel.query?.expr || '') as string
   const explicitQuerySignal = isQuerySignal(panel.query?.signal) ? panel.query.signal : null
   const registry = lookupPanel(panel.type)
   const isBuiltinTracePanel = panel.type === 'trace_list' || panel.type === 'trace_heatmap'

--- a/frontend/src/hooks/usePanelData.ts
+++ b/frontend/src/hooks/usePanelData.ts
@@ -3,7 +3,7 @@ import { queryDataSource, searchDataSourceTraces } from '@/api/datasources'
 import { useTimeRange } from '@/hooks/useTimeRange'
 import { type ChartSeries, queryPrometheus, transformToChartData } from '@/promql/client'
 import type { LogEntry, TraceSpan, TraceSummary } from '@/types/datasource'
-import type { Panel } from '@/types/panel'
+import { type Panel, panelQueryExpr } from '@/types/panel'
 import { lookupPanel } from '@/utils/panelRegistry'
 import { convertClickHouseSpansToTraceSummaries } from '@/utils/traceClickHouse'
 
@@ -48,7 +48,7 @@ export function usePanelData(
   const [traceSpans, setTraceSpans] = useState<TraceSpan[]>([])
 
   const datasourceId = panel.query?.datasource_id as string | undefined
-  const queryExpr = (panel.query?.promql || panel.query?.expr || '') as string
+  const queryExpr = panelQueryExpr(panel.query)
   const explicitQuerySignal = isQuerySignal(panel.query?.signal) ? panel.query.signal : null
   const registry = lookupPanel(panel.type)
   const isBuiltinTracePanel = panel.type === 'trace_list' || panel.type === 'trace_heatmap'

--- a/frontend/src/pages/DashboardDetailPage.spec.tsx
+++ b/frontend/src/pages/DashboardDetailPage.spec.tsx
@@ -56,6 +56,18 @@ vi.mock('@/hooks/useDatasources', () => ({
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
       },
+      {
+        id: 'ds-2',
+        organization_id: 'org-1',
+        name: 'Loki',
+        type: 'loki',
+        url: 'http://localhost:3100',
+        is_default: false,
+        auth_type: 'none',
+        trace_id_field: 'trace_id',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
     ],
   }),
 }))
@@ -235,6 +247,27 @@ describe('DashboardDetailPage', () => {
     expect(addPanel.textContent).toBe('Add panel')
     expect(addPanel.style.backgroundColor).toBe('var(--color-primary)')
     expect(addPanel.style.color).toBe('#0B0D0F')
+  })
+
+  it('omits datasource from the header when panels use different datasources', async () => {
+    vi.mocked(panelApi.listPanels).mockResolvedValue([
+      {
+        ...mockPanels[1]!,
+        id: 'panel-a',
+        query: { datasource_id: 'ds-1', expr: 'up', signal: 'metrics' },
+      },
+      {
+        ...mockPanels[1]!,
+        id: 'panel-b',
+        query: { datasource_id: 'ds-2', expr: 'up', signal: 'logs' },
+      },
+    ])
+
+    renderDashboardDetail()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-header-meta').textContent).toBe('Last 1 hour')
+    })
   })
 
   it('opens create panel modal from Add Panel button', async () => {

--- a/frontend/src/pages/DashboardDetailPage.spec.tsx
+++ b/frontend/src/pages/DashboardDetailPage.spec.tsx
@@ -230,6 +230,8 @@ describe('DashboardDetailPage', () => {
       expect(screen.getByTestId('dashboard-error')).toBeTruthy()
     })
     expect(screen.getByText('Dashboard not found')).toBeTruthy()
+    expect(screen.queryByTestId('dashboard-title')).toBeNull()
+    expect(screen.getByTestId('dashboard-header-actions').className).toContain('sm:ml-auto')
   })
 
   it('renders loaded header with time range, datasource, and solid gold add panel', async () => {

--- a/frontend/src/pages/DashboardDetailPage.spec.tsx
+++ b/frontend/src/pages/DashboardDetailPage.spec.tsx
@@ -244,6 +244,7 @@ describe('DashboardDetailPage', () => {
     const header = screen.getByTestId('dashboard-loaded-header')
     expect(header.getAttribute('style')).toBeNull()
     expect(screen.getByTestId('dashboard-header-meta').textContent).toBe('Last 1 hour · Prometheus')
+    expect(screen.getByTestId('dashboard-header-actions').className).toContain('sm:ml-auto')
 
     const addPanel = screen.getByTestId('dashboard-add-panel-btn')
     expect(addPanel.textContent).toBe('Add panel')

--- a/frontend/src/pages/DashboardDetailPage.spec.tsx
+++ b/frontend/src/pages/DashboardDetailPage.spec.tsx
@@ -1,12 +1,12 @@
-import type { ReactNode } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
 import { createMemoryRouter } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('echarts/core', async importOriginal => {
+vi.mock('echarts/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('echarts/core')>()
   return {
     ...actual,
@@ -28,17 +28,11 @@ vi.mock('react-grid-layout/legacy', () => ({
 }))
 
 vi.mock('@/components/QueryBuilder', () => ({
-  QueryBuilder: ({
-    value,
-    onChange,
-  }: {
-    value: string
-    onChange: (value: string) => void
-  }) => (
+  QueryBuilder: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
     <textarea
       data-testid="promql-query-input"
       value={value}
-      onChange={event => onChange(event.target.value)}
+      onChange={(event) => onChange(event.target.value)}
     />
   ),
 }))
@@ -70,8 +64,8 @@ import * as dashboardApi from '@/api/dashboards'
 import * as datasourceApi from '@/api/datasources'
 import * as panelApi from '@/api/panels'
 import * as variableApi from '@/api/variables'
-import * as promqlClient from '@/promql/client'
 import { DashboardDetailPage } from '@/pages/DashboardDetailPage'
+import * as promqlClient from '@/promql/client'
 import { useFavoritesStore } from '@/stores/favoritesStore'
 import { useTimeRangeStore } from '@/stores/timeRangeStore'
 import { createTestQueryClient } from '@/test/renderWithProviders'
@@ -226,18 +220,21 @@ describe('DashboardDetailPage', () => {
     expect(screen.getByText('Dashboard not found')).toBeTruthy()
   })
 
-  it('navigates back to dashboards list', async () => {
-    const user = userEvent.setup()
+  it('renders loaded header with time range, datasource, and solid gold add panel', async () => {
     renderDashboardDetail()
 
     await waitFor(() => {
-      expect(screen.getByTestId('dashboard-back-btn')).toBeTruthy()
+      expect(screen.getByTestId('dashboard-title').textContent).toContain('Test Dashboard')
     })
 
-    await user.click(screen.getByTestId('dashboard-back-btn'))
-    await waitFor(() => {
-      expect(screen.getByText('Dashboards list')).toBeTruthy()
-    })
+    const header = screen.getByTestId('dashboard-loaded-header')
+    expect(header.getAttribute('style')).toBeNull()
+    expect(screen.getByTestId('dashboard-header-meta').textContent).toBe('Last 1 hour · Prometheus')
+
+    const addPanel = screen.getByTestId('dashboard-add-panel-btn')
+    expect(addPanel.textContent).toBe('Add panel')
+    expect(addPanel.style.backgroundColor).toBe('var(--color-primary)')
+    expect(addPanel.style.color).toBe('#0B0D0F')
   })
 
   it('opens create panel modal from Add Panel button', async () => {

--- a/frontend/src/pages/DashboardDetailPage.tsx
+++ b/frontend/src/pages/DashboardDetailPage.tsx
@@ -1,5 +1,5 @@
-import { AlertCircle, ArrowLeft, LayoutGrid, Plus, Settings } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { AlertCircle, LayoutGrid, Plus, Settings } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 import { getDashboard } from '@/api/dashboards'
 import { deletePanel, listPanels } from '@/api/panels'
@@ -8,11 +8,14 @@ import { PanelEditModal } from '@/components/PanelEditModal'
 import { TimeRangePicker } from '@/components/TimeRangePicker'
 import { VariableBar } from '@/components/VariableBar'
 import { CrosshairSyncProvider } from '@/contexts/CrosshairSyncContext'
-import { VariablesProvider, useDashboardVariables } from '@/contexts/VariablesContext'
+import { useDashboardVariables, VariablesProvider } from '@/contexts/VariablesContext'
+import { useDatasources } from '@/hooks/useDatasources'
+import { useOrganization } from '@/hooks/useOrganization'
 import { useRegisterCommandContext } from '@/hooks/useRegisterCommandContext'
 import { useTimeRange } from '@/hooks/useTimeRange'
 import { useFavoritesStore } from '@/stores/favoritesStore'
 import type { Dashboard } from '@/types/dashboard'
+import type { DataSource } from '@/types/datasource'
 import type { Panel } from '@/types/panel'
 
 /** Shared with TracesExplorePanel — opens a specific trace after navigate. */
@@ -25,10 +28,22 @@ function dashboardLoadErrorMessage(cause: unknown): string {
   return 'Dashboard not found'
 }
 
+function dashboardDatasourceName(panels: Panel[], datasources: DataSource[]): string {
+  for (const panel of panels) {
+    const datasourceId = panel.query?.datasource_id
+    if (typeof datasourceId !== 'string' || !datasourceId) continue
+    const match = datasources.find((datasource) => datasource.id === datasourceId)
+    if (match) return match.name
+  }
+  return datasources.find((datasource) => datasource.is_default)?.name ?? datasources[0]?.name ?? ''
+}
+
 function DashboardDetailContent({ dashboardId }: { dashboardId: string }) {
   const navigate = useNavigate()
-  const addRecent = useFavoritesStore(state => state.addRecent)
-  const { setPreset, setRefreshInterval } = useTimeRange()
+  const addRecent = useFavoritesStore((state) => state.addRecent)
+  const { currentOrgId } = useOrganization()
+  const { data: datasources = [] } = useDatasources(currentOrgId)
+  const { displayText, setPreset, setRefreshInterval } = useTimeRange()
   const { variables, hasVariables, fetchVariables, setVariableValue } = useDashboardVariables()
 
   const [dashboard, setDashboard] = useState<Dashboard | null>(null)
@@ -46,6 +61,12 @@ function DashboardDetailContent({ dashboardId }: { dashboardId: string }) {
   const [editingPanel, setEditingPanel] = useState<Panel | null>(null)
   const [deletingPanel, setDeletingPanel] = useState<Panel | null>(null)
   const [deleting, setDeleting] = useState(false)
+
+  const datasourceName = useMemo(
+    () => dashboardDatasourceName(panels, datasources),
+    [datasources, panels],
+  )
+  const headerMeta = datasourceName ? `${displayText} · ${datasourceName}` : displayText
 
   useEffect(() => {
     setPreset('1h')
@@ -102,12 +123,12 @@ function DashboardDetailContent({ dashboardId }: { dashboardId: string }) {
   }
 
   function handlePanelSaved(saved: Panel) {
-    setPanels(current => {
-      const existingIndex = current.findIndex(panel => panel.id === saved.id)
+    setPanels((current) => {
+      const existingIndex = current.findIndex((panel) => panel.id === saved.id)
       if (existingIndex === -1) {
         return [...current, saved]
       }
-      return current.map(panel => (panel.id === saved.id ? saved : panel))
+      return current.map((panel) => (panel.id === saved.id ? saved : panel))
     })
     closePanelModal()
   }
@@ -141,7 +162,7 @@ function DashboardDetailContent({ dashboardId }: { dashboardId: string }) {
     setDeleting(true)
     try {
       await deletePanel(deletingPanel.id)
-      setPanels(current => current.filter(panel => panel.id !== deletingPanel.id))
+      setPanels((current) => current.filter((panel) => panel.id !== deletingPanel.id))
       setDeletingPanel(null)
     } catch {
       // Keep dialog open on failure; user can cancel
@@ -151,81 +172,63 @@ function DashboardDetailContent({ dashboardId }: { dashboardId: string }) {
   }
 
   return (
-    <div className="mx-auto max-w-[1600px] px-6 py-5">
+    <div className="p-[var(--section-gap)]">
       <header
-        className="relative z-20 mb-4 flex flex-col gap-3 rounded-lg px-6 py-3 sm:flex-row sm:items-center sm:justify-between"
-        style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+        className="relative z-20 mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        data-testid="dashboard-loaded-header"
       >
-        <div className="flex items-center gap-4">
-          <button
-            type="button"
-            className="flex h-[38px] w-[38px] items-center justify-center rounded-lg transition hover:opacity-80"
-            style={{
-              backgroundColor: 'var(--color-surface-container-high)',
-              color: 'var(--color-on-surface-variant)',
-            }}
-            data-testid="dashboard-back-btn"
-            title="Back to Dashboards"
-            onClick={() => navigate('/app/dashboards')}
-          >
-            <ArrowLeft size={20} />
-          </button>
-          {dashboard && (
-            <div>
-              <h1
-                className="mb-0.5 font-display text-lg font-semibold tracking-wide"
-                style={{ color: 'var(--color-on-surface)' }}
-                data-testid="dashboard-title"
-              >
-                {dashboard.title}
-              </h1>
-              {dashboard.description && (
-                <p className="text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-                  {dashboard.description}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-wrap items-center gap-3">
-          <TimeRangePicker />
-          <div
-            className="hidden h-6 w-px sm:block"
-            style={{ backgroundColor: 'var(--color-outline-variant)' }}
-          />
-          <div className="flex items-center gap-2">
-            {dashboard && (
-              <Link
-                to={`/app/dashboards/${dashboardId}/settings/general`}
-                className="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-semibold transition hover:opacity-80"
-                style={{
-                  backgroundColor: 'var(--color-surface-container-high)',
-                  color: 'var(--color-on-surface-variant)',
-                }}
-                data-testid="dashboard-settings-button"
-              >
-                <Settings size={16} />
-                <span>Settings</span>
-              </Link>
-            )}
-            {dashboard && !loading && !error ? (
-              <button
-                type="button"
-                className="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                style={{
-                  background:
-                    'linear-gradient(135deg, var(--color-primary), var(--color-primary-dim))',
-                }}
-                data-testid="dashboard-add-panel-btn"
-                onClick={openAddPanel}
-                disabled={loading}
-              >
-                <Plus size={18} />
-                <span>Add Panel</span>
-              </button>
-            ) : null}
+        {dashboard ? (
+          <div className="flex min-w-0 flex-col gap-1">
+            <h1
+              className="font-display text-2xl font-semibold tracking-[-0.02em]"
+              style={{ color: 'var(--color-on-surface)' }}
+              data-testid="dashboard-title"
+            >
+              {dashboard.title}
+            </h1>
+            <p
+              className="text-[13px]"
+              style={{ color: 'var(--color-on-surface-variant)' }}
+              data-testid="dashboard-header-meta"
+            >
+              {headerMeta}
+            </p>
           </div>
+        ) : (
+          <div />
+        )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <TimeRangePicker showStatus={false} />
+          {dashboard ? (
+            <Link
+              to={`/app/dashboards/${dashboardId}/settings/general`}
+              className="inline-flex h-8 items-center gap-2 rounded-lg px-2 text-xs font-medium transition hover:opacity-80"
+              style={{
+                backgroundColor: 'var(--color-surface-container-high)',
+                color: 'var(--color-on-surface)',
+              }}
+              data-testid="dashboard-settings-button"
+            >
+              <Settings size={14} />
+              <span>Settings</span>
+            </Link>
+          ) : null}
+          {dashboard && !loading && !error ? (
+            <button
+              type="button"
+              className="inline-flex h-8 items-center rounded-lg px-2 text-xs font-semibold transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              style={{
+                backgroundColor: 'var(--color-primary)',
+                color: '#0B0D0F',
+              }}
+              data-testid="dashboard-add-panel-btn"
+              onClick={openAddPanel}
+              disabled={loading}
+            >
+              Add panel
+            </button>
+          ) : null}
         </div>
       </header>
 

--- a/frontend/src/pages/DashboardDetailPage.tsx
+++ b/frontend/src/pages/DashboardDetailPage.tsx
@@ -29,11 +29,17 @@ function dashboardLoadErrorMessage(cause: unknown): string {
 }
 
 function dashboardDatasourceName(panels: Panel[], datasources: DataSource[]): string {
+  const names = new Set<string>()
   for (const panel of panels) {
     const datasourceId = panel.query?.datasource_id
     if (typeof datasourceId !== 'string' || !datasourceId) continue
     const match = datasources.find((datasource) => datasource.id === datasourceId)
-    if (match) return match.name
+    if (match) names.add(match.name)
+  }
+  if (names.size > 1) return ''
+  if (names.size === 1) {
+    const [name] = names
+    return name ?? ''
   }
   return datasources.find((datasource) => datasource.is_default)?.name ?? datasources[0]?.name ?? ''
 }

--- a/frontend/src/pages/DashboardDetailPage.tsx
+++ b/frontend/src/pages/DashboardDetailPage.tsx
@@ -180,11 +180,11 @@ function DashboardDetailContent({ dashboardId }: { dashboardId: string }) {
   return (
     <div className="p-[var(--section-gap)]">
       <header
-        className="relative z-20 mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        className="relative z-20 mb-4 flex flex-col gap-3 sm:flex-row sm:items-center"
         data-testid="dashboard-loaded-header"
       >
         {dashboard ? (
-          <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
             <h1
               className="font-display text-2xl font-semibold tracking-[-0.02em]"
               style={{ color: 'var(--color-on-surface)' }}
@@ -200,11 +200,12 @@ function DashboardDetailContent({ dashboardId }: { dashboardId: string }) {
               {headerMeta}
             </p>
           </div>
-        ) : (
-          <div />
-        )}
+        ) : null}
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div
+          className="flex flex-wrap items-center gap-2 sm:ml-auto"
+          data-testid="dashboard-header-actions"
+        >
           <TimeRangePicker showStatus={false} />
           {dashboard ? (
             <Link

--- a/frontend/src/types/panel.spec.ts
+++ b/frontend/src/types/panel.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { readPanelQueryExpr } from '@/types/panel'
+
+describe('readPanelQueryExpr', () => {
+  it('prefers promql over expr', () => {
+    expect(readPanelQueryExpr({ promql: 'up', expr: 'cpu' })).toBe('up')
+  })
+
+  it('falls back to expr', () => {
+    expect(readPanelQueryExpr({ expr: 'rate(http_requests_total[5m])' })).toBe(
+      'rate(http_requests_total[5m])',
+    )
+  })
+
+  it('trims and ignores empty strings', () => {
+    expect(readPanelQueryExpr({ promql: '  ', expr: '  mem  ' })).toBe('mem')
+    expect(readPanelQueryExpr({})).toBe('')
+    expect(readPanelQueryExpr(undefined)).toBe('')
+  })
+})

--- a/frontend/src/types/panel.spec.ts
+++ b/frontend/src/types/panel.spec.ts
@@ -1,20 +1,22 @@
 import { describe, expect, it } from 'vitest'
-import { readPanelQueryExpr } from '@/types/panel'
+import { panelQueryExpr } from '@/types/panel'
 
-describe('readPanelQueryExpr', () => {
-  it('prefers promql over expr', () => {
-    expect(readPanelQueryExpr({ promql: 'up', expr: 'cpu' })).toBe('up')
+describe('panelQueryExpr', () => {
+  it('prefers non-empty expr over promql', () => {
+    expect(panelQueryExpr({ expr: 'cpu', promql: 'up' })).toBe('cpu')
   })
 
-  it('falls back to expr', () => {
-    expect(readPanelQueryExpr({ expr: 'rate(http_requests_total[5m])' })).toBe(
-      'rate(http_requests_total[5m])',
+  it('falls back to non-empty promql', () => {
+    expect(panelQueryExpr({ promql: 'up' })).toBe('up')
+    expect(panelQueryExpr({ expr: '  ', promql: 'node_cpu_seconds_total' })).toBe(
+      'node_cpu_seconds_total',
     )
   })
 
   it('trims and ignores empty strings', () => {
-    expect(readPanelQueryExpr({ promql: '  ', expr: '  mem  ' })).toBe('mem')
-    expect(readPanelQueryExpr({})).toBe('')
-    expect(readPanelQueryExpr(undefined)).toBe('')
+    expect(panelQueryExpr({ expr: '  mem  ' })).toBe('mem')
+    expect(panelQueryExpr({ promql: '  up  ' })).toBe('up')
+    expect(panelQueryExpr({})).toBe('')
+    expect(panelQueryExpr(undefined)).toBe('')
   })
 })

--- a/frontend/src/types/panel.ts
+++ b/frontend/src/types/panel.ts
@@ -38,3 +38,11 @@ export interface RawQueryResult {
   logs?: unknown[]
   traces?: unknown[]
 }
+
+/** Canonical query text at the panel type edge. Prefer `promql`, then `expr`. */
+export function readPanelQueryExpr(query: Panel['query']): string {
+  if (!query) return ''
+  if (typeof query.promql === 'string' && query.promql.trim()) return query.promql.trim()
+  if (typeof query.expr === 'string' && query.expr.trim()) return query.expr.trim()
+  return ''
+}

--- a/frontend/src/types/panel.ts
+++ b/frontend/src/types/panel.ts
@@ -39,10 +39,10 @@ export interface RawQueryResult {
   traces?: unknown[]
 }
 
-/** Canonical query text at the panel type edge. Prefer `promql`, then `expr`. */
-export function readPanelQueryExpr(query: Panel['query']): string {
+/** Prefer non-empty trimmed `expr`, else non-empty trimmed `promql`, else `''`. */
+export function panelQueryExpr(query: Panel['query']): string {
   if (!query) return ''
-  if (typeof query.promql === 'string' && query.promql.trim()) return query.promql.trim()
   if (typeof query.expr === 'string' && query.expr.trim()) return query.expr.trim()
+  if (typeof query.promql === 'string' && query.promql.trim()) return query.promql.trim()
   return ''
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #433. Parent #432 stays open.

Refresh the **loaded** dashboard view to Figma Refresh Dashboard 11:40 (dark+gold). Charts stay on live `Panel` renderers — no mock encyclopedia bars, no agent dock, no Explore/query-editor files.

## What changed
- Loaded header: fluid page, 22px display title, `{time range} · {datasource}` meta (datasource omitted when panels disagree), solid brass **Add panel**, existing time picker (status dots off).
- Grid: 16px gutter (`DESIGN.md` grid-gutter).
- Panel chrome: surface-card + stroke-subtle border, 16px padding, compact title/`1h` vs wide title + live query. Edit/delete stay visible.

## Maintainability
- `PanelChrome` owns title/meta/actions and `useTimeRange`; `Panel` stays a body router.
- Pure `panelHeaderMeta({ isWidePanel, queryExpr, isCustomRange, selectedPreset })`.
- One type-edge helper: `panelQueryExpr` (trimmed `expr`, else trimmed `promql`, else `''`) used by chrome **and** `usePanelData` fetch.
- Loaded header: `null` instead of an empty spacer; controls use `sm:ml-auto`.

## Out of scope
- Login + empty chrome
- Agent dock, chart builder, MCP list
- Explore / query editors (#434)

## Prove
- Specs cover layout/tokens, mixed-datasource header, visible panel actions, live chart bodies, and fetch both-keys preferring trimmed `expr`.
- `bun run test src/pages/DashboardDetailPage.spec.tsx src/components/Panel.spec.tsx src/components/DashboardGrid.spec.tsx src/hooks/usePanelData.spec.tsx src/types/panel.spec.ts`

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40e4af6f-7161-4278-903d-2085aa5555d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40e4af6f-7161-4278-903d-2085aa5555d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

