### PR TITLE
feat(backend): add pkg/llm and RegisterDatasource contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,10 @@ Five canonical triage roles mapped 1:1 to default label strings. See `docs/agent
 ### Domain docs
 
 Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Module contracts
+
+LLM modules import `github.com/aceobservability/ace/backend/pkg/llm`
+(`RegisterLLM`, `AIProvider`). Datasource modules import
+`github.com/aceobservability/ace/backend/pkg/datasource`
+(`RegisterDatasource`, `Client`). See `docs/adr/0004-module-contracts.md`.

--- a/backend/internal/datasource/aliases.go
+++ b/backend/internal/datasource/aliases.go
@@ -1,0 +1,23 @@
+package datasource
+
+import dscontract "github.com/aceobservability/ace/backend/pkg/datasource"
+
+type (
+	Client                  = dscontract.Client
+	SignalQueryClient       = dscontract.SignalQueryClient
+	StreamClient            = dscontract.StreamClient
+	LabelsClient            = dscontract.LabelsClient
+	MetricLabelsClient      = dscontract.MetricLabelsClient
+	LabelValuesClient       = dscontract.LabelValuesClient
+	MetricLabelValuesClient = dscontract.MetricLabelValuesClient
+	MetricNamesClient       = dscontract.MetricNamesClient
+	LogStreamCallback       = dscontract.LogStreamCallback
+	QueryResult             = dscontract.QueryResult
+	QueryData               = dscontract.QueryData
+	MetricResult            = dscontract.MetricResult
+	LogEntry                = dscontract.LogEntry
+	TraceSpan               = dscontract.TraceSpan
+	TraceLog                = dscontract.TraceLog
+)
+
+var ErrUnknownType = dscontract.ErrUnknownType

--- a/backend/internal/datasource/client.go
+++ b/backend/internal/datasource/client.go
@@ -37,7 +37,7 @@ type connectionTester interface {
 
 // NewClient creates a datasource client based on the datasource type.
 func NewClient(ds models.DataSource) (Client, error) {
-	return dscontract.NewClient(string(ds.Type), configFromDataSource(ds))
+	return dscontract.NewClient(configFromDataSource(ds))
 }
 
 func TestConnection(ctx context.Context, ds models.DataSource) error {

--- a/backend/internal/datasource/client.go
+++ b/backend/internal/datasource/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aceobservability/ace/backend/internal/models"
 	"github.com/aceobservability/ace/backend/internal/ssrf"
+	dscontract "github.com/aceobservability/ace/backend/pkg/datasource"
 )
 
 // QueryRequest represents a query request body
@@ -30,109 +31,13 @@ type StreamRequest struct {
 	Limit int    `json:"limit,omitempty"` // Max entries per tail batch
 }
 
-// QueryResult is the unified query result format
-type QueryResult struct {
-	Status     string     `json:"status"`
-	Data       *QueryData `json:"data,omitempty"`
-	Error      string     `json:"error,omitempty"`
-	ResultType string     `json:"resultType"` // "metrics" or "logs"
-}
-
-// QueryData contains the result
-type QueryData struct {
-	ResultType string         `json:"resultType"`
-	Result     []MetricResult `json:"result,omitempty"`
-	Logs       []LogEntry     `json:"logs,omitempty"`
-	Traces     []TraceSpan    `json:"traces,omitempty"`
-}
-
-// MetricResult represents a single metric series (for Prometheus/VictoriaMetrics)
-type MetricResult struct {
-	Metric map[string]string `json:"metric"`
-	Values [][]interface{}   `json:"values"`
-}
-
-// LogEntry represents a single log line (for Loki/VictoriaLogs)
-type LogEntry struct {
-	Timestamp string            `json:"timestamp"`
-	Line      string            `json:"line"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	Level     string            `json:"level,omitempty"`
-}
-
-type LogStreamCallback func(LogEntry) error
-
-// Client is the interface that all datasource clients implement
-type Client interface {
-	Query(ctx context.Context, query string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error)
-}
-
-// SignalQueryClient is implemented by datasources that dispatch on signal
-// (ClickHouse, CloudWatch, Elasticsearch).
-type SignalQueryClient interface {
-	QueryWithSignal(ctx context.Context, query, signal string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error)
-}
-
-// StreamClient is implemented by log datasources that support live tail.
-type StreamClient interface {
-	Stream(ctx context.Context, query string, start time.Time, limit int, onLog LogStreamCallback) error
-}
-
-// LabelsClient is implemented by log datasources that expose label/field names.
-type LabelsClient interface {
-	Labels(ctx context.Context) ([]string, error)
-}
-
-// MetricLabelsClient is implemented by PromQL datasources that can scope labels
-// to a metric selector.
-type MetricLabelsClient interface {
-	Labels(ctx context.Context, metric string) ([]string, error)
-}
-
-// LabelValuesClient is implemented by log datasources that expose label values.
-type LabelValuesClient interface {
-	LabelValues(ctx context.Context, labelName string) ([]string, error)
-}
-
-// MetricLabelValuesClient is implemented by PromQL datasources that can scope
-// label values to a metric selector.
-type MetricLabelValuesClient interface {
-	LabelValues(ctx context.Context, label, metric string) ([]string, error)
-}
-
-// MetricNamesClient is implemented by PromQL datasources that expose metric names.
-type MetricNamesClient interface {
-	MetricNames(ctx context.Context, search string) ([]string, error)
-}
-
 type connectionTester interface {
 	TestConnection(ctx context.Context) error
 }
 
-// NewClient creates a datasource client based on the datasource type
+// NewClient creates a datasource client based on the datasource type.
 func NewClient(ds models.DataSource) (Client, error) {
-	switch ds.Type {
-	case models.DataSourcePrometheus:
-		return NewPrometheusClient(ds)
-	case models.DataSourceVictoriaMetrics:
-		return NewVictoriaMetricsClient(ds)
-	case models.DataSourceLoki:
-		return NewLokiClient(ds)
-	case models.DataSourceVictoriaLogs:
-		return NewVictoriaLogsClient(ds)
-	case models.DataSourceTempo:
-		return NewTempoClient(ds)
-	case models.DataSourceVictoriaTraces:
-		return NewVictoriaTracesClient(ds)
-	case models.DataSourceClickHouse:
-		return NewClickHouseClient(ds)
-	case models.DataSourceCloudWatch:
-		return NewCloudWatchClient(ds)
-	case models.DataSourceElasticsearch:
-		return NewElasticsearchClient(ds)
-	default:
-		return nil, fmt.Errorf("unsupported datasource type: %s", ds.Type)
-	}
+	return dscontract.NewClient(string(ds.Type), configFromDataSource(ds))
 }
 
 func TestConnection(ctx context.Context, ds models.DataSource) error {

--- a/backend/internal/datasource/client_test.go
+++ b/backend/internal/datasource/client_test.go
@@ -1,7 +1,9 @@
 package datasource
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
 	"testing"
@@ -177,25 +179,51 @@ func TestNewClient_VMAlertAndAlertManagerFailClosed(t *testing.T) {
 
 func TestRegisterDatasource_DispatchUsesRegisteredFactory(t *testing.T) {
 	const typ = "probe-internal-datasource"
+	wantName := "probe-one"
+	wantURL := "http://localhost:9090"
+	wantAuthType := "bearer"
+	wantAuthConfig := json.RawMessage(`{"token":"t"}`)
+	wantTraceID := "trace_id"
+
+	var got dscontract.Config
 	dscontract.RegisterDatasource(typ, func(cfg dscontract.Config) (dscontract.Client, error) {
+		got = cfg
 		return &probeQueryClient{name: cfg.Name}, nil
 	})
 	t.Cleanup(func() { dscontract.UnregisterDatasource(typ) })
 
 	client, err := NewClient(models.DataSource{
-		Type: models.DataSourceType(typ),
-		Name: "probe-one",
-		URL:  "http://localhost:9090",
+		Type:         models.DataSourceType(typ),
+		Name:         wantName,
+		URL:          wantURL,
+		AuthType:     wantAuthType,
+		AuthConfig:   wantAuthConfig,
+		TraceIDField: wantTraceID,
 	})
 	if err != nil {
 		t.Fatalf("dispatch registered type: %v", err)
 	}
-	got, ok := client.(*probeQueryClient)
+	gotClient, ok := client.(*probeQueryClient)
 	if !ok {
 		t.Fatalf("expected *probeQueryClient, got %T", client)
 	}
-	if got.name != "probe-one" {
-		t.Errorf("factory did not receive Config, name=%q", got.name)
+	if gotClient.name != wantName {
+		t.Errorf("factory did not receive Config.Name, name=%q", gotClient.name)
+	}
+	if got.Type != typ {
+		t.Errorf("Type=%q, want %q", got.Type, typ)
+	}
+	if got.URL != wantURL {
+		t.Errorf("URL=%q, want %q", got.URL, wantURL)
+	}
+	if got.AuthType != wantAuthType {
+		t.Errorf("AuthType=%q, want %q", got.AuthType, wantAuthType)
+	}
+	if !bytes.Equal(got.AuthConfig, wantAuthConfig) {
+		t.Errorf("AuthConfig=%s, want %s", got.AuthConfig, wantAuthConfig)
+	}
+	if got.TraceIDField != wantTraceID {
+		t.Errorf("TraceIDField=%q, want %q", got.TraceIDField, wantTraceID)
 	}
 }
 

--- a/backend/internal/datasource/client_test.go
+++ b/backend/internal/datasource/client_test.go
@@ -1,11 +1,23 @@
 package datasource
 
 import (
+	"context"
+	"errors"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/aceobservability/ace/backend/internal/models"
+	dscontract "github.com/aceobservability/ace/backend/pkg/datasource"
 )
+
+type probeQueryClient struct {
+	name string
+}
+
+func (c *probeQueryClient) Query(context.Context, string, time.Time, time.Time, time.Duration, int) (*QueryResult, error) {
+	return &QueryResult{Status: c.name}, nil
+}
 
 func TestNewClient_Prometheus(t *testing.T) {
 	ds := models.DataSource{
@@ -139,9 +151,51 @@ func TestNewClient_InvalidType(t *testing.T) {
 		Type: "invalid",
 		URL:  "http://localhost:9090",
 	}
-	_, err := NewClient(ds)
+	client, err := NewClient(ds)
 	if err == nil {
-		t.Error("expected error for invalid type, got nil")
+		t.Fatal("expected error for invalid type, got nil")
+	}
+	if !errors.Is(err, ErrUnknownType) {
+		t.Fatalf("expected ErrUnknownType, got %v", err)
+	}
+	if client != nil {
+		t.Fatalf("unknown type must not construct a client, got %T", client)
+	}
+}
+
+func TestNewClient_VMAlertAndAlertManagerFailClosed(t *testing.T) {
+	for _, typ := range []models.DataSourceType{models.DataSourceVMAlert, models.DataSourceAlertManager} {
+		client, err := NewClient(models.DataSource{Type: typ, URL: "http://localhost:8880"})
+		if !errors.Is(err, ErrUnknownType) {
+			t.Errorf("%s: expected ErrUnknownType, got %v", typ, err)
+		}
+		if client != nil {
+			t.Errorf("%s: unknown query type must not construct a client, got %T", typ, client)
+		}
+	}
+}
+
+func TestRegisterDatasource_DispatchUsesRegisteredFactory(t *testing.T) {
+	const typ = "probe-internal-datasource"
+	dscontract.RegisterDatasource(typ, func(cfg dscontract.Config) (dscontract.Client, error) {
+		return &probeQueryClient{name: cfg.Name}, nil
+	})
+	t.Cleanup(func() { dscontract.UnregisterDatasource(typ) })
+
+	client, err := NewClient(models.DataSource{
+		Type: models.DataSourceType(typ),
+		Name: "probe-one",
+		URL:  "http://localhost:9090",
+	})
+	if err != nil {
+		t.Fatalf("dispatch registered type: %v", err)
+	}
+	got, ok := client.(*probeQueryClient)
+	if !ok {
+		t.Fatalf("expected *probeQueryClient, got %T", client)
+	}
+	if got.name != "probe-one" {
+		t.Errorf("factory did not receive Config, name=%q", got.name)
 	}
 }
 

--- a/backend/internal/datasource/register.go
+++ b/backend/internal/datasource/register.go
@@ -23,6 +23,10 @@ func register[T Client](typ models.DataSourceType, ctor func(models.DataSource) 
 	})
 }
 
+// dataSourceFromConfig and configFromDataSource map the module Config, not the
+// stored row. ID, OrganizationID, IsDefault, LinkedTraceDatasourceID, CreatedAt,
+// and UpdatedAt are omitted on purpose. After a registry round-trip, constructors
+// must not rely on those fields.
 func dataSourceFromConfig(cfg dscontract.Config) models.DataSource {
 	return models.DataSource{
 		Name:         cfg.Name,

--- a/backend/internal/datasource/register.go
+++ b/backend/internal/datasource/register.go
@@ -1,0 +1,46 @@
+package datasource
+
+import (
+	"github.com/aceobservability/ace/backend/internal/models"
+	dscontract "github.com/aceobservability/ace/backend/pkg/datasource"
+)
+
+func init() {
+	register(models.DataSourcePrometheus, NewPrometheusClient)
+	register(models.DataSourceVictoriaMetrics, NewVictoriaMetricsClient)
+	register(models.DataSourceLoki, NewLokiClient)
+	register(models.DataSourceVictoriaLogs, NewVictoriaLogsClient)
+	register(models.DataSourceTempo, NewTempoClient)
+	register(models.DataSourceVictoriaTraces, NewVictoriaTracesClient)
+	register(models.DataSourceClickHouse, NewClickHouseClient)
+	register(models.DataSourceCloudWatch, NewCloudWatchClient)
+	register(models.DataSourceElasticsearch, NewElasticsearchClient)
+}
+
+func register[T Client](typ models.DataSourceType, ctor func(models.DataSource) (T, error)) {
+	dscontract.RegisterDatasource(string(typ), func(cfg dscontract.Config) (dscontract.Client, error) {
+		return ctor(dataSourceFromConfig(cfg))
+	})
+}
+
+func dataSourceFromConfig(cfg dscontract.Config) models.DataSource {
+	return models.DataSource{
+		Name:         cfg.Name,
+		Type:         models.DataSourceType(cfg.Type),
+		URL:          cfg.URL,
+		AuthType:     cfg.AuthType,
+		AuthConfig:   cfg.AuthConfig,
+		TraceIDField: cfg.TraceIDField,
+	}
+}
+
+func configFromDataSource(ds models.DataSource) dscontract.Config {
+	return dscontract.Config{
+		Name:         ds.Name,
+		Type:         string(ds.Type),
+		URL:          ds.URL,
+		AuthType:     ds.AuthType,
+		AuthConfig:   ds.AuthConfig,
+		TraceIDField: ds.TraceIDField,
+	}
+}

--- a/backend/internal/datasource/tracing.go
+++ b/backend/internal/datasource/tracing.go
@@ -45,25 +45,6 @@ type Trace struct {
 	DurationNano      int64       `json:"durationNano"`
 }
 
-// TraceSpan is a normalized span model.
-type TraceSpan struct {
-	SpanID            string            `json:"spanId"`
-	ParentSpanID      string            `json:"parentSpanId,omitempty"`
-	OperationName     string            `json:"operationName"`
-	ServiceName       string            `json:"serviceName"`
-	StartTimeUnixNano int64             `json:"startTimeUnixNano"`
-	DurationNano      int64             `json:"durationNano"`
-	Tags              map[string]string `json:"tags,omitempty"`
-	Logs              []TraceLog        `json:"logs,omitempty"`
-	Status            string            `json:"status,omitempty"`
-}
-
-// TraceLog is a normalized span log/event.
-type TraceLog struct {
-	TimestampUnixNano int64             `json:"timestampUnixNano"`
-	Fields            map[string]string `json:"fields,omitempty"`
-}
-
 // TraceSummary is a compact trace model for search results.
 type TraceSummary struct {
 	TraceID           string `json:"traceId"`

--- a/backend/internal/handlers/ai_handler.go
+++ b/backend/internal/handlers/ai_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aceobservability/ace/backend/internal/auth"
 	"github.com/aceobservability/ace/backend/internal/crypto"
 	"github.com/aceobservability/ace/backend/internal/ratelimit"
+	"github.com/aceobservability/ace/backend/pkg/llm"
 )
 
 // jsonError writes a JSON error response with proper encoding, preventing JSON injection.
@@ -356,7 +357,7 @@ func instantiateDBProvider(p providerRow) (AIProvider, providerQuota, error) {
 	if err != nil {
 		return nil, quota, err
 	}
-	provider, err := newLLMProvider(p.ProviderType, LLMConfig{
+	provider, err := llm.New(p.ProviderType, LLMConfig{
 		BaseURL:     p.BaseURL,
 		APIKey:      apiKey,
 		DisplayName: p.DisplayName,
@@ -693,7 +694,7 @@ func (h *AIHandler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := requireKnownLLMType(reqBody.ProviderType); err != nil {
+	if err := llm.RequireKnown(reqBody.ProviderType); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -827,7 +828,7 @@ func (h *AIHandler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		existing.RateLimitWindowSeconds = *reqBody.RateLimitWindowSeconds
 	}
 
-	if err := requireKnownLLMType(existing.ProviderType); err != nil {
+	if err := llm.RequireKnown(existing.ProviderType); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/backend/internal/handlers/ai_plugin.go
+++ b/backend/internal/handlers/ai_plugin.go
@@ -1,76 +1,31 @@
 package handlers
 
-import (
-	"errors"
-	"fmt"
-	"sync"
+import "github.com/aceobservability/ace/backend/pkg/llm"
+
+type (
+	AIProvider  = llm.AIProvider
+	AIModel     = llm.AIModel
+	ChatRequest = llm.ChatRequest
+	LLMConfig   = llm.LLMConfig
+	LLMFactory  = llm.LLMFactory
 )
 
-// LLMConfig is the in-process config passed to an LLM plugin factory.
-type LLMConfig struct {
-	BaseURL string
-	// APIKey is decrypted plaintext for openai/openrouter/ollama/custom/anthropic.
-	// For copilot it is still-encrypted GH token; CopilotProvider decrypts
-	// EncryptedGHToken on ListModels/Chat.
-	APIKey      string
-	DisplayName string
-}
+var ErrUnknownProviderType = llm.ErrUnknownProviderType
 
-// LLMFactory constructs an AIProvider from LLMConfig.
-type LLMFactory func(LLMConfig) (AIProvider, error)
-
-// ErrUnknownProviderType is returned when ai_providers.provider_type has no
-// registered factory. Callers must fail closed: never fall through to
-// OpenAI-compat.
-var ErrUnknownProviderType = errors.New("unknown provider_type")
-
-// pluginRegistry maps provider_type to factory.
-var pluginRegistry = struct {
-	mu sync.RWMutex
-	m  map[string]LLMFactory
-}{
-	m: map[string]LLMFactory{},
-}
-
-// RegisterLLM records a factory for provider_type.
 func RegisterLLM(providerType string, factory LLMFactory) {
-	if providerType == "" {
-		panic("RegisterLLM: empty provider_type")
-	}
-	if factory == nil {
-		panic("RegisterLLM: nil factory")
-	}
-	pluginRegistry.mu.Lock()
-	defer pluginRegistry.mu.Unlock()
-	pluginRegistry.m[providerType] = factory
-}
-
-func lookupLLM(providerType string) (LLMFactory, bool) {
-	pluginRegistry.mu.RLock()
-	defer pluginRegistry.mu.RUnlock()
-	f, ok := pluginRegistry.m[providerType]
-	return f, ok
+	llm.RegisterLLM(providerType, factory)
 }
 
 func unregisterLLM(providerType string) {
-	pluginRegistry.mu.Lock()
-	defer pluginRegistry.mu.Unlock()
-	delete(pluginRegistry.m, providerType)
+	llm.UnregisterLLM(providerType)
 }
 
 func newLLMProvider(providerType string, cfg LLMConfig) (AIProvider, error) {
-	factory, ok := lookupLLM(providerType)
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrUnknownProviderType, providerType)
-	}
-	return factory(cfg)
+	return llm.New(providerType, cfg)
 }
 
 func requireKnownLLMType(providerType string) error {
-	if _, ok := lookupLLM(providerType); !ok {
-		return fmt.Errorf("%w: %s", ErrUnknownProviderType, providerType)
-	}
-	return nil
+	return llm.RequireKnown(providerType)
 }
 
 func init() {

--- a/backend/internal/handlers/ai_plugin.go
+++ b/backend/internal/handlers/ai_plugin.go
@@ -12,36 +12,20 @@ type (
 
 var ErrUnknownProviderType = llm.ErrUnknownProviderType
 
-func RegisterLLM(providerType string, factory LLMFactory) {
-	llm.RegisterLLM(providerType, factory)
-}
-
-func unregisterLLM(providerType string) {
-	llm.UnregisterLLM(providerType)
-}
-
-func newLLMProvider(providerType string, cfg LLMConfig) (AIProvider, error) {
-	return llm.New(providerType, cfg)
-}
-
-func requireKnownLLMType(providerType string) error {
-	return llm.RequireKnown(providerType)
-}
-
 func init() {
 	openaiCompat := func(cfg LLMConfig) (AIProvider, error) {
 		return NewOpenAICompatibleProvider(cfg.BaseURL, cfg.APIKey, cfg.DisplayName), nil
 	}
-	RegisterLLM("openai", openaiCompat)
-	RegisterLLM("openrouter", openaiCompat)
-	RegisterLLM("ollama", openaiCompat)
-	RegisterLLM("custom", openaiCompat)
-	RegisterLLM("anthropic", NewAnthropic)
+	llm.RegisterLLM("openai", openaiCompat)
+	llm.RegisterLLM("openrouter", openaiCompat)
+	llm.RegisterLLM("ollama", openaiCompat)
+	llm.RegisterLLM("custom", openaiCompat)
+	llm.RegisterLLM("anthropic", NewAnthropic)
 	// Copilot's live chat path remains provider_id=="copilot" (user GH token).
 	// Registering the type means a stored provider_type=copilot does not
 	// impersonate OpenAI-compat. LLMConfig.APIKey is ciphertext; the factory
 	// must not receive a decrypted key (CopilotProvider decrypts on use).
-	RegisterLLM("copilot", func(cfg LLMConfig) (AIProvider, error) {
+	llm.RegisterLLM("copilot", func(cfg LLMConfig) (AIProvider, error) {
 		return &CopilotProvider{EncryptedGHToken: cfg.APIKey}, nil
 	})
 }

--- a/backend/internal/handlers/ai_plugin_test.go
+++ b/backend/internal/handlers/ai_plugin_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/aceobservability/ace/backend/internal/crypto"
+	"github.com/aceobservability/ace/backend/pkg/llm"
 )
 
 type probeProvider struct {
@@ -21,7 +22,7 @@ type probeProvider struct {
 }
 
 func TestNewLLMProvider_UnknownTypeFailsClosed(t *testing.T) {
-	p, err := newLLMProvider("nope", LLMConfig{
+	p, err := llm.New("nope", LLMConfig{
 		BaseURL:     "https://api.openai.com/v1",
 		APIKey:      "sk-should-not-be-used",
 		DisplayName: "Nope",
@@ -38,7 +39,7 @@ func TestNewLLMProvider_UnknownTypeFailsClosed(t *testing.T) {
 }
 
 func TestNewLLMProvider_AnthropicRegistered(t *testing.T) {
-	p, err := newLLMProvider("anthropic", LLMConfig{
+	p, err := llm.New("anthropic", LLMConfig{
 		BaseURL:     "https://api.anthropic.com",
 		APIKey:      "sk-ant",
 		DisplayName: "Anthropic",
@@ -79,13 +80,13 @@ func TestNewLLMProvider_OpenAICompatListsAndChats(t *testing.T) {
 
 	for _, providerType := range []string{"openai", "openrouter", "ollama", "custom"} {
 		t.Run(providerType, func(t *testing.T) {
-			p, err := newLLMProvider(providerType, LLMConfig{
+			p, err := llm.New(providerType, LLMConfig{
 				BaseURL:     server.URL,
 				APIKey:      "test-api-key",
 				DisplayName: providerType,
 			})
 			if err != nil {
-				t.Fatalf("newLLMProvider(%q): %v", providerType, err)
+				t.Fatalf("llm.New(%q): %v", providerType, err)
 			}
 			if _, ok := p.(*OpenAICompatibleProvider); !ok {
 				t.Fatalf("expected *OpenAICompatibleProvider, got %T", p)
@@ -115,7 +116,7 @@ func TestNewLLMProvider_OpenAICompatListsAndChats(t *testing.T) {
 }
 
 func TestNewLLMProvider_CopilotRegistered(t *testing.T) {
-	p, err := newLLMProvider("copilot", LLMConfig{APIKey: "encrypted-gh-token"})
+	p, err := llm.New("copilot", LLMConfig{APIKey: "encrypted-gh-token"})
 	if err != nil {
 		t.Fatalf("copilot should be registered: %v", err)
 	}
@@ -263,12 +264,12 @@ func TestInstantiateDBProvider_OpenAIDecryptsAPIKey(t *testing.T) {
 
 func TestRegisterLLM_DispatchUsesRegisteredFactory(t *testing.T) {
 	const providerType = "probe-dispatch"
-	RegisterLLM(providerType, func(cfg LLMConfig) (AIProvider, error) {
+	llm.RegisterLLM(providerType, func(cfg LLMConfig) (AIProvider, error) {
 		return &probeProvider{id: cfg.DisplayName}, nil
 	})
-	t.Cleanup(func() { unregisterLLM(providerType) })
+	t.Cleanup(func() { llm.UnregisterLLM(providerType) })
 
-	p, err := newLLMProvider(providerType, LLMConfig{DisplayName: "probe-one"})
+	p, err := llm.New(providerType, LLMConfig{DisplayName: "probe-one"})
 	if err != nil {
 		t.Fatalf("dispatch registered type: %v", err)
 	}
@@ -316,10 +317,10 @@ func TestChat_UnknownProviderType_Returns400(t *testing.T) {
 func TestChat_RegisteredTypeIsDispatched(t *testing.T) {
 	const providerType = "probe-chat-dispatch"
 	mock := &mockAIProvider{chatBody: `{"choices":[{"index":0,"delta":{"content":"from-probe"}}]}`}
-	RegisterLLM(providerType, func(LLMConfig) (AIProvider, error) {
+	llm.RegisterLLM(providerType, func(LLMConfig) (AIProvider, error) {
 		return mock, nil
 	})
-	t.Cleanup(func() { unregisterLLM(providerType) })
+	t.Cleanup(func() { llm.UnregisterLLM(providerType) })
 
 	h := NewAIHandler(nil, nil)
 	h.testProviderRow = &providerRow{
@@ -356,13 +357,13 @@ func TestChat_RegisteredTypeIsDispatched(t *testing.T) {
 }
 
 func TestRequireKnownLLMType(t *testing.T) {
-	if err := requireKnownLLMType("openai"); err != nil {
+	if err := llm.RequireKnown("openai"); err != nil {
 		t.Errorf("openai should be known: %v", err)
 	}
-	if err := requireKnownLLMType("anthropic"); err != nil {
+	if err := llm.RequireKnown("anthropic"); err != nil {
 		t.Errorf("anthropic should be known: %v", err)
 	}
-	if err := requireKnownLLMType("nope"); !errors.Is(err, ErrUnknownProviderType) {
+	if err := llm.RequireKnown("nope"); !errors.Is(err, ErrUnknownProviderType) {
 		t.Errorf("nope should fail closed, got %v", err)
 	}
 }

--- a/backend/internal/handlers/ai_provider.go
+++ b/backend/internal/handlers/ai_provider.go
@@ -22,29 +22,6 @@ func hashToken(token string) string {
 	return hex.EncodeToString(h[:])
 }
 
-// AIProvider defines the interface for AI model providers (OpenAI-compatible, Copilot, etc.)
-type AIProvider interface {
-	ListModels(ctx context.Context) ([]AIModel, error)
-	Chat(ctx context.Context, req ChatRequest, w http.ResponseWriter) error
-}
-
-// AIModel represents a model available from a provider.
-type AIModel struct {
-	ID       string                 `json:"id"`
-	Name     string                 `json:"name"`
-	Vendor   string                 `json:"vendor"`
-	Category string                 `json:"category"`
-	Meta     map[string]interface{} `json:"meta,omitempty"`
-}
-
-// ChatRequest represents an incoming chat completion request.
-type ChatRequest struct {
-	Model    string            `json:"model"`
-	Messages []json.RawMessage `json:"messages"`
-	Tools    []json.RawMessage `json:"tools,omitempty"`
-	Stream   bool              `json:"stream"`
-}
-
 // OpenAICompatibleProvider implements AIProvider for any OpenAI-compatible API
 // (OpenAI, Ollama, OpenRouter, vLLM, LiteLLM, etc.).
 //

--- a/backend/pkg/datasource/contract.go
+++ b/backend/pkg/datasource/contract.go
@@ -1,0 +1,108 @@
+// Package datasource is the stable import path for Ace datasource module contracts.
+//
+// External ace-datasource-* modules import
+// github.com/aceobservability/ace/backend/pkg/datasource and call
+// RegisterDatasource from init. In-tree adapters in internal/datasource
+// register the same way. Do not import internal/datasource or
+// internal/handlers from a module.
+package datasource
+
+import (
+	"context"
+	"time"
+)
+
+// Client is the interface every query datasource implements.
+type Client interface {
+	Query(ctx context.Context, query string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error)
+}
+
+// SignalQueryClient is implemented by datasources that dispatch on signal
+// (ClickHouse, CloudWatch, Elasticsearch).
+type SignalQueryClient interface {
+	QueryWithSignal(ctx context.Context, query, signal string, start, end time.Time, step time.Duration, limit int) (*QueryResult, error)
+}
+
+// StreamClient is implemented by log datasources that support live tail.
+type StreamClient interface {
+	Stream(ctx context.Context, query string, start time.Time, limit int, onLog LogStreamCallback) error
+}
+
+// LabelsClient is implemented by log datasources that expose label/field names.
+type LabelsClient interface {
+	Labels(ctx context.Context) ([]string, error)
+}
+
+// MetricLabelsClient is implemented by PromQL datasources that can scope labels
+// to a metric selector.
+type MetricLabelsClient interface {
+	Labels(ctx context.Context, metric string) ([]string, error)
+}
+
+// LabelValuesClient is implemented by log datasources that expose label values.
+type LabelValuesClient interface {
+	LabelValues(ctx context.Context, labelName string) ([]string, error)
+}
+
+// MetricLabelValuesClient is implemented by PromQL datasources that can scope
+// label values to a metric selector.
+type MetricLabelValuesClient interface {
+	LabelValues(ctx context.Context, label, metric string) ([]string, error)
+}
+
+// MetricNamesClient is implemented by PromQL datasources that expose metric names.
+type MetricNamesClient interface {
+	MetricNames(ctx context.Context, search string) ([]string, error)
+}
+
+// LogStreamCallback receives one live-tail log line.
+type LogStreamCallback func(LogEntry) error
+
+// QueryResult is the unified query result format.
+type QueryResult struct {
+	Status     string     `json:"status"`
+	Data       *QueryData `json:"data,omitempty"`
+	Error      string     `json:"error,omitempty"`
+	ResultType string     `json:"resultType"` // "metrics" or "logs"
+}
+
+// QueryData contains the result.
+type QueryData struct {
+	ResultType string         `json:"resultType"`
+	Result     []MetricResult `json:"result,omitempty"`
+	Logs       []LogEntry     `json:"logs,omitempty"`
+	Traces     []TraceSpan    `json:"traces,omitempty"`
+}
+
+// MetricResult is a single metric series (Prometheus/VictoriaMetrics).
+type MetricResult struct {
+	Metric map[string]string `json:"metric"`
+	Values [][]interface{}   `json:"values"`
+}
+
+// LogEntry is a single log line (Loki/VictoriaLogs).
+type LogEntry struct {
+	Timestamp string            `json:"timestamp"`
+	Line      string            `json:"line"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	Level     string            `json:"level,omitempty"`
+}
+
+// TraceSpan is a normalized span in a query result.
+type TraceSpan struct {
+	SpanID            string            `json:"spanId"`
+	ParentSpanID      string            `json:"parentSpanId,omitempty"`
+	OperationName     string            `json:"operationName"`
+	ServiceName       string            `json:"serviceName"`
+	StartTimeUnixNano int64             `json:"startTimeUnixNano"`
+	DurationNano      int64             `json:"durationNano"`
+	Tags              map[string]string `json:"tags,omitempty"`
+	Logs              []TraceLog        `json:"logs,omitempty"`
+	Status            string            `json:"status,omitempty"`
+}
+
+// TraceLog is a normalized span log/event.
+type TraceLog struct {
+	TimestampUnixNano int64             `json:"timestampUnixNano"`
+	Fields            map[string]string `json:"fields,omitempty"`
+}

--- a/backend/pkg/datasource/register.go
+++ b/backend/pkg/datasource/register.go
@@ -42,6 +42,9 @@ func RegisterDatasource(typ string, factory Factory) {
 	}
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
+	if _, exists := registry.m[typ]; exists {
+		panic(fmt.Sprintf("RegisterDatasource: type already registered: %s", typ))
+	}
 	registry.m[typ] = factory
 }
 
@@ -60,10 +63,11 @@ func UnregisterDatasource(typ string) {
 }
 
 // NewClient constructs a client from the registry. Unknown types fail closed.
-func NewClient(typ string, cfg Config) (Client, error) {
-	factory, ok := lookup(typ)
+// cfg.Type is the registry key.
+func NewClient(cfg Config) (Client, error) {
+	factory, ok := lookup(cfg.Type)
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrUnknownType, typ)
+		return nil, fmt.Errorf("%w: %s", ErrUnknownType, cfg.Type)
 	}
 	return factory(cfg)
 }

--- a/backend/pkg/datasource/register.go
+++ b/backend/pkg/datasource/register.go
@@ -1,0 +1,69 @@
+package datasource
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrUnknownType is returned when a datasource type has no registered factory.
+// Callers must fail closed.
+var ErrUnknownType = errors.New("unknown datasource type")
+
+// Config is the in-process config passed to a datasource factory.
+// It is the module-facing subset of a stored datasource row.
+type Config struct {
+	Name         string
+	Type         string
+	URL          string
+	AuthType     string
+	AuthConfig   json.RawMessage
+	TraceIDField string
+}
+
+// Factory constructs a Client from Config.
+type Factory func(Config) (Client, error)
+
+var registry = struct {
+	mu sync.RWMutex
+	m  map[string]Factory
+}{
+	m: map[string]Factory{},
+}
+
+// RegisterDatasource records a factory for datasource type.
+func RegisterDatasource(typ string, factory Factory) {
+	if typ == "" {
+		panic("RegisterDatasource: empty type")
+	}
+	if factory == nil {
+		panic("RegisterDatasource: nil factory")
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.m[typ] = factory
+}
+
+func lookup(typ string) (Factory, bool) {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	f, ok := registry.m[typ]
+	return f, ok
+}
+
+// UnregisterDatasource removes a factory. Tests use this to isolate probe types.
+func UnregisterDatasource(typ string) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	delete(registry.m, typ)
+}
+
+// NewClient constructs a client from the registry. Unknown types fail closed.
+func NewClient(typ string, cfg Config) (Client, error) {
+	factory, ok := lookup(typ)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownType, typ)
+	}
+	return factory(cfg)
+}

--- a/backend/pkg/datasource/register_test.go
+++ b/backend/pkg/datasource/register_test.go
@@ -1,7 +1,9 @@
 package datasource
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -16,7 +18,7 @@ func (s *stubClient) Query(context.Context, string, time.Time, time.Time, time.D
 }
 
 func TestNewClient_UnknownTypeFailsClosed(t *testing.T) {
-	c, err := NewClient("nope", Config{URL: "http://localhost:9090"})
+	c, err := NewClient(Config{Type: "nope", URL: "http://localhost:9090"})
 	if err == nil {
 		t.Fatal("expected error for unknown datasource type")
 	}
@@ -30,28 +32,77 @@ func TestNewClient_UnknownTypeFailsClosed(t *testing.T) {
 
 func TestRegisterDatasource_DispatchUsesRegisteredFactory(t *testing.T) {
 	const typ = "probe-pkg-datasource"
+	want := Config{
+		Type:         typ,
+		Name:         "probe-one",
+		URL:          "http://localhost:9090",
+		AuthType:     "bearer",
+		AuthConfig:   json.RawMessage(`{"token":"t"}`),
+		TraceIDField: "trace_id",
+	}
+	var got Config
 	RegisterDatasource(typ, func(cfg Config) (Client, error) {
+		got = cfg
 		return &stubClient{id: cfg.Name}, nil
 	})
 	t.Cleanup(func() { UnregisterDatasource(typ) })
 
-	c, err := NewClient(typ, Config{Name: "probe-one", URL: "http://localhost:9090"})
+	c, err := NewClient(want)
 	if err != nil {
 		t.Fatalf("dispatch registered type: %v", err)
 	}
-	got, ok := c.(*stubClient)
+	gotClient, ok := c.(*stubClient)
 	if !ok {
 		t.Fatalf("expected *stubClient, got %T", c)
 	}
-	if got.id != "probe-one" {
-		t.Errorf("factory did not receive Config, id=%q", got.id)
+	if gotClient.id != want.Name {
+		t.Errorf("factory did not receive Config.Name, id=%q", gotClient.id)
+	}
+	if got.Type != want.Type {
+		t.Errorf("Type=%q, want %q", got.Type, want.Type)
+	}
+	if got.URL != want.URL {
+		t.Errorf("URL=%q, want %q", got.URL, want.URL)
+	}
+	if got.AuthType != want.AuthType {
+		t.Errorf("AuthType=%q, want %q", got.AuthType, want.AuthType)
+	}
+	if !bytes.Equal(got.AuthConfig, want.AuthConfig) {
+		t.Errorf("AuthConfig=%s, want %s", got.AuthConfig, want.AuthConfig)
+	}
+	if got.TraceIDField != want.TraceIDField {
+		t.Errorf("TraceIDField=%q, want %q", got.TraceIDField, want.TraceIDField)
 	}
 
 	result, err := c.Query(context.Background(), "up", time.Time{}, time.Time{}, 0, 0)
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
-	if result.Status != "probe-one" {
+	if result.Status != want.Name {
 		t.Fatalf("unexpected result status %q", result.Status)
 	}
+}
+
+func TestRegisterDatasource_DuplicatePanics(t *testing.T) {
+	const typ = "probe-dup-datasource"
+	factory := func(Config) (Client, error) { return &stubClient{}, nil }
+	RegisterDatasource(typ, factory)
+	t.Cleanup(func() { UnregisterDatasource(typ) })
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on duplicate RegisterDatasource")
+			return
+		}
+		got, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic type %T, want string", r)
+		}
+		want := "RegisterDatasource: type already registered: " + typ
+		if got != want {
+			t.Fatalf("panic %q, want %q", got, want)
+		}
+	}()
+	RegisterDatasource(typ, factory)
 }

--- a/backend/pkg/datasource/register_test.go
+++ b/backend/pkg/datasource/register_test.go
@@ -1,0 +1,57 @@
+package datasource
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type stubClient struct {
+	id string
+}
+
+func (s *stubClient) Query(context.Context, string, time.Time, time.Time, time.Duration, int) (*QueryResult, error) {
+	return &QueryResult{Status: s.id, ResultType: "metrics"}, nil
+}
+
+func TestNewClient_UnknownTypeFailsClosed(t *testing.T) {
+	c, err := NewClient("nope", Config{URL: "http://localhost:9090"})
+	if err == nil {
+		t.Fatal("expected error for unknown datasource type")
+	}
+	if !errors.Is(err, ErrUnknownType) {
+		t.Fatalf("expected ErrUnknownType, got %v", err)
+	}
+	if c != nil {
+		t.Fatalf("unknown type must not construct a client, got %T", c)
+	}
+}
+
+func TestRegisterDatasource_DispatchUsesRegisteredFactory(t *testing.T) {
+	const typ = "probe-pkg-datasource"
+	RegisterDatasource(typ, func(cfg Config) (Client, error) {
+		return &stubClient{id: cfg.Name}, nil
+	})
+	t.Cleanup(func() { UnregisterDatasource(typ) })
+
+	c, err := NewClient(typ, Config{Name: "probe-one", URL: "http://localhost:9090"})
+	if err != nil {
+		t.Fatalf("dispatch registered type: %v", err)
+	}
+	got, ok := c.(*stubClient)
+	if !ok {
+		t.Fatalf("expected *stubClient, got %T", c)
+	}
+	if got.id != "probe-one" {
+		t.Errorf("factory did not receive Config, id=%q", got.id)
+	}
+
+	result, err := c.Query(context.Background(), "up", time.Time{}, time.Time{}, 0, 0)
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if result.Status != "probe-one" {
+		t.Fatalf("unexpected result status %q", result.Status)
+	}
+}

--- a/backend/pkg/llm/provider.go
+++ b/backend/pkg/llm/provider.go
@@ -1,0 +1,44 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// AIProvider is the LLM module contract. In-tree providers and future
+// ace-llm-* modules implement this interface.
+type AIProvider interface {
+	ListModels(ctx context.Context) ([]AIModel, error)
+	Chat(ctx context.Context, req ChatRequest, w http.ResponseWriter) error
+}
+
+// AIModel is a model advertised by a provider.
+type AIModel struct {
+	ID       string                 `json:"id"`
+	Name     string                 `json:"name"`
+	Vendor   string                 `json:"vendor"`
+	Category string                 `json:"category"`
+	Meta     map[string]interface{} `json:"meta,omitempty"`
+}
+
+// ChatRequest is the in-process chat completion request.
+type ChatRequest struct {
+	Model    string            `json:"model"`
+	Messages []json.RawMessage `json:"messages"`
+	Tools    []json.RawMessage `json:"tools,omitempty"`
+	Stream   bool              `json:"stream"`
+}
+
+// LLMConfig is the in-process config passed to an LLM factory.
+type LLMConfig struct {
+	BaseURL string
+	// APIKey is decrypted plaintext for openai/openrouter/ollama/custom/anthropic.
+	// For copilot it is still-encrypted GH token; CopilotProvider decrypts
+	// EncryptedGHToken on ListModels/Chat.
+	APIKey      string
+	DisplayName string
+}
+
+// LLMFactory constructs an AIProvider from LLMConfig.
+type LLMFactory func(LLMConfig) (AIProvider, error)

--- a/backend/pkg/llm/register.go
+++ b/backend/pkg/llm/register.go
@@ -1,0 +1,67 @@
+// Package llm is the stable import path for Ace LLM module contracts.
+//
+// External ace-llm-* modules import github.com/aceobservability/ace/backend/pkg/llm
+// and call RegisterLLM from init. In-tree providers in internal/handlers register
+// the same way. Do not import internal/handlers from a module.
+package llm
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrUnknownProviderType is returned when provider_type has no registered
+// factory. Callers must fail closed: never fall through to OpenAI-compat.
+var ErrUnknownProviderType = errors.New("unknown provider_type")
+
+var pluginRegistry = struct {
+	mu sync.RWMutex
+	m  map[string]LLMFactory
+}{
+	m: map[string]LLMFactory{},
+}
+
+// RegisterLLM records a factory for provider_type.
+func RegisterLLM(providerType string, factory LLMFactory) {
+	if providerType == "" {
+		panic("RegisterLLM: empty provider_type")
+	}
+	if factory == nil {
+		panic("RegisterLLM: nil factory")
+	}
+	pluginRegistry.mu.Lock()
+	defer pluginRegistry.mu.Unlock()
+	pluginRegistry.m[providerType] = factory
+}
+
+func lookup(providerType string) (LLMFactory, bool) {
+	pluginRegistry.mu.RLock()
+	defer pluginRegistry.mu.RUnlock()
+	f, ok := pluginRegistry.m[providerType]
+	return f, ok
+}
+
+// UnregisterLLM removes a factory. Tests use this to isolate probe types.
+func UnregisterLLM(providerType string) {
+	pluginRegistry.mu.Lock()
+	defer pluginRegistry.mu.Unlock()
+	delete(pluginRegistry.m, providerType)
+}
+
+// New constructs a provider from the registry. Unknown types fail closed.
+func New(providerType string, cfg LLMConfig) (AIProvider, error) {
+	factory, ok := lookup(providerType)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownProviderType, providerType)
+	}
+	return factory(cfg)
+}
+
+// RequireKnown reports ErrUnknownProviderType when provider_type is unregistered.
+func RequireKnown(providerType string) error {
+	if _, ok := lookup(providerType); !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownProviderType, providerType)
+	}
+	return nil
+}

--- a/backend/pkg/llm/register.go
+++ b/backend/pkg/llm/register.go
@@ -32,6 +32,9 @@ func RegisterLLM(providerType string, factory LLMFactory) {
 	}
 	pluginRegistry.mu.Lock()
 	defer pluginRegistry.mu.Unlock()
+	if _, exists := pluginRegistry.m[providerType]; exists {
+		panic(fmt.Sprintf("RegisterLLM: provider_type already registered: %s", providerType))
+	}
 	pluginRegistry.m[providerType] = factory
 }
 

--- a/backend/pkg/llm/register_test.go
+++ b/backend/pkg/llm/register_test.go
@@ -1,0 +1,85 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+type stubProvider struct {
+	id string
+}
+
+func (s *stubProvider) ListModels(context.Context) ([]AIModel, error) {
+	return []AIModel{{ID: s.id, Name: s.id}}, nil
+}
+
+func (s *stubProvider) Chat(context.Context, ChatRequest, http.ResponseWriter) error {
+	return nil
+}
+
+func TestNew_UnknownTypeFailsClosed(t *testing.T) {
+	p, err := New("nope", LLMConfig{APIKey: "sk-should-not-be-used"})
+	if err == nil {
+		t.Fatal("expected error for unknown provider_type")
+	}
+	if !errors.Is(err, ErrUnknownProviderType) {
+		t.Fatalf("expected ErrUnknownProviderType, got %v", err)
+	}
+	if p != nil {
+		t.Fatalf("unknown type must not construct a provider, got %T", p)
+	}
+}
+
+func TestRegisterLLM_DispatchUsesRegisteredFactory(t *testing.T) {
+	const providerType = "probe-pkg-llm"
+	RegisterLLM(providerType, func(cfg LLMConfig) (AIProvider, error) {
+		return &stubProvider{id: cfg.DisplayName}, nil
+	})
+	t.Cleanup(func() { UnregisterLLM(providerType) })
+
+	p, err := New(providerType, LLMConfig{DisplayName: "probe-one"})
+	if err != nil {
+		t.Fatalf("dispatch registered type: %v", err)
+	}
+	got, ok := p.(*stubProvider)
+	if !ok {
+		t.Fatalf("expected *stubProvider, got %T", p)
+	}
+	if got.id != "probe-one" {
+		t.Errorf("factory did not receive LLMConfig, id=%q", got.id)
+	}
+
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "probe-one" {
+		t.Fatalf("unexpected models: %+v", models)
+	}
+
+	if err := p.Chat(context.Background(), ChatRequest{
+		Model:    "probe",
+		Messages: []json.RawMessage{json.RawMessage(`{"role":"user"}`)},
+	}, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+}
+
+func TestRequireKnown(t *testing.T) {
+	if err := RequireKnown("nope"); !errors.Is(err, ErrUnknownProviderType) {
+		t.Fatalf("expected ErrUnknownProviderType, got %v", err)
+	}
+
+	const providerType = "probe-require-known"
+	RegisterLLM(providerType, func(LLMConfig) (AIProvider, error) {
+		return &stubProvider{id: providerType}, nil
+	})
+	t.Cleanup(func() { UnregisterLLM(providerType) })
+
+	if err := RequireKnown(providerType); err != nil {
+		t.Fatalf("registered type should be known: %v", err)
+	}
+}

--- a/backend/pkg/llm/register_test.go
+++ b/backend/pkg/llm/register_test.go
@@ -83,3 +83,27 @@ func TestRequireKnown(t *testing.T) {
 		t.Fatalf("registered type should be known: %v", err)
 	}
 }
+
+func TestRegisterLLM_DuplicatePanics(t *testing.T) {
+	const providerType = "probe-dup-llm"
+	factory := func(LLMConfig) (AIProvider, error) { return &stubProvider{id: providerType}, nil }
+	RegisterLLM(providerType, factory)
+	t.Cleanup(func() { UnregisterLLM(providerType) })
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on duplicate RegisterLLM")
+			return
+		}
+		got, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic type %T, want string", r)
+		}
+		want := "RegisterLLM: provider_type already registered: " + providerType
+		if got != want {
+			t.Fatalf("panic %q, want %q", got, want)
+		}
+	}()
+	RegisterLLM(providerType, factory)
+}

--- a/docs/adr/0004-module-contracts.md
+++ b/docs/adr/0004-module-contracts.md
@@ -18,7 +18,7 @@ needs one. There is no runtime loader.
 | Module family | Import | Register | Construct |
 | --- | --- | --- | --- |
 | LLM | `github.com/aceobservability/ace/backend/pkg/llm` | `RegisterLLM` | `llm.New` |
-| Datasource | `github.com/aceobservability/ace/backend/pkg/datasource` | `RegisterDatasource` | `datasource.NewClient` |
+| Datasource | `github.com/aceobservability/ace/backend/pkg/datasource` | `RegisterDatasource` | `datasource.NewClient` (lookup `cfg.Type`) |
 
 Do not import `internal/handlers` from an LLM module. Do not import
 `internal/datasource` from a datasource module.
@@ -27,11 +27,11 @@ Do not import `internal/handlers` from an LLM module. Do not import
 
 ## In-tree wiring
 
-LLM factories still live in `internal/handlers` and call `RegisterLLM` from
+LLM factories still live in `internal/handlers` and call `llm.RegisterLLM` from
 `init`. Datasource factories still live in `internal/datasource` and call
-`RegisterDatasource` from `init`. HTTP handlers keep calling
-`internal/datasource.NewClient` and the existing LLM helpers. Those functions
-are thin lookups over the `pkg` registries.
+`RegisterDatasource` from `init`. HTTP handlers call
+`internal/datasource.NewClient` and `llm.New` / `llm.RequireKnown`.
+`datasource.NewClient` looks up `cfg.Type`. There is no parallel type argument.
 
 `vmalert` and `alertmanager` are not query `Client` types. `TestConnection`
 keeps a dedicated path for them.

--- a/docs/adr/0004-module-contracts.md
+++ b/docs/adr/0004-module-contracts.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+---
+
+# Module contracts for LLM and datasource adapters
+
+> **Implementation status:** Accepted for the in-core contract path that
+> [#447](https://github.com/aceobservability/ace/issues/447) lands ahead of
+> out-of-tree `ace-llm-*` / `ace-datasource-*` modules ([#446](https://github.com/aceobservability/ace/issues/446)).
+
+Ace keeps LLM and datasource **contracts plus registries** in this repo.
+Adapters register from `init`. Construction is a registry lookup and fails
+closed on an unknown type. There is no plugin SDK repo until a second consumer
+needs one. There is no runtime loader.
+
+## Import paths
+
+| Module family | Import | Register | Construct |
+| --- | --- | --- | --- |
+| LLM | `github.com/aceobservability/ace/backend/pkg/llm` | `RegisterLLM` | `llm.New` |
+| Datasource | `github.com/aceobservability/ace/backend/pkg/datasource` | `RegisterDatasource` | `datasource.NewClient` |
+
+Do not import `internal/handlers` from an LLM module. Do not import
+`internal/datasource` from a datasource module.
+
+`internal/` is not a stable path for other Go modules. `pkg/` is.
+
+## In-tree wiring
+
+LLM factories still live in `internal/handlers` and call `RegisterLLM` from
+`init`. Datasource factories still live in `internal/datasource` and call
+`RegisterDatasource` from `init`. HTTP handlers keep calling
+`internal/datasource.NewClient` and the existing LLM helpers. Those functions
+are thin lookups over the `pkg` registries.
+
+`vmalert` and `alertmanager` are not query `Client` types. `TestConnection`
+keeps a dedicated path for them.
+
+## Out of scope
+
+Moving Anthropic, Prometheus, or any other adapter out of tree. WASM,
+go-plugin, or marketplace loading.

--- a/website/guide/contributing.md
+++ b/website/guide/contributing.md
@@ -28,3 +28,10 @@ Five canonical triage roles mapped 1:1 to default label strings. See `docs/agent
 ### Domain docs
 
 Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Module contracts
+
+LLM modules import `github.com/aceobservability/ace/backend/pkg/llm`
+(`RegisterLLM`, `AIProvider`). Datasource modules import
+`github.com/aceobservability/ace/backend/pkg/datasource`
+(`RegisterDatasource`, `Client`). See `docs/adr/0004-module-contracts.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #447. Parent epic #446.

## Why

Prove the module seam before any extract. Datasource `NewClient` was a hard `switch`. LLM `RegisterLLM` already existed, but `AIProvider` and the registry lived in `internal/handlers`. Future `ace-llm-*` and `ace-datasource-*` modules cannot import `internal/`.

## Scope

- `github.com/aceobservability/ace/backend/pkg/llm` owns `AIProvider`, `LLMConfig`, `RegisterLLM`, and `ErrUnknownProviderType`.
- `github.com/aceobservability/ace/backend/pkg/datasource` owns `Client`, the query/stream/label interfaces, `RegisterDatasource`, and `ErrUnknownType`.
- `datasource.NewClient` takes `Config` and looks up `cfg.Type`. There is no parallel type argument.
- `RegisterLLM` and `RegisterDatasource` panic if the type is already registered.
- `internal/handlers` keeps type aliases. `init` and handlers call `pkg/llm` directly.
- `internal/datasource.NewClient` is a registry lookup. Unknown types fail closed with `ErrUnknownType`.
- In-tree query types (prometheus, victoriametrics, loki, victorialogs, tempo, victoriatraces, clickhouse, cloudwatch, elasticsearch) register from `init`.
- `vmalert` and `alertmanager` stay on the `TestConnection` special path. They are not query `Client` types.
- ADR 0004 and `AGENTS.md` name the contract import paths.

Out of scope: new GitHub repos, moving Anthropic or Prometheus out of tree, WASM / go-plugin / marketplace loading, frontend panel work.

## Tradeoffs

Contracts live in `backend/pkg/`, not `backend/internal/plugin`. Other Go modules cannot import `internal/`. That is the requirement for a stable path that #448 and #449 can use.

Datasource factories take `datasource.Config`, not `models.DataSource`. `models` is still under `internal/`. In-tree constructors still take `models.DataSource`. `init` maps `Config` across that boundary. Row fields `ID`, `OrganizationID`, `IsDefault`, `LinkedTraceDatasourceID`, `CreatedAt`, and `UpdatedAt` are omitted on purpose.

Type aliases in `internal/handlers` and `internal/datasource` keep existing call sites compiling.

## Blast Radius

In-tree LLM and query construction still call the same factories. Unknown types still error. The unknown-datasource error is now wrapped `ErrUnknownType` (`unknown datasource type`) instead of `unsupported datasource type`. Callers that only checked `err != nil` are unchanged.

`ssrf.go` pin/proxy/TLS is untouched.

## Verification

In `backend/`:

```
go test ./pkg/llm ./pkg/datasource ./internal/datasource ./internal/handlers ./internal/mcp
```

All passed. Hold for review and CI. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f722cb6-5208-46fe-980e-91199136f235?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f722cb6-5208-46fe-980e-91199136f235&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

