### PR TITLE
feat(mcp-plugins): match settings list to Figma 12:188

### DIFF
--- a/frontend/src/components/settings/McpPluginsPanel.spec.tsx
+++ b/frontend/src/components/settings/McpPluginsPanel.spec.tsx
@@ -1,0 +1,130 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { McpPluginsPanel } from './McpPluginsPanel'
+import { type McpPlugin, UNREACHABLE_SERVER_ERROR } from './mcpPlugins'
+
+function rowNamed(name: string) {
+  const row = screen.getAllByTestId('mcp-plugin-row').find((el) => within(el).queryByText(name))
+  expect(row).toBeTruthy()
+  return row as HTMLElement
+}
+
+function expectGoldInk(el: HTMLElement) {
+  const gold =
+    el.style.backgroundColor === 'var(--color-primary)' || el.className.includes('bg-primary')
+  const ink = el.style.color === '#0B0D0F' || el.className.includes('text-[#0B0D0F]')
+  expect(gold).toBe(true)
+  expect(ink).toBe(true)
+}
+
+function expectQuietChip(el: HTMLElement) {
+  expect(el.style.backgroundColor).toBe('var(--color-surface-container-high)')
+  expect(el.style.color).toBe('var(--color-on-surface-variant)')
+}
+
+function expectNoQueryToasts() {
+  expect(screen.queryByRole('status')).toBeNull()
+  expect(screen.queryByTestId('toast')).toBeNull()
+  expect(screen.queryByTestId('toast-notification')).toBeNull()
+}
+
+describe('McpPluginsPanel', () => {
+  it('renders the Figma default list with gold On chips and a quiet Off chip', () => {
+    render(<McpPluginsPanel />)
+
+    expect(screen.getByTestId('mcp-plugins-panel')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'MCP / Plugins' })).toBeTruthy()
+    expect(screen.getByText('Tools the agent can call. Quiet list, one gold enable.')).toBeTruthy()
+
+    const add = screen.getByTestId('mcp-plugins-add')
+    expect(add.textContent).toContain('Add server')
+    expectGoldInk(add)
+
+    expect(screen.getByTestId('mcp-plugins-list')).toBeTruthy()
+    expect(screen.getAllByTestId('mcp-plugin-row')).toHaveLength(3)
+
+    const victoria = rowNamed('Victoria Metrics')
+    expect(within(victoria).getByText('Connected · queries + labels')).toBeTruthy()
+    const victoriaChip = within(victoria).getByTestId('mcp-plugin-toggle')
+    expect(victoriaChip.textContent).toBe('On')
+    expectGoldInk(victoriaChip)
+
+    const github = rowNamed('GitHub')
+    expect(within(github).getByText('Connected · issues, PRs')).toBeTruthy()
+    const githubChip = within(github).getByTestId('mcp-plugin-toggle')
+    expect(githubChip.textContent).toBe('On')
+    expectGoldInk(githubChip)
+
+    const pager = rowNamed('PagerDuty')
+    expect(within(pager).getByText('Off · not configured')).toBeTruthy()
+    const pagerChip = within(pager).getByTestId('mcp-plugin-toggle')
+    expect(pagerChip.textContent).toBe('Off')
+    expectQuietChip(pagerChip)
+  })
+
+  it('shows an empty state and keeps Add server gold when there are no plugins', () => {
+    render(<McpPluginsPanel initialPlugins={[]} />)
+
+    const empty = screen.getByTestId('mcp-plugins-empty')
+    expect(empty.textContent?.toLowerCase()).toContain('no servers yet')
+    expect(screen.queryByTestId('mcp-plugins-list')).toBeNull()
+    expectGoldInk(screen.getByTestId('mcp-plugins-add'))
+  })
+
+  it('adds an Off row from the inline Add server field', async () => {
+    const user = userEvent.setup()
+    render(<McpPluginsPanel initialPlugins={[]} />)
+
+    await user.click(screen.getByTestId('mcp-plugins-add'))
+    await user.type(screen.getByTestId('mcp-plugins-add-name'), 'Slack')
+    await user.keyboard('{Enter}')
+
+    const slack = rowNamed('Slack')
+    expect(within(slack).getByText('Off · not configured')).toBeTruthy()
+    expectQuietChip(within(slack).getByTestId('mcp-plugin-toggle'))
+  })
+
+  it('toggles PagerDuty On with accent ink and Victoria Metrics Off quiet', async () => {
+    const user = userEvent.setup()
+    render(<McpPluginsPanel />)
+
+    await user.click(within(rowNamed('PagerDuty')).getByTestId('mcp-plugin-toggle'))
+    const pagerOn = within(rowNamed('PagerDuty')).getByTestId('mcp-plugin-toggle')
+    expect(pagerOn.textContent).toBe('On')
+    expectGoldInk(pagerOn)
+
+    await user.click(within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle'))
+    const victoriaOff = within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle')
+    expect(victoriaOff.textContent).toBe('Off')
+    expectQuietChip(victoriaOff)
+  })
+
+  it('retries an error row inline without a toast', async () => {
+    const user = userEvent.setup()
+    const initialPlugins: McpPlugin[] = [
+      {
+        id: 'broken',
+        name: 'Broken',
+        state: 'error',
+        detail: 'timeout',
+      },
+    ]
+    render(<McpPluginsPanel initialPlugins={initialPlugins} />)
+
+    const row = rowNamed('Broken')
+    expect(within(row).getByText(UNREACHABLE_SERVER_ERROR)).toBeTruthy()
+    expect(within(row).getByTestId('mcp-plugin-retry')).toBeTruthy()
+    expectNoQueryToasts()
+
+    await user.click(within(row).getByTestId('mcp-plugin-retry'))
+
+    const recovered = rowNamed('Broken')
+    expect(within(recovered).queryByTestId('mcp-plugin-retry')).toBeNull()
+    expect(within(recovered).queryByText(UNREACHABLE_SERVER_ERROR)).toBeNull()
+    const chip = within(recovered).getByTestId('mcp-plugin-toggle')
+    expect(chip.textContent).toBe('On')
+    expectGoldInk(chip)
+    expectNoQueryToasts()
+  })
+})

--- a/frontend/src/components/settings/McpPluginsPanel.spec.tsx
+++ b/frontend/src/components/settings/McpPluginsPanel.spec.tsx
@@ -93,11 +93,27 @@ describe('McpPluginsPanel', () => {
     const pagerOn = within(rowNamed('PagerDuty')).getByTestId('mcp-plugin-toggle')
     expect(pagerOn.textContent).toBe('On')
     expectGoldInk(pagerOn)
+    expect(within(rowNamed('PagerDuty')).getByText('Connected')).toBeTruthy()
 
     await user.click(within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle'))
     const victoriaOff = within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle')
     expect(victoriaOff.textContent).toBe('Off')
     expectQuietChip(victoriaOff)
+    expect(within(rowNamed('Victoria Metrics')).getByText('Off · not configured')).toBeTruthy()
+  })
+
+  it('restores catalog Connected details when turning Victoria Metrics and GitHub back On', async () => {
+    const user = userEvent.setup()
+    render(<McpPluginsPanel />)
+
+    await user.click(within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle'))
+    await user.click(within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle'))
+    expect(within(rowNamed('Victoria Metrics')).getByText('Connected · queries + labels')).toBeTruthy()
+
+    await user.click(within(rowNamed('GitHub')).getByTestId('mcp-plugin-toggle'))
+    expect(within(rowNamed('GitHub')).getByText('Off · not configured')).toBeTruthy()
+    await user.click(within(rowNamed('GitHub')).getByTestId('mcp-plugin-toggle'))
+    expect(within(rowNamed('GitHub')).getByText('Connected · issues, PRs')).toBeTruthy()
   })
 
   it('retries an error row inline without a toast', async () => {
@@ -122,6 +138,8 @@ describe('McpPluginsPanel', () => {
     const recovered = rowNamed('Broken')
     expect(within(recovered).queryByTestId('mcp-plugin-retry')).toBeNull()
     expect(within(recovered).queryByText(UNREACHABLE_SERVER_ERROR)).toBeNull()
+    expect(within(recovered).queryByText('timeout')).toBeNull()
+    expect(within(recovered).getByText('Connected')).toBeTruthy()
     const chip = within(recovered).getByTestId('mcp-plugin-toggle')
     expect(chip.textContent).toBe('On')
     expectGoldInk(chip)

--- a/frontend/src/components/settings/McpPluginsPanel.spec.tsx
+++ b/frontend/src/components/settings/McpPluginsPanel.spec.tsx
@@ -108,7 +108,9 @@ describe('McpPluginsPanel', () => {
 
     await user.click(within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle'))
     await user.click(within(rowNamed('Victoria Metrics')).getByTestId('mcp-plugin-toggle'))
-    expect(within(rowNamed('Victoria Metrics')).getByText('Connected · queries + labels')).toBeTruthy()
+    expect(
+      within(rowNamed('Victoria Metrics')).getByText('Connected · queries + labels'),
+    ).toBeTruthy()
 
     await user.click(within(rowNamed('GitHub')).getByTestId('mcp-plugin-toggle'))
     expect(within(rowNamed('GitHub')).getByText('Off · not configured')).toBeTruthy()

--- a/frontend/src/components/settings/McpPluginsPanel.tsx
+++ b/frontend/src/components/settings/McpPluginsPanel.tsx
@@ -1,0 +1,216 @@
+import { type FormEvent, useState } from 'react'
+import {
+  addMcpPlugin,
+  FIGMA_MCP_PLUGINS,
+  MCP_PLUGINS_ADD_LABEL,
+  MCP_PLUGINS_EMPTY,
+  MCP_PLUGINS_RETRY_LABEL,
+  MCP_PLUGINS_SUBTITLE,
+  MCP_PLUGINS_TITLE,
+  type McpPlugin,
+  retryMcpPlugin,
+  toggleMcpPlugin,
+  UNREACHABLE_SERVER_ERROR,
+} from '@/components/settings/mcpPlugins'
+import { Button } from '@/components/ui/button'
+
+export type McpPluginsPanelProps = {
+  initialPlugins?: McpPlugin[]
+}
+
+export function McpPluginsPanel({ initialPlugins = FIGMA_MCP_PLUGINS }: McpPluginsPanelProps) {
+  const [plugins, setPlugins] = useState<McpPlugin[]>(initialPlugins)
+  const [composerOpen, setComposerOpen] = useState(false)
+  const [draftName, setDraftName] = useState('')
+
+  function openComposer() {
+    setDraftName('')
+    setComposerOpen(true)
+  }
+
+  function submitComposer(event: FormEvent) {
+    event.preventDefault()
+    const next = addMcpPlugin(plugins, draftName)
+    if (next === plugins) return
+    setPlugins(next)
+    setComposerOpen(false)
+    setDraftName('')
+  }
+
+  return (
+    <section
+      data-testid="mcp-plugins-panel"
+      className="flex min-w-0 flex-1 flex-col gap-4 p-6"
+      style={{ color: 'var(--color-on-surface)' }}
+    >
+      <header className="flex w-full items-start justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="m-0 font-display text-2xl font-semibold text-on-surface">
+            {MCP_PLUGINS_TITLE}
+          </h1>
+          <p className="m-0 text-[13px] text-on-surface-variant">{MCP_PLUGINS_SUBTITLE}</p>
+        </div>
+        <Button
+          type="button"
+          data-testid="mcp-plugins-add"
+          className="h-auto rounded-lg px-2 py-2 text-xs font-semibold"
+          onClick={openComposer}
+        >
+          {MCP_PLUGINS_ADD_LABEL}
+        </Button>
+      </header>
+
+      {composerOpen ? (
+        <form
+          data-testid="mcp-plugins-add-form"
+          className="flex items-center gap-2"
+          onSubmit={submitComposer}
+        >
+          <input
+            data-testid="mcp-plugins-add-name"
+            value={draftName}
+            onChange={(event) => setDraftName(event.target.value)}
+            aria-label="Server name"
+            placeholder="Server name"
+            className="min-w-0 flex-1 rounded-lg border-0 px-3 py-2 text-sm outline-none"
+            style={{
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface)',
+            }}
+          />
+          <Button
+            type="submit"
+            data-testid="mcp-plugins-add-submit"
+            className="h-auto rounded-lg px-2 py-2 text-xs font-semibold"
+          >
+            {MCP_PLUGINS_ADD_LABEL}
+          </Button>
+        </form>
+      ) : null}
+
+      {plugins.length === 0 ? (
+        <p data-testid="mcp-plugins-empty" className="m-0 text-xs text-on-surface-variant">
+          {MCP_PLUGINS_EMPTY}.
+        </p>
+      ) : (
+        <ul data-testid="mcp-plugins-list" className="m-0 flex list-none flex-col gap-2 p-0">
+          {plugins.map((plugin) => (
+            <McpPluginRow
+              key={plugin.id}
+              plugin={plugin}
+              onToggle={() =>
+                setPlugins((current) =>
+                  current.map((row) => (row.id === plugin.id ? toggleMcpPlugin(row) : row)),
+                )
+              }
+              onRetry={() =>
+                setPlugins((current) =>
+                  current.map((row) => (row.id === plugin.id ? retryMcpPlugin(row) : row)),
+                )
+              }
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+function McpPluginRow({
+  plugin,
+  onToggle,
+  onRetry,
+}: {
+  plugin: McpPlugin
+  onToggle: () => void
+  onRetry: () => void
+}) {
+  return (
+    <li
+      data-testid="mcp-plugin-row"
+      data-plugin-id={plugin.id}
+      className="flex items-center gap-3 rounded-lg p-4"
+      style={{
+        backgroundColor: 'var(--color-surface-container-low)',
+        border: '1px solid var(--color-surface-container-high)',
+      }}
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="m-0 text-sm font-medium text-on-surface">{plugin.name}</p>
+        <PluginStatus plugin={plugin} onRetry={onRetry} />
+      </div>
+      <PluginChip plugin={plugin} onToggle={onToggle} />
+    </li>
+  )
+}
+
+function PluginStatus({ plugin, onRetry }: { plugin: McpPlugin; onRetry: () => void }) {
+  switch (plugin.state) {
+    case 'on':
+    case 'off':
+      return <p className="m-0 text-xs text-on-surface-variant">{plugin.detail}</p>
+    case 'error':
+      return (
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="m-0 text-xs text-error">{UNREACHABLE_SERVER_ERROR}</p>
+          <button
+            type="button"
+            data-testid="mcp-plugin-retry"
+            className="cursor-pointer rounded-lg border-0 px-1.5 py-1.5 text-[11px] font-medium"
+            style={{
+              backgroundColor: 'var(--color-surface-container-high)',
+              color: 'var(--color-on-surface-variant)',
+            }}
+            onClick={onRetry}
+          >
+            {MCP_PLUGINS_RETRY_LABEL}
+          </button>
+        </div>
+      )
+    default: {
+      const _exhaustive: never = plugin
+      return _exhaustive
+    }
+  }
+}
+
+function PluginChip({ plugin, onToggle }: { plugin: McpPlugin; onToggle: () => void }) {
+  switch (plugin.state) {
+    case 'on':
+    case 'error':
+      return (
+        <button
+          type="button"
+          data-testid="mcp-plugin-toggle"
+          aria-pressed="true"
+          aria-label={`${plugin.name} On`}
+          className="cursor-pointer rounded-lg border-0 p-1.5 text-[11px] font-medium"
+          style={{ backgroundColor: 'var(--color-primary)', color: '#0B0D0F' }}
+          onClick={onToggle}
+        >
+          On
+        </button>
+      )
+    case 'off':
+      return (
+        <button
+          type="button"
+          data-testid="mcp-plugin-toggle"
+          aria-pressed="false"
+          aria-label={`${plugin.name} Off`}
+          className="cursor-pointer rounded-lg border-0 p-1.5 text-[11px] font-medium"
+          style={{
+            backgroundColor: 'var(--color-surface-container-high)',
+            color: 'var(--color-on-surface-variant)',
+          }}
+          onClick={onToggle}
+        >
+          Off
+        </button>
+      )
+    default: {
+      const _exhaustive: never = plugin
+      return _exhaustive
+    }
+  }
+}

--- a/frontend/src/components/settings/mcpPlugins.spec.ts
+++ b/frontend/src/components/settings/mcpPlugins.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addMcpPlugin,
+  FIGMA_MCP_PLUGINS,
+  retryMcpPlugin,
+  toggleMcpPlugin,
+  UNREACHABLE_SERVER_ERROR,
+} from './mcpPlugins'
+
+describe('toggleMcpPlugin', () => {
+  it('turns On into Off with not-configured detail', () => {
+    expect(toggleMcpPlugin(FIGMA_MCP_PLUGINS[0]!)).toEqual({
+      id: 'victoria-metrics',
+      name: 'Victoria Metrics',
+      state: 'off',
+      detail: 'Off · not configured',
+    })
+  })
+
+  it('turns Off into On with a Connected detail', () => {
+    expect(toggleMcpPlugin(FIGMA_MCP_PLUGINS[2]!)).toEqual({
+      id: 'pagerduty',
+      name: 'PagerDuty',
+      state: 'on',
+      detail: 'Connected',
+    })
+  })
+
+  it('clears error into On and keeps a non-Off detail', () => {
+    const plugin = {
+      id: 'broken',
+      name: 'Broken',
+      state: 'error' as const,
+      detail: UNREACHABLE_SERVER_ERROR,
+    }
+    expect(toggleMcpPlugin(plugin)).toEqual({
+      id: 'broken',
+      name: 'Broken',
+      state: 'on',
+      detail: UNREACHABLE_SERVER_ERROR,
+    })
+  })
+})
+
+describe('retryMcpPlugin', () => {
+  it('turns error into On and keeps detail', () => {
+    const plugin = {
+      id: 'broken',
+      name: 'Broken',
+      state: 'error' as const,
+      detail: UNREACHABLE_SERVER_ERROR,
+    }
+    expect(retryMcpPlugin(plugin)).toEqual({
+      id: 'broken',
+      name: 'Broken',
+      state: 'on',
+      detail: UNREACHABLE_SERVER_ERROR,
+    })
+  })
+
+  it('is identity for On and Off', () => {
+    expect(retryMcpPlugin(FIGMA_MCP_PLUGINS[0]!)).toBe(FIGMA_MCP_PLUGINS[0])
+    expect(retryMcpPlugin(FIGMA_MCP_PLUGINS[2]!)).toBe(FIGMA_MCP_PLUGINS[2])
+  })
+})
+
+describe('addMcpPlugin', () => {
+  it('appends an Off row from a trimmed name', () => {
+    expect(addMcpPlugin([], ' Slack ')).toEqual([
+      { id: 'slack', name: 'Slack', state: 'off', detail: 'Off · not configured' },
+    ])
+  })
+
+  it('ignores a blank name and returns the same array', () => {
+    expect(addMcpPlugin(FIGMA_MCP_PLUGINS, '   ')).toBe(FIGMA_MCP_PLUGINS)
+    expect(addMcpPlugin(FIGMA_MCP_PLUGINS, '')).toBe(FIGMA_MCP_PLUGINS)
+  })
+
+  it('makes a colliding slug unique', () => {
+    const next = addMcpPlugin(FIGMA_MCP_PLUGINS, 'GitHub')
+    expect(next.at(-1)).toEqual({
+      id: 'github-2',
+      name: 'GitHub',
+      state: 'off',
+      detail: 'Off · not configured',
+    })
+  })
+})

--- a/frontend/src/components/settings/mcpPlugins.spec.ts
+++ b/frontend/src/components/settings/mcpPlugins.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   addMcpPlugin,
   FIGMA_MCP_PLUGINS,
+  MCP_PLUGINS_CONNECTED_DETAIL,
+  MCP_PLUGINS_OFF_DETAIL,
   retryMcpPlugin,
   toggleMcpPlugin,
   UNREACHABLE_SERVER_ERROR,
@@ -13,7 +15,7 @@ describe('toggleMcpPlugin', () => {
       id: 'victoria-metrics',
       name: 'Victoria Metrics',
       state: 'off',
-      detail: 'Off · not configured',
+      detail: MCP_PLUGINS_OFF_DETAIL,
     })
   })
 
@@ -22,28 +24,33 @@ describe('toggleMcpPlugin', () => {
       id: 'pagerduty',
       name: 'PagerDuty',
       state: 'on',
-      detail: 'Connected',
+      detail: MCP_PLUGINS_CONNECTED_DETAIL,
     })
   })
 
-  it('clears error into On and keeps a non-Off detail', () => {
+  it('restores catalog Connected details when turning Victoria Metrics and GitHub back On', () => {
+    expect(toggleMcpPlugin(toggleMcpPlugin(FIGMA_MCP_PLUGINS[0]!))).toEqual(FIGMA_MCP_PLUGINS[0])
+    expect(toggleMcpPlugin(toggleMcpPlugin(FIGMA_MCP_PLUGINS[1]!))).toEqual(FIGMA_MCP_PLUGINS[1])
+  })
+
+  it('clears error into On with an explicit Connected detail', () => {
     const plugin = {
       id: 'broken',
       name: 'Broken',
       state: 'error' as const,
-      detail: UNREACHABLE_SERVER_ERROR,
+      detail: 'timeout',
     }
     expect(toggleMcpPlugin(plugin)).toEqual({
       id: 'broken',
       name: 'Broken',
       state: 'on',
-      detail: UNREACHABLE_SERVER_ERROR,
+      detail: MCP_PLUGINS_CONNECTED_DETAIL,
     })
   })
 })
 
 describe('retryMcpPlugin', () => {
-  it('turns error into On and keeps detail', () => {
+  it('turns error into On with an explicit Connected detail', () => {
     const plugin = {
       id: 'broken',
       name: 'Broken',
@@ -54,8 +61,19 @@ describe('retryMcpPlugin', () => {
       id: 'broken',
       name: 'Broken',
       state: 'on',
-      detail: UNREACHABLE_SERVER_ERROR,
+      detail: MCP_PLUGINS_CONNECTED_DETAIL,
     })
+  })
+
+  it('retries a catalog error row back to its Connected detail', () => {
+    expect(
+      retryMcpPlugin({
+        id: 'github',
+        name: 'GitHub',
+        state: 'error',
+        detail: 'timeout',
+      }),
+    ).toEqual(FIGMA_MCP_PLUGINS[1])
   })
 
   it('is identity for On and Off', () => {

--- a/frontend/src/components/settings/mcpPlugins.ts
+++ b/frontend/src/components/settings/mcpPlugins.ts
@@ -1,0 +1,100 @@
+export const UNREACHABLE_SERVER_ERROR = "Couldn't reach this server"
+export const MCP_PLUGINS_TITLE = 'MCP / Plugins'
+export const MCP_PLUGINS_SUBTITLE = 'Tools the agent can call. Quiet list, one gold enable.'
+export const MCP_PLUGINS_ADD_LABEL = 'Add server'
+export const MCP_PLUGINS_EMPTY = 'No servers yet'
+export const MCP_PLUGINS_OFF_DETAIL = 'Off · not configured'
+export const MCP_PLUGINS_RETRY_LABEL = 'Retry'
+
+export type McpPlugin =
+  | { id: string; name: string; state: 'on'; detail: string }
+  | { id: string; name: string; state: 'off'; detail: string }
+  | { id: string; name: string; state: 'error'; detail: string }
+
+export const FIGMA_MCP_PLUGINS: McpPlugin[] = [
+  {
+    id: 'victoria-metrics',
+    name: 'Victoria Metrics',
+    state: 'on',
+    detail: 'Connected · queries + labels',
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    state: 'on',
+    detail: 'Connected · issues, PRs',
+  },
+  {
+    id: 'pagerduty',
+    name: 'PagerDuty',
+    state: 'off',
+    detail: MCP_PLUGINS_OFF_DETAIL,
+  },
+]
+
+export function toggleMcpPlugin(plugin: McpPlugin): McpPlugin {
+  switch (plugin.state) {
+    case 'on':
+      return { id: plugin.id, name: plugin.name, state: 'off', detail: MCP_PLUGINS_OFF_DETAIL }
+    case 'off':
+    case 'error':
+      return {
+        id: plugin.id,
+        name: plugin.name,
+        state: 'on',
+        detail: connectedDetail(plugin.detail),
+      }
+    default: {
+      const _exhaustive: never = plugin
+      return _exhaustive
+    }
+  }
+}
+
+export function retryMcpPlugin(plugin: McpPlugin): McpPlugin {
+  switch (plugin.state) {
+    case 'error':
+      return { id: plugin.id, name: plugin.name, state: 'on', detail: plugin.detail }
+    case 'on':
+    case 'off':
+      return plugin
+    default: {
+      const _exhaustive: never = plugin
+      return _exhaustive
+    }
+  }
+}
+
+export function addMcpPlugin(plugins: McpPlugin[], name: string): McpPlugin[] {
+  const trimmed = name.trim()
+  if (!trimmed) return plugins
+  return [
+    ...plugins,
+    {
+      id: uniquePluginId(plugins, slugify(trimmed)),
+      name: trimmed,
+      state: 'off',
+      detail: MCP_PLUGINS_OFF_DETAIL,
+    },
+  ]
+}
+
+function connectedDetail(detail: string): string {
+  return detail.startsWith('Off') ? 'Connected' : detail
+}
+
+function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || 'server'
+}
+
+function uniquePluginId(plugins: McpPlugin[], base: string): string {
+  const taken = new Set(plugins.map((plugin) => plugin.id))
+  if (!taken.has(base)) return base
+  let n = 2
+  while (taken.has(`${base}-${n}`)) n += 1
+  return `${base}-${n}`
+}

--- a/frontend/src/components/settings/mcpPlugins.ts
+++ b/frontend/src/components/settings/mcpPlugins.ts
@@ -3,6 +3,7 @@ export const MCP_PLUGINS_TITLE = 'MCP / Plugins'
 export const MCP_PLUGINS_SUBTITLE = 'Tools the agent can call. Quiet list, one gold enable.'
 export const MCP_PLUGINS_ADD_LABEL = 'Add server'
 export const MCP_PLUGINS_EMPTY = 'No servers yet'
+export const MCP_PLUGINS_CONNECTED_DETAIL = 'Connected'
 export const MCP_PLUGINS_OFF_DETAIL = 'Off · not configured'
 export const MCP_PLUGINS_RETRY_LABEL = 'Retry'
 
@@ -38,12 +39,7 @@ export function toggleMcpPlugin(plugin: McpPlugin): McpPlugin {
       return { id: plugin.id, name: plugin.name, state: 'off', detail: MCP_PLUGINS_OFF_DETAIL }
     case 'off':
     case 'error':
-      return {
-        id: plugin.id,
-        name: plugin.name,
-        state: 'on',
-        detail: connectedDetail(plugin.detail),
-      }
+      return enableMcpPlugin(plugin)
     default: {
       const _exhaustive: never = plugin
       return _exhaustive
@@ -54,7 +50,7 @@ export function toggleMcpPlugin(plugin: McpPlugin): McpPlugin {
 export function retryMcpPlugin(plugin: McpPlugin): McpPlugin {
   switch (plugin.state) {
     case 'error':
-      return { id: plugin.id, name: plugin.name, state: 'on', detail: plugin.detail }
+      return enableMcpPlugin(plugin)
     case 'on':
     case 'off':
       return plugin
@@ -79,8 +75,19 @@ export function addMcpPlugin(plugins: McpPlugin[], name: string): McpPlugin[] {
   ]
 }
 
-function connectedDetail(detail: string): string {
-  return detail.startsWith('Off') ? 'Connected' : detail
+function enableMcpPlugin(plugin: McpPlugin): McpPlugin {
+  return {
+    id: plugin.id,
+    name: plugin.name,
+    state: 'on',
+    detail: connectedOnDetail(plugin.id),
+  }
+}
+
+function connectedOnDetail(id: string): string {
+  const catalog = FIGMA_MCP_PLUGINS.find((row) => row.id === id)
+  if (catalog?.state === 'on') return catalog.detail
+  return MCP_PLUGINS_CONNECTED_DETAIL
 }
 
 function slugify(name: string): string {

--- a/frontend/src/components/settings/settingsSections.ts
+++ b/frontend/src/components/settings/settingsSections.ts
@@ -4,6 +4,7 @@ export const SETTINGS_SECTIONS = [
   'groups',
   'datasources',
   'ai',
+  'mcp',
   'sso',
 ] as const
 

--- a/frontend/src/components/sidebar/navigationConfig.ts
+++ b/frontend/src/components/sidebar/navigationConfig.ts
@@ -48,6 +48,7 @@ export const sectionSubNav: Record<string, SubNavItem[]> = {
     { id: 'groups', label: 'Groups & Permissions', path: '/app/settings/groups' },
     { id: 'datasources', label: 'Data Sources', path: '/app/settings/datasources' },
     { id: 'ai', label: 'AI Configuration', path: '/app/settings/ai' },
+    { id: 'mcp', label: 'MCP / Plugins', path: '/app/settings/mcp' },
     { id: 'sso', label: 'SSO / Auth', path: '/app/settings/sso' },
     { id: 'audit-log', label: 'Audit Log', path: '/app/audit-log' },
   ],

--- a/frontend/src/pages/SettingsPage.spec.tsx
+++ b/frontend/src/pages/SettingsPage.spec.tsx
@@ -510,7 +510,9 @@ describe('SettingsPage', () => {
 
       expect(screen.getByRole('heading', { name: 'MCP / Plugins' })).toBeTruthy()
       expect(screen.getByText('Victoria Metrics')).toBeTruthy()
-      expect(screen.queryByTestId('settings-section-nav')).toBeNull()
+      expect(screen.getByTestId('settings-section-nav')).toBeTruthy()
+      expect(screen.getByTestId('settings-nav-mcp')).toBeTruthy()
+      expect(screen.queryByRole('heading', { name: 'Settings' })).toBeNull()
     })
   })
 
@@ -520,7 +522,8 @@ describe('SettingsPage', () => {
 
       expect(await screen.findByTestId('mcp-plugins-panel')).toBeTruthy()
       expect(screen.getByRole('heading', { name: 'MCP / Plugins' })).toBeTruthy()
-      expect(screen.queryByTestId('settings-section-nav')).toBeNull()
+      expect(screen.getByTestId('settings-section-nav')).toBeTruthy()
+      expect(screen.getByTestId('settings-nav-mcp')).toBeTruthy()
       expect(screen.queryByRole('heading', { name: 'Settings' })).toBeNull()
     })
   })

--- a/frontend/src/pages/SettingsPage.spec.tsx
+++ b/frontend/src/pages/SettingsPage.spec.tsx
@@ -493,6 +493,26 @@ describe('SettingsPage', () => {
       })
     })
 
+    it('does not refetch org data when switching general to members', async () => {
+      const user = userEvent.setup()
+      renderSettings('/app/settings/general')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('settings-general')).toBeTruthy()
+      })
+      expect(organizationsApi.getOrganization).toHaveBeenCalledTimes(1)
+      expect(organizationsApi.listMembers).toHaveBeenCalledTimes(1)
+
+      await user.click(screen.getByTestId('settings-nav-members'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('settings-members')).toBeTruthy()
+      })
+      expect(screen.queryByText('Loading...')).toBeNull()
+      expect(organizationsApi.getOrganization).toHaveBeenCalledTimes(1)
+      expect(organizationsApi.listMembers).toHaveBeenCalledTimes(1)
+    })
+
     it('opens MCP / Plugins as the Figma 12:188 list', async () => {
       const user = userEvent.setup()
       const router = renderSettings('/app/settings/general')
@@ -525,6 +545,24 @@ describe('SettingsPage', () => {
       expect(screen.getByTestId('settings-section-nav')).toBeTruthy()
       expect(screen.getByTestId('settings-nav-mcp')).toBeTruthy()
       expect(screen.queryByRole('heading', { name: 'Settings' })).toBeNull()
+      expect(organizationsApi.getOrganization).not.toHaveBeenCalled()
+      expect(organizationsApi.listMembers).not.toHaveBeenCalled()
+    })
+
+    it('loads org data once when leaving MCP for general', async () => {
+      const user = userEvent.setup()
+      renderSettings('/app/settings/mcp')
+
+      expect(await screen.findByTestId('mcp-plugins-panel')).toBeTruthy()
+      expect(organizationsApi.getOrganization).not.toHaveBeenCalled()
+
+      await user.click(screen.getByTestId('settings-nav-general'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('settings-general')).toBeTruthy()
+      })
+      expect(organizationsApi.getOrganization).toHaveBeenCalledTimes(1)
+      expect(organizationsApi.listMembers).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/frontend/src/pages/SettingsPage.spec.tsx
+++ b/frontend/src/pages/SettingsPage.spec.tsx
@@ -480,6 +480,7 @@ describe('SettingsPage', () => {
 
       expect(screen.getByTestId('settings-nav-general')).toBeTruthy()
       expect(screen.getByTestId('settings-nav-members')).toBeTruthy()
+      expect(screen.getByTestId('settings-nav-mcp')).toBeTruthy()
       expect(screen.getByTestId('settings-nav-sso')).toBeTruthy()
       expect(screen.getByTestId('settings-general')).toBeTruthy()
       expect(screen.getByTestId('settings-branding')).toBeTruthy()
@@ -490,6 +491,37 @@ describe('SettingsPage', () => {
         expect(router.state.location.pathname).toBe('/app/settings/members')
         expect(screen.getByTestId('settings-members')).toBeTruthy()
       })
+    })
+
+    it('opens MCP / Plugins as the Figma 12:188 list', async () => {
+      const user = userEvent.setup()
+      const router = renderSettings('/app/settings/general')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('settings-nav-mcp')).toBeTruthy()
+      })
+
+      await user.click(screen.getByTestId('settings-nav-mcp'))
+
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe('/app/settings/mcp')
+        expect(screen.getByTestId('mcp-plugins-panel')).toBeTruthy()
+      })
+
+      expect(screen.getByRole('heading', { name: 'MCP / Plugins' })).toBeTruthy()
+      expect(screen.getByText('Victoria Metrics')).toBeTruthy()
+      expect(screen.queryByTestId('settings-section-nav')).toBeNull()
+    })
+  })
+
+  describe('MCP / Plugins section', () => {
+    it('renders /app/settings/mcp as the Figma panel', async () => {
+      renderSettings('/app/settings/mcp')
+
+      expect(await screen.findByTestId('mcp-plugins-panel')).toBeTruthy()
+      expect(screen.getByRole('heading', { name: 'MCP / Plugins' })).toBeTruthy()
+      expect(screen.queryByTestId('settings-section-nav')).toBeNull()
+      expect(screen.queryByRole('heading', { name: 'Settings' })).toBeNull()
     })
   })
 })

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -82,36 +82,33 @@ export function SettingsPage() {
   }, [activeSection, loadData])
 
   const isAdmin = org?.role === 'admin'
+  const showSettingsTitle = activeSection !== 'mcp'
 
   if (!isSettingsSection(sectionParam) && sectionParam !== undefined) {
     return <Navigate to="/app/settings/general" replace />
-  }
-
-  if (activeSection === 'mcp') {
-    return (
-      <div className="flex min-h-0 flex-1" style={{ color: 'var(--color-on-surface)' }}>
-        <McpPluginsPanel />
-      </div>
-    )
   }
 
   return (
     <div className="flex min-h-0 flex-1" style={{ color: 'var(--color-on-surface)' }}>
       <div className="flex-1 overflow-y-auto px-8 py-6">
         <header className="mb-6">
-          <h1
-            className="font-display text-2xl font-semibold"
-            style={{ color: 'var(--color-on-surface)' }}
-          >
-            Settings
-          </h1>
-          <p className="mt-1 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
-            {org?.name
-              ? `Manage ${org.name} profile, members, datasources, and preferences`
-              : 'Manage organization profile, members, datasources, and preferences'}
-          </p>
+          {showSettingsTitle ? (
+            <>
+              <h1
+                className="font-display text-2xl font-semibold"
+                style={{ color: 'var(--color-on-surface)' }}
+              >
+                Settings
+              </h1>
+              <p className="mt-1 text-sm" style={{ color: 'var(--color-on-surface-variant)' }}>
+                {org?.name
+                  ? `Manage ${org.name} profile, members, datasources, and preferences`
+                  : 'Manage organization profile, members, datasources, and preferences'}
+              </p>
+            </>
+          ) : null}
           <nav
-            className="mt-4 flex flex-wrap gap-2"
+            className={showSettingsTitle ? 'mt-4 flex flex-wrap gap-2' : 'flex flex-wrap gap-2'}
             aria-label="Settings sections"
             data-testid="settings-section-nav"
           >
@@ -143,94 +140,100 @@ export function SettingsPage() {
           </nav>
         </header>
 
-        {loading ? (
-          <div className="py-8 text-center" style={{ color: 'var(--color-outline)' }}>
-            Loading...
-          </div>
-        ) : null}
-        {!loading && error ? (
-          <div className="py-8 text-center" style={{ color: 'var(--color-error)' }}>
-            {error}
-          </div>
-        ) : null}
-        {!loading && !error && !orgId ? (
-          <div className="py-8 text-center" style={{ color: 'var(--color-outline)' }}>
-            No organization selected.
-          </div>
-        ) : null}
-
-        {!loading && !error && orgId && org ? (
+        {activeSection === 'mcp' ? (
+          <McpPluginsPanel />
+        ) : (
           <>
-            {activeSection === 'general' ? (
-              <GeneralSettingsSection
-                org={org}
-                orgId={orgId}
-                isAdmin={Boolean(isAdmin)}
-                onOrgUpdated={setOrg}
-              />
+            {loading ? (
+              <div className="py-8 text-center" style={{ color: 'var(--color-outline)' }}>
+                Loading...
+              </div>
+            ) : null}
+            {!loading && error ? (
+              <div className="py-8 text-center" style={{ color: 'var(--color-error)' }}>
+                {error}
+              </div>
+            ) : null}
+            {!loading && !error && !orgId ? (
+              <div className="py-8 text-center" style={{ color: 'var(--color-outline)' }}>
+                No organization selected.
+              </div>
             ) : null}
 
-            {activeSection === 'members' ? (
-              <MembersSettingsSection
-                orgId={orgId}
-                isAdmin={Boolean(isAdmin)}
-                currentUserId={currentUserId}
-                members={members}
-                onMembersChange={setMembers}
-              />
-            ) : null}
+            {!loading && !error && orgId && org ? (
+              <>
+                {activeSection === 'general' ? (
+                  <GeneralSettingsSection
+                    org={org}
+                    orgId={orgId}
+                    isAdmin={Boolean(isAdmin)}
+                    onOrgUpdated={setOrg}
+                  />
+                ) : null}
 
-            {activeSection === 'groups' ? (
-              <GroupsSettingsSection
-                orgId={orgId}
-                isAdmin={Boolean(isAdmin)}
-                orgMembers={members}
-              />
-            ) : null}
+                {activeSection === 'members' ? (
+                  <MembersSettingsSection
+                    orgId={orgId}
+                    isAdmin={Boolean(isAdmin)}
+                    currentUserId={currentUserId}
+                    members={members}
+                    onMembersChange={setMembers}
+                  />
+                ) : null}
 
-            {activeSection === 'datasources' ? (
-              <section
-                className="flex max-w-3xl flex-col gap-4"
-                data-testid="settings-datasources"
-              >
-                <div
-                  className="rounded-lg p-6"
-                  style={{ backgroundColor: 'var(--color-surface-container-low)' }}
-                >
-                  <h2
-                    className="mb-2 flex items-center gap-2 font-display text-base font-semibold"
-                    style={{ color: 'var(--color-on-surface)' }}
+                {activeSection === 'groups' ? (
+                  <GroupsSettingsSection
+                    orgId={orgId}
+                    isAdmin={Boolean(isAdmin)}
+                    orgMembers={members}
+                  />
+                ) : null}
+
+                {activeSection === 'datasources' ? (
+                  <section
+                    className="flex max-w-3xl flex-col gap-4"
+                    data-testid="settings-datasources"
                   >
-                    <Database size={20} /> Data Sources
-                  </h2>
-                  <p
-                    className="mb-4 text-sm"
-                    style={{ color: 'var(--color-on-surface-variant)' }}
-                  >
-                    Configure connections to Prometheus, Loki, Tempo, VictoriaMetrics, and other
-                    data sources.
-                  </p>
-                  <DataSourceSettingsPanel orgId={orgId} isAdmin={Boolean(isAdmin)} />
-                </div>
-              </section>
-            ) : null}
+                    <div
+                      className="rounded-lg p-6"
+                      style={{ backgroundColor: 'var(--color-surface-container-low)' }}
+                    >
+                      <h2
+                        className="mb-2 flex items-center gap-2 font-display text-base font-semibold"
+                        style={{ color: 'var(--color-on-surface)' }}
+                      >
+                        <Database size={20} /> Data Sources
+                      </h2>
+                      <p
+                        className="mb-4 text-sm"
+                        style={{ color: 'var(--color-on-surface-variant)' }}
+                      >
+                        Configure connections to Prometheus, Loki, Tempo, VictoriaMetrics, and
+                        other data sources.
+                      </p>
+                      <DataSourceSettingsPanel orgId={orgId} isAdmin={Boolean(isAdmin)} />
+                    </div>
+                  </section>
+                ) : null}
 
-            {activeSection === 'ai' ? (
-              <section className="flex max-w-2xl flex-col gap-4" data-testid="settings-ai">
-                <AIProviderSettings
-                  orgId={orgId}
-                  isAdmin={Boolean(isAdmin)}
-                  onProviderCount={count => setHasOrgProviders(count > 0)}
-                />
-                {!hasOrgProviders ? <CopilotConnectionPanel orgId={orgId} /> : null}
-              </section>
-            ) : null}
+                {activeSection === 'ai' ? (
+                  <section className="flex max-w-2xl flex-col gap-4" data-testid="settings-ai">
+                    <AIProviderSettings
+                      orgId={orgId}
+                      isAdmin={Boolean(isAdmin)}
+                      onProviderCount={count => setHasOrgProviders(count > 0)}
+                    />
+                    {!hasOrgProviders ? <CopilotConnectionPanel orgId={orgId} /> : null}
+                  </section>
+                ) : null}
 
-            {activeSection === 'sso' ? (
-              <SsoSettingsSection orgId={orgId} isAdmin={Boolean(isAdmin)} />
+                {activeSection === 'sso' ? (
+                  <SsoSettingsSection orgId={orgId} isAdmin={Boolean(isAdmin)} />
+                ) : null}
+              </>
             ) : null}
           </>
-        ) : null}
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -76,10 +76,12 @@ export function SettingsPage() {
     }
   }, [orgId])
 
+  const needsOrgData = activeSection !== 'mcp'
+
   useEffect(() => {
-    if (activeSection === 'mcp') return
+    if (!needsOrgData) return
     void loadData()
-  }, [activeSection, loadData])
+  }, [needsOrgData, loadData])
 
   const isAdmin = org?.role === 'admin'
   const showSettingsTitle = activeSection !== 'mcp'

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Bot, Database, Edit2, Lock, Shield, Users } from 'lucide-react'
+import { Bot, Database, Edit2, Lock, Puzzle, Shield, Users } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router'
 import { getOrganization, listMembers } from '@/api/organizations'
@@ -7,6 +7,7 @@ import { CopilotConnectionPanel } from '@/components/settings/CopilotConnectionP
 import { DataSourceSettingsPanel } from '@/components/settings/DataSourceSettingsPanel'
 import { GeneralSettingsSection } from '@/components/settings/GeneralSettingsSection'
 import { GroupsSettingsSection } from '@/components/settings/GroupsSettingsSection'
+import { McpPluginsPanel } from '@/components/settings/McpPluginsPanel'
 import { MembersSettingsSection } from '@/components/settings/MembersSettingsSection'
 import {
   isSettingsSection,
@@ -27,6 +28,7 @@ const SECTION_META: Array<{
   { key: 'groups', label: 'Groups & Permissions', icon: Shield },
   { key: 'datasources', label: 'Data Sources', icon: Database },
   { key: 'ai', label: 'AI Configuration', icon: Bot },
+  { key: 'mcp', label: 'MCP / Plugins', icon: Puzzle },
   { key: 'sso', label: 'SSO / Auth', icon: Lock },
 ]
 
@@ -75,13 +77,22 @@ export function SettingsPage() {
   }, [orgId])
 
   useEffect(() => {
+    if (activeSection === 'mcp') return
     void loadData()
-  }, [loadData])
+  }, [activeSection, loadData])
 
   const isAdmin = org?.role === 'admin'
 
   if (!isSettingsSection(sectionParam) && sectionParam !== undefined) {
     return <Navigate to="/app/settings/general" replace />
+  }
+
+  if (activeSection === 'mcp') {
+    return (
+      <div className="flex min-h-0 flex-1" style={{ color: 'var(--color-on-surface)' }}>
+        <McpPluginsPanel />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -208,8 +208,8 @@ export function SettingsPage() {
                         className="mb-4 text-sm"
                         style={{ color: 'var(--color-on-surface-variant)' }}
                       >
-                        Configure connections to Prometheus, Loki, Tempo, VictoriaMetrics, and
-                        other data sources.
+                        Configure connections to Prometheus, Loki, Tempo, VictoriaMetrics, and other
+                        data sources.
                       </p>
                       <DataSourceSettingsPanel orgId={orgId} isAdmin={Boolean(isAdmin)} />
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #443

## Why

Refresh MCP/Plugins is a quiet list of servers the agent can call. Frame 12:188 and the locked notes ask for ink-on-gold Add server, On as accent/on-accent, Off as quiet, plus empty and inline Retry. Ace had no this surface. Ace's own `/mcp` API is the inverse product and stays untouched.

## Scope

- `McpPlugin` union (`on` | `off` | `error`) plus `toggleMcpPlugin` / `retryMcpPlugin` / `addMcpPlugin` in `frontend/src/components/settings/mcpPlugins.ts`
- Default potato catalog matches the frame. Victoria Metrics and GitHub On, PagerDuty Off
- `McpPluginsPanel` at `/app/settings/mcp`. Header, quiet rows, gold Add server (`Button` default), On/Off chips, empty copy, inline Retry
- Thin wiring. `settingsSections` adds `mcp`. Settings subnav and section chips link to the page. The MCP route skips the generic Settings h1 so the frame title is the page title

Out of scope. AgentDock, AppLayout, chart builder, dashboard, Explore, new tokens, MCP server APIs, marketplace.

## Tradeoffs

On chips use `--color-primary` and `#0B0D0F`, not the green in the Figma PNG. The locked notes name accent fill and on-accent text. Off stays quiet, not danger.

The catalog lives in component state. Nothing else reads this list yet, so a Zustand store would be a second owner for one caller.

## Blast Radius

Settings navigation gains an MCP / Plugins item. Other settings sections are unchanged. No backend or token file edits.

## Verification

`bunx vitest run` on `mcpPlugins.spec.ts`, `McpPluginsPanel.spec.tsx`, and `SettingsPage.spec.tsx`. 28 passed. List, empty, Add server, On/Off, Retry, and `/app/settings/mcp` wiring.

Browser (Vite preview of `McpPluginsPanel`, 1280x800). Default list, PagerDuty Off→On, empty, Add Slack, unreachable + Retry, Retry recovery. Add server stays ink-on-gold. On stays primary/`#0B0D0F`. Off stays quiet surface. Retry is inline, not a toast.

[Default MCP/Plugins list](https://cursor.com/agents/bc-9b2050d5-f2be-4a89-bb55-8d523d73130e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmcp-plugins-list.png)
[Empty state with gold Add server](https://cursor.com/agents/bc-9b2050d5-f2be-4a89-bb55-8d523d73130e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmcp-plugins-empty.png)
[PagerDuty toggled On](https://cursor.com/agents/bc-9b2050d5-f2be-4a89-bb55-8d523d73130e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmcp-plugins-toggle-on.png)
[Unreachable server with inline Retry](https://cursor.com/agents/bc-9b2050d5-f2be-4a89-bb55-8d523d73130e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmcp-plugins-retry.png)
[Retry recovered GitHub to On](https://cursor.com/agents/bc-9b2050d5-f2be-4a89-bb55-8d523d73130e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmcp-plugins-retried.png)
[Added Slack as Off](https://cursor.com/agents/bc-9b2050d5-f2be-4a89-bb55-8d523d73130e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmcp-plugins-add-slack.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b2050d5-f2be-4a89-bb55-8d523d73130e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b2050d5-f2be-4a89-bb55-8d523d73130e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

